### PR TITLE
fix(analytics): allow production hostname fallback when env is missing

### DIFF
--- a/src/components/analytics/ConditionalAnalytics.tsx
+++ b/src/components/analytics/ConditionalAnalytics.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useMounted } from "@/hooks/useMounted";
+import { isAnalyticsProductionEnvironment } from "@/lib/analytics/trackEvent";
 
 const SpeedInsights = dynamic(
   () => import("@vercel/speed-insights/next").then((mod) => mod.SpeedInsights),
@@ -39,9 +40,7 @@ export function ConditionalAnalytics() {
 
   // Only render Analytics if component has mounted and user has given consent
   // Disable analytics in development and preview environments
-  const isProduction =
-    process.env.NODE_ENV === "production" &&
-    process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
+  const isProduction = isAnalyticsProductionEnvironment();
 
   if (mounted === false || !preferences.analytics || !isProduction) {
     return null;
@@ -59,9 +58,7 @@ export function ConditionalSpeedInsights() {
 
   // Only render SpeedInsights if component has mounted and user has given consent
   // Disable speed insights in development and preview environments
-  const isProduction =
-    process.env.NODE_ENV === "production" &&
-    process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
+  const isProduction = isAnalyticsProductionEnvironment();
 
   if (mounted === false || !preferences.speedInsights || !isProduction) {
     return null;

--- a/src/lib/analytics/__tests__/trackEvent.test.ts
+++ b/src/lib/analytics/__tests__/trackEvent.test.ts
@@ -65,7 +65,7 @@ describe("analytics transport wrapper", () => {
     });
   });
 
-  it("checks production and vercel production env", () => {
+  it("checks production environment with safe hostname fallback", () => {
     expect(
       isAnalyticsProductionEnvironment({
         NODE_ENV: "production",
@@ -91,6 +91,24 @@ describe("analytics transport wrapper", () => {
       isAnalyticsProductionEnvironment({
         NODE_ENV: "production",
       }),
+    ).toBe(false);
+
+    expect(
+      isAnalyticsProductionEnvironment(
+        {
+          NODE_ENV: "production",
+        },
+        "fusion.nuzlocke.io",
+      ),
+    ).toBe(true);
+
+    expect(
+      isAnalyticsProductionEnvironment(
+        {
+          NODE_ENV: "production",
+        },
+        "preview-deploy.vercel.app",
+      ),
     ).toBe(false);
   });
 

--- a/src/lib/analytics/trackEvent.ts
+++ b/src/lib/analytics/trackEvent.ts
@@ -252,6 +252,11 @@ type AppEnvironment = {
   ANALYTICS_DEBUG?: string;
 };
 
+const ANALYTICS_PRODUCTION_HOSTNAMES = new Set([
+  "fusion.nuzlocke.io",
+  "www.fusion.nuzlocke.io",
+]);
+
 const createByEventCounter = (): Record<AnalyticsEventName, EventCounter> => {
   return {
     playthrough_created: { sent: 0, blocked: 0 },
@@ -386,11 +391,32 @@ function isValidEventPayload<EventName extends AnalyticsEventName>(
 
 export function isAnalyticsProductionEnvironment(
   environment: AppEnvironment = process.env,
+  browserHostname?: string,
 ): boolean {
-  return (
-    environment.NODE_ENV === "production" &&
-    environment.NEXT_PUBLIC_VERCEL_ENV === "production"
-  );
+  if (environment.NODE_ENV !== "production") {
+    return false;
+  }
+
+  if (environment.NEXT_PUBLIC_VERCEL_ENV === "production") {
+    return true;
+  }
+
+  if (
+    environment.NEXT_PUBLIC_VERCEL_ENV === "preview" ||
+    environment.NEXT_PUBLIC_VERCEL_ENV === "development"
+  ) {
+    return false;
+  }
+
+  const hostname =
+    browserHostname ??
+    (typeof window === "undefined" ? undefined : globalThis.location?.hostname);
+
+  if (hostname == null) {
+    return false;
+  }
+
+  return ANALYTICS_PRODUCTION_HOSTNAMES.has(hostname.toLowerCase());
 }
 
 function getBrowserStorage(): Pick<Storage, "getItem"> | null {


### PR DESCRIPTION
## Summary
- add a safe fallback in analytics production gating: if `NEXT_PUBLIC_VERCEL_ENV` is missing, allow only known production hostnames
- reuse the same gate in `ConditionalAnalytics` and `ConditionalSpeedInsights` to keep runtime behavior consistent
- add coverage for hostname fallback and preview-host rejection in `trackEvent` tests

## Why
- production users were still being blocked with `non_production` even after CI env changes because client bundles can still lack `NEXT_PUBLIC_VERCEL_ENV` in some deploy paths
- this keeps preview and development blocked while unblocking the canonical production domain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated and enhanced analytics environment detection across the application for improved accuracy in identifying production deployments across multiple deployment configurations and custom production domains.

* **Tests**
  * Expanded test coverage for environment detection logic with additional validation scenarios for hostname-based production environment identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->