### PR TITLE
fix(analytics): remove NODE_ENV dependency from prod gate

### DIFF
--- a/src/lib/analytics/__tests__/trackEvent.test.ts
+++ b/src/lib/analytics/__tests__/trackEvent.test.ts
@@ -78,7 +78,7 @@ describe("analytics transport wrapper", () => {
         NODE_ENV: "development",
         NEXT_PUBLIC_VERCEL_ENV: "production",
       }),
-    ).toBe(false);
+    ).toBe(true);
 
     expect(
       isAnalyticsProductionEnvironment({

--- a/src/lib/analytics/trackEvent.ts
+++ b/src/lib/analytics/trackEvent.ts
@@ -393,10 +393,6 @@ export function isAnalyticsProductionEnvironment(
   environment: AppEnvironment = process.env,
   browserHostname?: string,
 ): boolean {
-  if (environment.NODE_ENV !== "production") {
-    return false;
-  }
-
   if (environment.NEXT_PUBLIC_VERCEL_ENV === "production") {
     return true;
   }


### PR DESCRIPTION
## Summary
- make analytics production gating trust `NEXT_PUBLIC_VERCEL_ENV=production` regardless of `NODE_ENV`
- keep preview/development explicitly blocked when `NEXT_PUBLIC_VERCEL_ENV` is set accordingly
- update `trackEvent` tests to cover the adjusted contract

## Why
- production traffic was still counted as `non_production` on `fusion.nuzlocke.io`
- this removes an unnecessary strictness point that can misclassify real production runtime in bundled client code