### PR TITLE
fix(ci): set NEXT_PUBLIC_VERCEL_ENV for production deploy builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,6 +55,7 @@ jobs:
       cancel-in-progress: false
     env:
       VERCEL_NEXT_BUNDLED_SERVER: '1'
+      NEXT_PUBLIC_VERCEL_ENV: production
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- set NEXT_PUBLIC_VERCEL_ENV=production in the deploy-production job of release-please.yml
- ensure client-side production gating for custom analytics evaluates correctly in release deployments
- keep behavior scoped to the release workflow deploy path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated deployment configuration.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->