### PR TITLE
fix(analytics): persist dedupe markers only after successful sends

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Karla as Font } from "next/font/google";
 import localFont from "next/font/local";
 import "./globals.css";
+import { AnalyticsDebugPanel } from "@/components/analytics/AnalyticsDebugPanel";
 import {
   ConditionalAnalytics,
   ConditionalSpeedInsights,
@@ -170,6 +171,7 @@ export default function RootLayout({
           </ErrorBoundary>
           <ConditionalAnalytics />
           <ConditionalSpeedInsights />
+          <AnalyticsDebugPanel />
           <ServiceWorkerInit />
           {/* Portal root for context menus */}
           <div id="context-menu-root" />

--- a/src/components/analytics/AnalyticsDebugPanel.tsx
+++ b/src/components/analytics/AnalyticsDebugPanel.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { Bug, RotateCcw, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useMounted } from "@/hooks/useMounted";
+import {
+  type AnalyticsDebugCounters,
+  getAnalyticsDebugCounters,
+  resetAnalyticsDebugCounters,
+} from "@/lib/analytics/trackEvent";
+
+const DEBUG_QUERY_KEY = "analytics_debug";
+const DEBUG_STORAGE_KEY = "analytics-debug-panel";
+
+function isPanelEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const queryEnabled = params.get(DEBUG_QUERY_KEY) === "1";
+  if (queryEnabled) {
+    try {
+      localStorage.setItem(DEBUG_STORAGE_KEY, "1");
+    } catch {
+      // Ignore localStorage write failures.
+    }
+
+    return true;
+  }
+
+  try {
+    return localStorage.getItem(DEBUG_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function AnalyticsDebugPanel() {
+  const mounted = useMounted();
+  const [enabled, setEnabled] = useState(false);
+  const [open, setOpen] = useState(true);
+  const [counters, setCounters] = useState<AnalyticsDebugCounters>(
+    getAnalyticsDebugCounters(),
+  );
+
+  useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
+    setEnabled(isPanelEnabled());
+  }, [mounted]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    setCounters(getAnalyticsDebugCounters());
+    const intervalId = window.setInterval(() => {
+      setCounters(getAnalyticsDebugCounters());
+    }, 1000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [enabled]);
+
+  const consentIsOnlyBlocker = useMemo(() => {
+    const { blockReasons } = counters;
+    const hasConsentBlocks = blockReasons.no_consent > 0;
+    const hasOtherBlockers =
+      blockReasons.non_browser > 0 ||
+      blockReasons.non_production > 0 ||
+      blockReasons.kill_switch > 0 ||
+      blockReasons.invalid_payload > 0 ||
+      blockReasons.track_error > 0;
+
+    return hasConsentBlocks && !hasOtherBlockers;
+  }, [counters]);
+
+  if (!mounted || !enabled) {
+    return null;
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-4 right-4 z-[60] inline-flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-900 shadow-sm"
+        aria-label="Open analytics debug panel"
+      >
+        <Bug className="h-4 w-4" aria-hidden="true" />
+        Analytics Debug
+      </button>
+    );
+  }
+
+  return (
+    <section
+      className="fixed bottom-4 right-4 z-[60] w-[22rem] rounded-lg border border-gray-300 bg-white p-3 text-xs text-gray-900 shadow-lg"
+      aria-label="Analytics debug panel"
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <div className="inline-flex items-center gap-2 font-semibold">
+          <Bug className="h-4 w-4" aria-hidden="true" />
+          Analytics Debug
+        </div>
+        <div className="inline-flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => {
+              resetAnalyticsDebugCounters();
+              setCounters(getAnalyticsDebugCounters());
+            }}
+            className="rounded border border-gray-300 px-2 py-1 hover:bg-gray-50"
+            aria-label="Reset analytics counters"
+          >
+            <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="rounded border border-gray-300 px-2 py-1 hover:bg-gray-50"
+            aria-label="Collapse analytics debug panel"
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div className="rounded border border-gray-200 p-2">
+          sent: {counters.sent}
+        </div>
+        <div className="rounded border border-gray-200 p-2">
+          blocked: {counters.blocked}
+        </div>
+      </div>
+
+      <div className="mt-2 rounded border border-gray-200 p-2">
+        <div className="mb-1 font-medium">blocked reasons</div>
+        <pre className="whitespace-pre-wrap break-words text-[11px]">
+          {JSON.stringify(counters.blockReasons, null, 2)}
+        </pre>
+      </div>
+
+      <div className="mt-2 rounded border border-gray-200 p-2">
+        <div className="mb-1 font-medium">events</div>
+        <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words text-[11px]">
+          {JSON.stringify(counters.byEvent, null, 2)}
+        </pre>
+      </div>
+
+      <p className="mt-2 text-[11px] text-gray-700">
+        {consentIsOnlyBlocker
+          ? "Events are currently blocked only by consent; with analytics consent enabled, matching events should send."
+          : "If blockers other than no_consent are non-zero, consent alone will not guarantee event delivery."}
+      </p>
+      <p className="mt-1 text-[11px] text-gray-500">
+        Enable with <code>?analytics_debug=1</code>.
+      </p>
+    </section>
+  );
+}

--- a/src/lib/analytics/__tests__/playthroughEventData.test.ts
+++ b/src/lib/analytics/__tests__/playthroughEventData.test.ts
@@ -166,12 +166,12 @@ describe("playthroughEventData", () => {
     expect(getNewlyReachedCheckpoints("playthrough-1", 0, 6, storage)).toEqual([
       1, 5,
     ]);
-    markCheckpointEventsTracked("playthrough-1", [1, 5], storage);
+    markCheckpointEventsTracked("playthrough-1", [1, 5], [1, 5], storage);
 
     expect(getNewlyReachedCheckpoints("playthrough-1", 4, 10, storage)).toEqual(
       [10],
     );
-    markCheckpointEventsTracked("playthrough-1", [10], storage);
+    markCheckpointEventsTracked("playthrough-1", [10], [10], storage);
 
     expect(getNewlyReachedCheckpoints("playthrough-1", 9, 10, storage)).toEqual(
       [],
@@ -185,6 +185,52 @@ describe("playthroughEventData", () => {
     markPlaythroughResumedTracked("playthrough-1", storage);
     expect(shouldTrackPlaythroughResumed("playthrough-1", storage)).toBe(false);
     expect(shouldTrackPlaythroughResumed("playthrough-2", storage)).toBe(true);
+  });
+
+  it("avoids duplicate emissions while checkpoints are pending", () => {
+    const storage = createStorage();
+
+    expect(getNewlyReachedCheckpoints("playthrough-1", 0, 6, storage)).toEqual([
+      1, 5,
+    ]);
+
+    expect(getNewlyReachedCheckpoints("playthrough-1", 0, 6, storage)).toEqual(
+      [],
+    );
+
+    markCheckpointEventsTracked("playthrough-1", [1, 5], [1], storage);
+
+    expect(getNewlyReachedCheckpoints("playthrough-1", 0, 6, storage)).toEqual([
+      5,
+    ]);
+  });
+
+  it("swallows storage read/write failures for analytics markers", () => {
+    const storage = {
+      getItem() {
+        throw new Error("SecurityError");
+      },
+      setItem() {
+        throw new Error("QuotaExceededError");
+      },
+    } as unknown as Storage;
+
+    expect(() => {
+      const checkpoints = getNewlyReachedCheckpoints(
+        "playthrough-1",
+        0,
+        1,
+        storage,
+      );
+      markCheckpointEventsTracked(
+        "playthrough-1",
+        checkpoints,
+        checkpoints,
+        storage,
+      );
+      shouldTrackPlaythroughResumed("playthrough-1", storage);
+      markPlaythroughResumedTracked("playthrough-1", storage);
+    }).not.toThrow();
   });
 
   it("computes days since active and team size", () => {

--- a/src/lib/analytics/__tests__/playthroughEventData.test.ts
+++ b/src/lib/analytics/__tests__/playthroughEventData.test.ts
@@ -11,6 +11,8 @@ import {
   getCheckpointLabel,
   getDaysSinceLastActive,
   getNewlyReachedCheckpoints,
+  markCheckpointEventsTracked,
+  markPlaythroughResumedTracked,
   shouldTrackPlaythroughResumed,
 } from "../playthroughEventData";
 import {
@@ -164,10 +166,12 @@ describe("playthroughEventData", () => {
     expect(getNewlyReachedCheckpoints("playthrough-1", 0, 6, storage)).toEqual([
       1, 5,
     ]);
+    markCheckpointEventsTracked("playthrough-1", [1, 5], storage);
 
     expect(getNewlyReachedCheckpoints("playthrough-1", 4, 10, storage)).toEqual(
       [10],
     );
+    markCheckpointEventsTracked("playthrough-1", [10], storage);
 
     expect(getNewlyReachedCheckpoints("playthrough-1", 9, 10, storage)).toEqual(
       [],
@@ -178,6 +182,7 @@ describe("playthroughEventData", () => {
     const storage = createStorage();
 
     expect(shouldTrackPlaythroughResumed("playthrough-1", storage)).toBe(true);
+    markPlaythroughResumedTracked("playthrough-1", storage);
     expect(shouldTrackPlaythroughResumed("playthrough-1", storage)).toBe(false);
     expect(shouldTrackPlaythroughResumed("playthrough-2", storage)).toBe(true);
   });

--- a/src/lib/analytics/playthroughEventData.ts
+++ b/src/lib/analytics/playthroughEventData.ts
@@ -5,6 +5,7 @@ const CHECKPOINT_STORAGE_KEY_PREFIX = "analytics:checkpoints:";
 const RESUME_STORAGE_KEY_PREFIX = "analytics:playthrough-resumed:";
 
 type StorageValue = Storage | null | undefined;
+const pendingCheckpointEvents = new Map<string, Set<Checkpoint>>();
 
 const isUsableStorage = (value: StorageValue): value is Storage => {
   if (value == null) {
@@ -14,6 +15,22 @@ const isUsableStorage = (value: StorageValue): value is Storage => {
   return (
     typeof value.getItem === "function" && typeof value.setItem === "function"
   );
+};
+
+const safeGetItem = (storage: Storage, key: string): string | null => {
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const safeSetItem = (storage: Storage, key: string, value: string): void => {
+  try {
+    storage.setItem(key, value);
+  } catch {
+    // Keep analytics bookkeeping non-blocking when storage access fails.
+  }
 };
 
 export const getCheckpointStorageKey = (playthroughId: string): string => {
@@ -75,27 +92,56 @@ export const getNewlyReachedCheckpoints = (
   }
 
   const key = getCheckpointStorageKey(playthroughId);
-  const existing = parseStoredCheckpoints(storage.getItem(key));
-  return crossed.filter((checkpoint) => !existing.has(checkpoint));
+  const existing = parseStoredCheckpoints(safeGetItem(storage, key));
+  const pending = pendingCheckpointEvents.get(playthroughId) ?? new Set();
+  const unsent = crossed.filter(
+    (checkpoint) => !existing.has(checkpoint) && !pending.has(checkpoint),
+  );
+
+  if (unsent.length > 0) {
+    for (const checkpoint of unsent) {
+      pending.add(checkpoint);
+    }
+
+    pendingCheckpointEvents.set(playthroughId, pending);
+  }
+
+  return unsent;
 };
 
 export const markCheckpointEventsTracked = (
   playthroughId: string,
-  checkpoints: readonly Checkpoint[],
+  attemptedCheckpoints: readonly Checkpoint[],
+  trackedCheckpoints: readonly Checkpoint[],
   storage: StorageValue = globalThis.localStorage,
 ): void => {
-  if (!isUsableStorage(storage) || checkpoints.length === 0) {
+  if (attemptedCheckpoints.length === 0) {
     return;
   }
 
-  const key = getCheckpointStorageKey(playthroughId);
-  const existing = parseStoredCheckpoints(storage.getItem(key));
+  if (isUsableStorage(storage) && trackedCheckpoints.length > 0) {
+    const key = getCheckpointStorageKey(playthroughId);
+    const existing = parseStoredCheckpoints(safeGetItem(storage, key));
 
-  for (const checkpoint of checkpoints) {
-    existing.add(checkpoint);
+    for (const checkpoint of trackedCheckpoints) {
+      existing.add(checkpoint);
+    }
+
+    safeSetItem(storage, key, JSON.stringify(Array.from(existing.values())));
   }
 
-  storage.setItem(key, JSON.stringify(Array.from(existing.values())));
+  const pending = pendingCheckpointEvents.get(playthroughId);
+  if (!pending) {
+    return;
+  }
+
+  for (const checkpoint of attemptedCheckpoints) {
+    pending.delete(checkpoint);
+  }
+
+  if (pending.size === 0) {
+    pendingCheckpointEvents.delete(playthroughId);
+  }
 };
 
 export const shouldTrackPlaythroughResumed = (
@@ -107,7 +153,7 @@ export const shouldTrackPlaythroughResumed = (
   }
 
   const key = getResumeStorageKey(playthroughId);
-  return storage.getItem(key) !== "1";
+  return safeGetItem(storage, key) !== "1";
 };
 
 export const markPlaythroughResumedTracked = (
@@ -118,7 +164,7 @@ export const markPlaythroughResumedTracked = (
     return;
   }
 
-  storage.setItem(getResumeStorageKey(playthroughId), "1");
+  safeSetItem(storage, getResumeStorageKey(playthroughId), "1");
 };
 
 export const getDaysSinceLastActive = (

--- a/src/lib/analytics/playthroughEventData.ts
+++ b/src/lib/analytics/playthroughEventData.ts
@@ -76,18 +76,26 @@ export const getNewlyReachedCheckpoints = (
 
   const key = getCheckpointStorageKey(playthroughId);
   const existing = parseStoredCheckpoints(storage.getItem(key));
-  const unsent = crossed.filter((checkpoint) => !existing.has(checkpoint));
+  return crossed.filter((checkpoint) => !existing.has(checkpoint));
+};
 
-  if (unsent.length === 0) {
-    return [];
+export const markCheckpointEventsTracked = (
+  playthroughId: string,
+  checkpoints: readonly Checkpoint[],
+  storage: StorageValue = globalThis.localStorage,
+): void => {
+  if (!isUsableStorage(storage) || checkpoints.length === 0) {
+    return;
   }
 
-  for (const checkpoint of unsent) {
+  const key = getCheckpointStorageKey(playthroughId);
+  const existing = parseStoredCheckpoints(storage.getItem(key));
+
+  for (const checkpoint of checkpoints) {
     existing.add(checkpoint);
   }
 
   storage.setItem(key, JSON.stringify(Array.from(existing.values())));
-  return unsent;
 };
 
 export const shouldTrackPlaythroughResumed = (
@@ -99,12 +107,18 @@ export const shouldTrackPlaythroughResumed = (
   }
 
   const key = getResumeStorageKey(playthroughId);
-  if (storage.getItem(key) === "1") {
-    return false;
+  return storage.getItem(key) !== "1";
+};
+
+export const markPlaythroughResumedTracked = (
+  playthroughId: string,
+  storage: StorageValue = globalThis.sessionStorage,
+): void => {
+  if (!isUsableStorage(storage)) {
+    return;
   }
 
-  storage.setItem(key, "1");
-  return true;
+  storage.setItem(getResumeStorageKey(playthroughId), "1");
 };
 
 export const getDaysSinceLastActive = (

--- a/src/lib/analytics/trackEvent.ts
+++ b/src/lib/analytics/trackEvent.ts
@@ -436,38 +436,40 @@ export function hasAnalyticsConsent(
 export function trackEvent<EventName extends AnalyticsEventName>(
   eventName: EventName,
   properties: AnalyticsEventMap[EventName],
-): void {
+): boolean {
   if (typeof window === "undefined") {
     recordBlocked(eventName, "non_browser");
-    return;
+    return false;
   }
 
   if (!isValidEventPayload(eventName, properties)) {
     recordBlocked(eventName, "invalid_payload");
-    return;
+    return false;
   }
 
   if (isCustomEventKillSwitchEnabled()) {
     recordBlocked(eventName, "kill_switch");
     debugLog("Analytics event blocked by kill switch", { eventName });
-    return;
+    return false;
   }
 
   if (!isAnalyticsProductionEnvironment()) {
     recordBlocked(eventName, "non_production");
-    return;
+    return false;
   }
 
   if (!hasAnalyticsConsent()) {
     recordBlocked(eventName, "no_consent");
-    return;
+    return false;
   }
 
   try {
     track(eventName, properties satisfies AnalyticsProperties);
     recordSent(eventName);
+    return true;
   } catch {
     recordBlocked(eventName, "track_error");
     debugLog("Analytics event failed to send", { eventName });
+    return false;
   }
 }

--- a/src/stores/playthroughs/PlaythroughResumeObserver.tsx
+++ b/src/stores/playthroughs/PlaythroughResumeObserver.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import {
   getDaysSinceLastActive,
   getSharedEventProperties,
+  markPlaythroughResumedTracked,
   shouldTrackPlaythroughResumed,
   toDormancyBucket,
 } from "@/lib/analytics/playthroughEventData";
@@ -29,14 +30,17 @@ export function PlaythroughResumeObserver() {
       return;
     }
 
-    trackEvent("playthrough_resumed", {
+    const wasTracked = trackEvent("playthrough_resumed", {
       ...getSharedEventProperties(activePlaythrough),
       days_since_last_active_bucket: toDormancyBucket(
         getDaysSinceLastActive(activePlaythrough.updatedAt),
       ),
     });
 
-    lastTrackedPlaythroughId.current = activePlaythrough.id;
+    if (wasTracked) {
+      markPlaythroughResumedTracked(activePlaythrough.id);
+      lastTrackedPlaythroughId.current = activePlaythrough.id;
+    }
   }, [activePlaythrough, isLoading]);
 
   return null;

--- a/src/stores/playthroughs/PlaythroughResumeObserver.tsx
+++ b/src/stores/playthroughs/PlaythroughResumeObserver.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import {
   getDaysSinceLastActive,
   getSharedEventProperties,
@@ -11,10 +12,25 @@ import {
 import { trackEvent } from "@/lib/analytics/trackEvent";
 import { useActivePlaythrough, useIsLoading } from "./hooks";
 
+type ConsentPreferences = {
+  analytics: boolean;
+  speedInsights: boolean;
+};
+
+const DEFAULT_CONSENT_PREFERENCES: ConsentPreferences = {
+  analytics: false,
+  speedInsights: false,
+};
+
 export function PlaythroughResumeObserver() {
   const activePlaythrough = useActivePlaythrough();
   const isLoading = useIsLoading();
   const lastTrackedPlaythroughId = useRef<string | null>(null);
+  const [preferences] = useLocalStorage<ConsentPreferences>(
+    "cookie-preferences",
+    DEFAULT_CONSENT_PREFERENCES,
+  );
+  const hasAnalyticsConsent = preferences.analytics;
 
   useEffect(() => {
     if (isLoading || !activePlaythrough) {
@@ -41,7 +57,7 @@ export function PlaythroughResumeObserver() {
       markPlaythroughResumedTracked(activePlaythrough.id);
       lastTrackedPlaythroughId.current = activePlaythrough.id;
     }
-  }, [activePlaythrough, isLoading]);
+  }, [activePlaythrough, hasAnalyticsConsent, isLoading]);
 
   return null;
 }

--- a/src/stores/playthroughs/__tests__/analytics-events.test.ts
+++ b/src/stores/playthroughs/__tests__/analytics-events.test.ts
@@ -32,6 +32,7 @@ describe("analytics event instrumentation", () => {
 
   beforeEach(() => {
     analyticsMocks.trackEvent.mockReset();
+    analyticsMocks.trackEvent.mockReturnValue(true);
     localStorage.clear();
     sessionStorage.clear();
   });
@@ -52,7 +53,7 @@ describe("analytics event instrumentation", () => {
 
   it("tracks run checkpoints once per threshold", async () => {
     createTestPlaythrough();
-    analyticsMocks.trackEvent.mockReset();
+    analyticsMocks.trackEvent.mockClear();
 
     await updateEncounter("route1", testPokemon.pikachu("p-1"), "head", false);
     await updateEncounter("route2", testPokemon.pikachu("p-2"), "head", false);
@@ -80,7 +81,7 @@ describe("analytics event instrumentation", () => {
 
   it("tracks fusion_created for update, create, and drag-drop transitions", async () => {
     createTestPlaythrough();
-    analyticsMocks.trackEvent.mockReset();
+    analyticsMocks.trackEvent.mockClear();
 
     await updateEncounter(
       "route1",
@@ -113,7 +114,7 @@ describe("analytics event instrumentation", () => {
       "head",
       false,
     );
-    analyticsMocks.trackEvent.mockReset();
+    analyticsMocks.trackEvent.mockClear();
 
     const sourcePokemon =
       playthroughsStore.playthroughs[0]?.encounters?.route3?.head;
@@ -137,7 +138,7 @@ describe("analytics event instrumentation", () => {
 
   it("tracks encounter_marked_deceased only on transition", async () => {
     createTestPlaythrough();
-    analyticsMocks.trackEvent.mockReset();
+    analyticsMocks.trackEvent.mockClear();
 
     await updateEncounter(
       "route1",
@@ -152,7 +153,7 @@ describe("analytics event instrumentation", () => {
       true,
     );
 
-    analyticsMocks.trackEvent.mockReset();
+    analyticsMocks.trackEvent.mockClear();
 
     await markEncounterAsDeceased("route1");
     await markEncounterAsDeceased("route1");

--- a/src/stores/playthroughs/__tests__/playthrough-resume-observer.test.ts
+++ b/src/stores/playthroughs/__tests__/playthrough-resume-observer.test.ts
@@ -125,4 +125,38 @@ describe("PlaythroughResumeObserver", () => {
       ).toHaveLength(2);
     });
   });
+
+  it("retries when consent changes after an initially blocked send", async () => {
+    const { activePlaythrough } = createTestPlaythrough();
+    activePlaythrough.updatedAt = Date.now() - 8 * 86_400_000;
+    playthroughsStore.isLoading = false;
+    analyticsMocks.trackEvent.mockClear();
+    analyticsMocks.trackEvent.mockReturnValueOnce(false).mockReturnValue(true);
+
+    render(createElement(PlaythroughResumeObserver));
+
+    await waitFor(() => {
+      expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    });
+
+    localStorage.setItem(
+      "cookie-preferences",
+      JSON.stringify({ analytics: true, speedInsights: false }),
+    );
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "cookie-preferences",
+        newValue: JSON.stringify({ analytics: true, speedInsights: false }),
+        storageArea: localStorage,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        analyticsMocks.trackEvent.mock.calls.filter(
+          (call) => call[0] === "playthrough_resumed",
+        ),
+      ).toHaveLength(2);
+    });
+  });
 });

--- a/src/stores/playthroughs/__tests__/playthrough-resume-observer.test.ts
+++ b/src/stores/playthroughs/__tests__/playthrough-resume-observer.test.ts
@@ -43,6 +43,7 @@ describe("PlaythroughResumeObserver", () => {
 
   beforeEach(() => {
     analyticsMocks.trackEvent.mockReset();
+    analyticsMocks.trackEvent.mockReturnValue(true);
     Object.defineProperty(globalThis, "sessionStorage", {
       value: createStorageMock(),
       configurable: true,
@@ -55,7 +56,7 @@ describe("PlaythroughResumeObserver", () => {
     const { activePlaythrough } = createTestPlaythrough();
     activePlaythrough.updatedAt = Date.now() - 2 * 86_400_000;
     playthroughsStore.isLoading = true;
-    analyticsMocks.trackEvent.mockReset();
+    analyticsMocks.trackEvent.mockClear();
 
     render(createElement(PlaythroughResumeObserver));
 
@@ -70,7 +71,7 @@ describe("PlaythroughResumeObserver", () => {
     const { activePlaythrough } = createTestPlaythrough();
     activePlaythrough.updatedAt = Date.now() - 8 * 86_400_000;
     playthroughsStore.isLoading = false;
-    analyticsMocks.trackEvent.mockReset();
+    analyticsMocks.trackEvent.mockClear();
 
     const view = render(createElement(PlaythroughResumeObserver));
 
@@ -98,7 +99,7 @@ describe("PlaythroughResumeObserver", () => {
     const first = createTestPlaythrough("First");
     first.activePlaythrough.updatedAt = Date.now() - 86_400_000;
     playthroughsStore.isLoading = false;
-    analyticsMocks.trackEvent.mockReset();
+    analyticsMocks.trackEvent.mockClear();
 
     const view = render(createElement(PlaythroughResumeObserver));
 

--- a/src/stores/playthroughs/encounters/crud.ts
+++ b/src/stores/playthroughs/encounters/crud.ts
@@ -126,7 +126,11 @@ export const updateEncounter = async (
       }
     }
 
-    markCheckpointEventsTracked(activePlaythrough.id, trackedCheckpoints);
+    markCheckpointEventsTracked(
+      activePlaythrough.id,
+      newlyReachedCheckpoints,
+      trackedCheckpoints,
+    );
 
     return;
   }
@@ -227,7 +231,11 @@ export const updateEncounter = async (
       }
     }
 
-    markCheckpointEventsTracked(activePlaythrough.id, trackedCheckpoints);
+    markCheckpointEventsTracked(
+      activePlaythrough.id,
+      newlyReachedCheckpoints,
+      trackedCheckpoints,
+    );
 
     return;
   }
@@ -262,7 +270,11 @@ export const updateEncounter = async (
     }
   }
 
-  markCheckpointEventsTracked(activePlaythrough.id, trackedCheckpoints);
+  markCheckpointEventsTracked(
+    activePlaythrough.id,
+    newlyReachedCheckpoints,
+    trackedCheckpoints,
+  );
 };
 
 // Reset encounter for a location

--- a/src/stores/playthroughs/encounters/crud.ts
+++ b/src/stores/playthroughs/encounters/crud.ts
@@ -3,6 +3,7 @@ import { getCheckpointLabel } from "@/lib/analytics/buckets";
 import {
   getEncounterCount,
   getNewlyReachedCheckpoints,
+  markCheckpointEventsTracked,
 } from "@/lib/analytics/playthroughEventData";
 import { getSharedEventProperties } from "@/lib/analytics/selectors";
 import { trackEvent } from "@/lib/analytics/trackEvent";
@@ -111,14 +112,21 @@ export const updateEncounter = async (
       previousEncounterCount,
       nextEncounterCount,
     );
+    const trackedCheckpoints: typeof newlyReachedCheckpoints = [];
 
     for (const checkpoint of newlyReachedCheckpoints) {
-      trackEvent("run_checkpoint_reached", {
+      const wasTracked = trackEvent("run_checkpoint_reached", {
         ...getSharedEventProperties(activePlaythrough),
         checkpoint,
         checkpoint_label: getCheckpointLabel(checkpoint),
       });
+
+      if (wasTracked) {
+        trackedCheckpoints.push(checkpoint);
+      }
     }
+
+    markCheckpointEventsTracked(activePlaythrough.id, trackedCheckpoints);
 
     return;
   }
@@ -205,14 +213,21 @@ export const updateEncounter = async (
       previousEncounterCount,
       nextEncounterCount,
     );
+    const trackedCheckpoints: typeof newlyReachedCheckpoints = [];
 
     for (const checkpoint of newlyReachedCheckpoints) {
-      trackEvent("run_checkpoint_reached", {
+      const wasTracked = trackEvent("run_checkpoint_reached", {
         ...getSharedEventProperties(activePlaythrough),
         checkpoint,
         checkpoint_label: getCheckpointLabel(checkpoint),
       });
+
+      if (wasTracked) {
+        trackedCheckpoints.push(checkpoint);
+      }
     }
+
+    markCheckpointEventsTracked(activePlaythrough.id, trackedCheckpoints);
 
     return;
   }
@@ -233,14 +248,21 @@ export const updateEncounter = async (
     previousEncounterCount,
     nextEncounterCount,
   );
+  const trackedCheckpoints: typeof newlyReachedCheckpoints = [];
 
   for (const checkpoint of newlyReachedCheckpoints) {
-    trackEvent("run_checkpoint_reached", {
+    const wasTracked = trackEvent("run_checkpoint_reached", {
       ...getSharedEventProperties(activePlaythrough),
       checkpoint,
       checkpoint_label: getCheckpointLabel(checkpoint),
     });
+
+    if (wasTracked) {
+      trackedCheckpoints.push(checkpoint);
+    }
   }
+
+  markCheckpointEventsTracked(activePlaythrough.id, trackedCheckpoints);
 };
 
 // Reset encounter for a location

--- a/src/stores/playthroughs/encounters/fusion.ts
+++ b/src/stores/playthroughs/encounters/fusion.ts
@@ -141,5 +141,9 @@ export const createFusion = async (
     }
   }
 
-  markCheckpointEventsTracked(activePlaythrough.id, trackedCheckpoints);
+  markCheckpointEventsTracked(
+    activePlaythrough.id,
+    newlyReachedCheckpoints,
+    trackedCheckpoints,
+  );
 };

--- a/src/stores/playthroughs/encounters/fusion.ts
+++ b/src/stores/playthroughs/encounters/fusion.ts
@@ -2,6 +2,7 @@ import { getCheckpointLabel } from "@/lib/analytics/buckets";
 import {
   getEncounterCount,
   getNewlyReachedCheckpoints,
+  markCheckpointEventsTracked,
 } from "@/lib/analytics/playthroughEventData";
 import { getSharedEventProperties } from "@/lib/analytics/selectors";
 import { trackEvent } from "@/lib/analytics/trackEvent";
@@ -126,12 +127,19 @@ export const createFusion = async (
     previousEncounterCount,
     nextEncounterCount,
   );
+  const trackedCheckpoints: typeof newlyReachedCheckpoints = [];
 
   for (const checkpoint of newlyReachedCheckpoints) {
-    trackEvent("run_checkpoint_reached", {
+    const wasTracked = trackEvent("run_checkpoint_reached", {
       ...getSharedEventProperties(activePlaythrough),
       checkpoint,
       checkpoint_label: getCheckpointLabel(checkpoint),
     });
+
+    if (wasTracked) {
+      trackedCheckpoints.push(checkpoint);
+    }
   }
+
+  markCheckpointEventsTracked(activePlaythrough.id, trackedCheckpoints);
 };


### PR DESCRIPTION
## Summary
- prevent one-time analytics dedupe markers from being written when events are blocked (for example before consent), so events can still be sent after consent is granted
- make `trackEvent` return a success boolean and use it in checkpoint/resume emitters to mark storage only for successfully sent events
- add an opt-in `?analytics_debug=1` in-app analytics debug panel that surfaces sent/blocked counters and blocker reasons for production troubleshooting

## Validation
- `pnpm test:run src/lib/analytics/__tests__/playthroughEventData.test.ts src/stores/playthroughs/__tests__/playthrough-resume-observer.test.ts src/stores/playthroughs/__tests__/analytics-events.test.ts src/lib/analytics/__tests__/trackEvent.test.ts`
- `pnpm type-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added analytics debug panel displaying event tracking metrics (sent/blocked counters) and detailed block reasons in collapsible bottom-right interface.

* **Refactor**
  * Enhanced event tracking system to record and persist which events successfully sent versus were blocked.
  * Improved tracking state management for checkpoint and resume events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->