### PR TITLE
INF-14: keep context menus inside viewport edges

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -18,6 +18,7 @@ import {
   isValidElement,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   useTransition,
@@ -27,6 +28,27 @@ import { match } from "ts-pattern";
 import { CursorTooltip } from "./CursorTooltip";
 
 // Filter out separators at the beginning and end of the items array
+const VIEWPORT_EDGE_PADDING = 8;
+
+export function clampMenuPosition(
+  position: { x: number; y: number },
+  size: { width: number; height: number },
+) {
+  const maxX = Math.max(
+    VIEWPORT_EDGE_PADDING,
+    window.innerWidth - size.width - VIEWPORT_EDGE_PADDING,
+  );
+  const maxY = Math.max(
+    VIEWPORT_EDGE_PADDING,
+    window.innerHeight - size.height - VIEWPORT_EDGE_PADDING,
+  );
+
+  return {
+    x: Math.min(Math.max(position.x, VIEWPORT_EDGE_PADDING), maxX),
+    y: Math.min(Math.max(position.y, VIEWPORT_EDGE_PADDING), maxY),
+  };
+}
+
 function filterEdgeSeparators(items: ContextMenuItem[]): ContextMenuItem[] {
   if (items.length === 0) return items;
 
@@ -82,6 +104,7 @@ function useContextMenuState() {
 
   return {
     menuPosition,
+    setMenuPosition,
     isOpen,
     isVisible,
     activeIndex,
@@ -98,8 +121,7 @@ export interface ContextMenuItem {
   icon?: LucideIcon;
   iconClassName?: string;
   favicon?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onClick?: (event: React.MouseEvent<any>) => void;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   href?: string;
   target?: string;
   disabled?: boolean;
@@ -131,6 +153,7 @@ export function ContextMenu({
 }: ContextMenuProps) {
   const {
     menuPosition,
+    setMenuPosition,
     isOpen,
     isVisible,
     activeIndex,
@@ -144,6 +167,20 @@ export function ContextMenu({
   const menuElementRef = useRef<HTMLDivElement>(null);
   const [openSubmenuIndex, setOpenSubmenuIndex] = useState<number | null>(null);
   const submenuRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!isVisible || !menuElementRef.current) return;
+
+    const { width, height } = menuElementRef.current.getBoundingClientRect();
+    const nextPosition = clampMenuPosition(menuPosition, { width, height });
+
+    if (
+      nextPosition.x !== menuPosition.x ||
+      nextPosition.y !== menuPosition.y
+    ) {
+      setMenuPosition(nextPosition);
+    }
+  }, [isVisible, menuPosition, setMenuPosition]);
 
   useEffect(() => {
     onOpenChange?.(isOpen);
@@ -297,6 +334,7 @@ export function ContextMenu({
               }}
               className={clsx(
                 "min-w-[12rem] rounded-md border border-gray-200 dark:border-gray-800",
+                "max-h-[calc(100vh-1rem)] max-w-[calc(100vw-1rem)] overflow-y-auto",
                 "bg-white dark:bg-gray-900/80 shadow-elevation-3",
                 "p-1 backdrop-blur-xl tooltip-enter",
                 "origin-top-left backdrop-blur-xl",

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -121,7 +121,8 @@ export interface ContextMenuItem {
   icon?: LucideIcon;
   iconClassName?: string;
   favicon?: string;
-  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onClick?: (event: React.MouseEvent<any>) => void;
   href?: string;
   target?: string;
   disabled?: boolean;

--- a/src/components/__tests__/ContextMenu.test.tsx
+++ b/src/components/__tests__/ContextMenu.test.tsx
@@ -1,0 +1,32 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { clampMenuPosition } from "../ContextMenu";
+
+describe("ContextMenu", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 300,
+    });
+
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      writable: true,
+      value: 200,
+    });
+  });
+
+  it("keeps the context menu inside the viewport near bottom-right edges", () => {
+    expect(
+      clampMenuPosition({ x: 280, y: 190 }, { width: 120, height: 80 }),
+    ).toEqual({ x: 172, y: 112 });
+  });
+
+  it("keeps the requested position when enough viewport space exists", () => {
+    expect(
+      clampMenuPosition({ x: 100, y: 60 }, { width: 120, height: 80 }),
+    ).toEqual({ x: 100, y: 60 });
+  });
+});


### PR DESCRIPTION
## Summary
- fix `ContextMenu` positioning by clamping the opened menu to viewport edges before paint
- constrain menu width and height so oversized menus stay usable inside the viewport
- add focused regression coverage for edge clamping behavior

## Motivation
Issue `INF-14` tracks context menus rendering off-canvas near viewport edges, which can hide actions and make the menu unusable.

## Changes
- add `clampMenuPosition` and apply it from a layout effect when the menu opens
- add viewport-bound max height and max width styling to the shared context menu surface
- add targeted tests for edge overflow clamping and in-bounds placement

## Testing
- `pnpm exec biome format --write "src/components/ContextMenu.tsx" "src/components/__tests__/ContextMenu.test.tsx"`
- `pnpm exec biome lint "src/components/ContextMenu.tsx" "src/components/__tests__/ContextMenu.test.tsx"`
- `pnpm exec vitest run src/components/__tests__/ContextMenu.test.tsx`
- `pnpm type-check`

## Linear
- Issue: `INF-14`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Context menus now automatically reposition themselves to remain fully visible within the viewport, preventing off-screen overflow
  * Added internal scrolling capability to context menus when constrained by viewport boundaries

* **Tests**
  * Added test coverage for context menu viewport positioning behavior and edge case handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #56 