### PR TITLE
feat(INF-40): add fusion name-part fields to runtime model

### DIFF
--- a/src/loaders/__tests__/pokemon.test.ts
+++ b/src/loaders/__tests__/pokemon.test.ts
@@ -3,6 +3,7 @@ import {
   getPokemon,
   getPokemonEvolutionIds,
   getPokemonPreEvolutionId,
+  PokemonSchema,
   searchPokemon,
 } from "../pokemon";
 
@@ -250,5 +251,41 @@ describe("Pokemon Loader with Evolution Data", () => {
     // Pikachu should have evolution data (evolves to Raichu)
     const evolutionIds = await getPokemonEvolutionIds(pikachuId);
     expect(evolutionIds).toEqual([26]); // Raichu's ID
+  });
+
+  it("accepts optional fusion name parts on runtime Pokemon objects", () => {
+    const result = PokemonSchema.safeParse({
+      id: 500,
+      nationalDexId: 500,
+      name: "DemoMon",
+      types: [{ name: "normal" }],
+      species: {
+        is_legendary: false,
+        is_mythical: false,
+        generation: null,
+        evolution_chain: null,
+      },
+      headNamePart: "Demo",
+      bodyNamePart: "Mon",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("remains backward compatible when fusion name parts are absent", () => {
+    const result = PokemonSchema.safeParse({
+      id: 501,
+      nationalDexId: 501,
+      name: "LegacyMon",
+      types: [{ name: "normal" }],
+      species: {
+        is_legendary: false,
+        is_mythical: false,
+        generation: null,
+        evolution_chain: null,
+      },
+    });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/src/loaders/pokemon.ts
+++ b/src/loaders/pokemon.ts
@@ -127,19 +127,27 @@ export const EvolutionDataSchema = z.object({
   evolves_from: EvolutionDetailSchema.optional(),
 });
 
-// Zod schema for Pokemon data
-export const PokemonSchema = z.object({
-  id: z.number().int({ error: "Pokemon ID must be an integer" }),
-  nationalDexId: z
-    .number()
-    .int({ error: "National Dex ID must be an integer" }),
-  name: z.string().min(1, { error: "Pokemon name is required" }),
-  types: z.array(PokemonTypeSchema),
-  species: PokemonSpeciesSchema,
-  evolution: EvolutionDataSchema.optional(),
+export const FusionNamePartsSchema = z.object({
+  headNamePart: z.string().optional(),
+  bodyNamePart: z.string().optional(),
 });
 
+// Zod schema for Pokemon data
+export const PokemonSchema = z
+  .object({
+    id: z.number().int({ error: "Pokemon ID must be an integer" }),
+    nationalDexId: z
+      .number()
+      .int({ error: "National Dex ID must be an integer" }),
+    name: z.string().min(1, { error: "Pokemon name is required" }),
+    types: z.array(PokemonTypeSchema),
+    species: PokemonSpeciesSchema,
+    evolution: EvolutionDataSchema.optional(),
+  })
+  .extend(FusionNamePartsSchema.shape);
+
 export type Pokemon = z.infer<typeof PokemonSchema>;
+export type FusionNameParts = z.infer<typeof FusionNamePartsSchema>;
 export type PokemonType = z.infer<typeof PokemonTypeSchema>;
 export type PokemonSpecies = z.infer<typeof PokemonSpeciesSchema>;
 export type EvolutionDetail = z.infer<typeof EvolutionDetailSchema>;


### PR DESCRIPTION
## Summary
Add optional fusion naming metadata (`headNamePart`, `bodyNamePart`) to the runtime Pokemon schema so naming logic can consume app-layer types without script-layer coupling.

## Motivation
INF-40 requires first-class runtime support for fusion name parts with backward compatibility for existing data that does not include those fields.

## Changes
- add `FusionNamePartsSchema` in `src/loaders/pokemon.ts` with optional `headNamePart` and `bodyNamePart`
- extend `PokemonSchema` with fusion name-part fields while keeping all existing required fields unchanged
- export `FusionNameParts` type from the loader boundary for app-side usage
- add parser compatibility tests in `src/loaders/__tests__/pokemon.test.ts` for both present and absent fusion name-part fields

## Testing
### Automated
- `pnpm exec vitest run src/loaders/__tests__/pokemon.test.ts`
- `pnpm type-check`

### Manual
- not run (runtime schema/type-only change validated via automated tests)

## Linear
- INF-40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Pokemon data structures with optional head and body name part fields, providing enhanced naming flexibility.

* **Tests**
  * Added validation tests for the newly added optional name part fields.
  * Added backward compatibility tests to ensure existing Pokemon data without these fields continues to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->