### PR TITLE
INF-15: show duplicate indicators in Pokemon combobox

### DIFF
--- a/openspec/changes/inf-15-combobox-duplicate-indicator/.openspec.yaml
+++ b/openspec/changes/inf-15-combobox-duplicate-indicator/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/inf-15-combobox-duplicate-indicator/design.md
+++ b/openspec/changes/inf-15-combobox-duplicate-indicator/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`PokemonCombobox` builds its option list from route encounter data plus global search results, while `PokemonOptions` owns the visible option row. The requested duplicate signal is a shared UI concern, but its truth source must come from canonical playthrough encounter state rather than ad-hoc local flags so the combobox stays aligned with run data across team, box, and historical encounter views.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Surface duplicate state for a species directly in combobox option rows.
+- Derive duplicate state from current playthrough encounters in a way that survives later status transitions like stored or deceased.
+- Preserve existing combobox search ordering, source tags, selection flow, and keyboard behavior.
+
+**Non-Goals:**
+- No changes to duplicate-clause enforcement logic or selection blocking.
+- No redesign of combobox layout beyond the added indicator treatment.
+- No persistence or schema changes.
+
+## Decisions
+
+- **Use species id as the duplicate key:** Duplicate state will be keyed by `pokemon.id`, matching how combobox options are already deduplicated and rendered. Alternative considered: keying by nickname or UID, rejected because duplicate-clause semantics are species-based.
+- **Derive from canonical encounter snapshots:** Build a `Set<number>` of duplicate species from `useEncounters()` data rather than route data or search results. Alternative considered: infer from `routeEncounterData`, rejected because it only describes possible encounters for one location, not current run history.
+- **Treat capture provenance as sticky:** A Pokemon counts as already captured when its encounter record shows captured provenance, preferring `originalReceivalStatus` when present and falling back to current `status` for older/unmigrated data. Alternative considered: check only current `status === captured`, rejected because boxed or deceased Pokemon would lose duplicate visibility after later status changes.
+- **Keep the indicator additive-only:** The option row will add a compact icon/label treatment without changing option enabled state, ordering, or selection behavior. Alternative considered: disabling duplicates, rejected because the issue asks for indication, not enforcement.
+
+## Risks / Trade-offs
+
+- **Ambiguity between captured vs received/traded provenance** -> Mitigation: scope the duplicate signal to captured provenance only and document that explicitly in the spec.
+- **Visual crowding in option rows** -> Mitigation: use a compact right-side treatment that coexists with source tags and dex number without changing row height.
+- **False negatives on legacy data without `originalReceivalStatus`** -> Mitigation: fall back to current `status` when provenance is absent.
+- **Future mismatch with stricter duplicate-clause rules** -> Mitigation: isolate duplicate derivation so later policy changes can update one helper/selector path.
+
+## Migration Plan
+
+1. Add a small selector/helper that scans canonical encounters for captured species ids.
+2. Thread duplicate-state lookups into `PokemonCombobox` and `PokemonOptions`.
+3. Add focused rendering tests for duplicate and non-duplicate rows.
+4. Validate formatting, linting, and targeted tests before implementation review.
+
+## Open Questions
+
+- Should future duplicate signaling also cover `received` or `traded` provenance, or remain strictly limited to captured encounters?

--- a/openspec/changes/inf-15-combobox-duplicate-indicator/proposal.md
+++ b/openspec/changes/inf-15-combobox-duplicate-indicator/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The Pokemon combobox currently shows route and search matches without signaling when a species has already been captured elsewhere in the run. That forces duplicate-rule checks into memory and makes accidental duplicate selections more likely during normal encounter entry.
+
+## What Changes
+
+- Add duplicate-state signaling to combobox options when the displayed species already exists in the current playthrough as a captured Pokemon.
+- Define the duplicate signal source from canonical run-state data instead of ad-hoc component-local tracking.
+- Preserve existing combobox search, selection, loading, and keyboard behavior while layering the indicator into option rendering.
+
+## Capabilities
+
+### New Capabilities
+- `combobox-duplicate-indicators`: Defines when Pokemon combobox options must surface a duplicate indicator based on current playthrough capture state.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code will likely include `src/components/PokemonCombobox/PokemonCombobox.tsx`, `src/components/PokemonCombobox/PokemonOptions.tsx`, and a small shared selector/helper for reading duplicate state from `useEncounters()`.
+- Validation should stay focused on combobox rendering behavior and duplicate-state derivation from canonical encounter data.
+- No API, persistence schema, or migration work is expected.

--- a/openspec/changes/inf-15-combobox-duplicate-indicator/specs/combobox-duplicate-indicators/spec.md
+++ b/openspec/changes/inf-15-combobox-duplicate-indicator/specs/combobox-duplicate-indicators/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Combobox options signal previously captured species
+The system MUST mark a Pokemon combobox option as a duplicate when the current playthrough already contains that species as a captured encounter.
+
+#### Scenario: Duplicate species appears in option results
+- **WHEN** a combobox option represents a species whose id already exists in the current playthrough with captured provenance
+- **THEN** that option shows a visible duplicate indicator in its rendered row
+
+#### Scenario: Species not yet captured stays unmarked
+- **WHEN** a combobox option represents a species with no captured provenance in the current playthrough
+- **THEN** that option renders without the duplicate indicator
+
+### Requirement: Duplicate state uses canonical playthrough capture provenance
+The system MUST derive combobox duplicate state from canonical playthrough encounter records, using stored capture provenance so later status changes do not remove duplicate visibility.
+
+#### Scenario: Stored or deceased Pokemon still counts as duplicate
+- **WHEN** a species was previously captured and later moved to another non-active status such as stored or deceased
+- **THEN** combobox options for that species still render the duplicate indicator
+
+#### Scenario: Non-captured provenance does not trigger duplicate state
+- **WHEN** a playthrough contains a species only through non-captured provenance or no provenance data that indicates capture
+- **THEN** combobox options for that species do not render the duplicate indicator
+
+### Requirement: Duplicate indication preserves combobox behavior
+The system MUST add duplicate signaling without changing option ordering, filtering, keyboard navigation, or selection behavior.
+
+#### Scenario: Keyboard selection remains unchanged
+- **WHEN** a user navigates combobox options with the keyboard and encounters duplicate-marked options
+- **THEN** active-state movement, selection, and focus behavior match non-duplicate options
+
+#### Scenario: Search and route ordering remain unchanged
+- **WHEN** duplicate and non-duplicate options are shown together in a combobox result list
+- **THEN** existing route-priority and search-result ordering rules remain unchanged

--- a/openspec/changes/inf-15-combobox-duplicate-indicator/tasks.md
+++ b/openspec/changes/inf-15-combobox-duplicate-indicator/tasks.md
@@ -1,0 +1,14 @@
+## 1. Duplicate-state derivation
+
+- [ ] 1.1 Add a focused helper or selector that scans canonical playthrough encounters and returns captured-species ids for combobox duplicate checks.
+- [ ] 1.2 Cover captured-provenance fallback behavior so stored or deceased Pokemon that were previously captured still count as duplicates.
+
+## 2. Combobox rendering
+
+- [ ] 2.1 Thread duplicate-state lookup from `PokemonCombobox.tsx` into option rendering without changing current search and route ordering.
+- [ ] 2.2 Update `PokemonOptions.tsx` to render a compact duplicate indicator that coexists with source tags, dex number, and existing keyboard/selection states.
+
+## 3. Verification
+
+- [ ] 3.1 Add targeted tests for duplicate-marked and non-duplicate option rows.
+- [ ] 3.2 Run focused validation for the touched files: format, lint, and targeted test coverage.

--- a/src/components/PokemonCombobox/PokemonCombobox.tsx
+++ b/src/components/PokemonCombobox/PokemonCombobox.tsx
@@ -33,7 +33,8 @@ import {
   useAllPokemon,
   usePokemonSearch,
 } from "@/loaders/pokemon";
-import { useGameMode } from "@/stores/playthroughs";
+import { useEncounters, useGameMode } from "@/stores/playthroughs";
+import { buildCapturedSpeciesIdSet } from "@/utils/encounter-utils";
 import { DraggableComboboxSprite } from "./DraggableComboboxSprite";
 import {
   applyEncounterDefaultStatus,
@@ -93,6 +94,7 @@ export const PokemonCombobox = ({
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const gameMode = useGameMode();
+  const encounters = useEncounters();
 
   // Ref to maintain focus on input
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -121,6 +123,17 @@ export const PokemonCombobox = ({
     (pokemonId: number): boolean => routePokemonIds.has(pokemonId),
     [routePokemonIds],
   );
+
+  const capturedSpeciesIds = useMemo(
+    () => buildCapturedSpeciesIdSet(encounters),
+    [encounters],
+  );
+
+  const isDuplicatePokemon = useCallback(
+    (pokemonId: number): boolean => capturedSpeciesIds.has(pokemonId),
+    [capturedSpeciesIds],
+  );
+
   // Use the search hook
   const { data: resultsData, isLoading: isSearchLoading } = usePokemonSearch({
     query: deferredQuery,
@@ -551,6 +564,7 @@ export const PokemonCombobox = ({
                           index={virtualItem.index}
                           disabled={virtualizer.isScrolling}
                           isRoutePokemon={isRoutePokemon}
+                          isDuplicatePokemon={isDuplicatePokemon}
                           getPokemonSource={getPokemonSource}
                           comboboxId={comboboxId || ""}
                           gameMode={gameMode}
@@ -574,6 +588,7 @@ export const PokemonCombobox = ({
                         finalOptions={finalOptions}
                         deferredQuery={deferredQuery}
                         isRoutePokemon={isRoutePokemon}
+                        isDuplicatePokemon={isDuplicatePokemon}
                         getPokemonSource={getPokemonSource}
                         gameMode={gameMode}
                         isLoading={isShowingLoading}

--- a/src/components/PokemonCombobox/PokemonOptions.tsx
+++ b/src/components/PokemonCombobox/PokemonOptions.tsx
@@ -18,6 +18,7 @@ interface PokemonOptionsProps {
   deferredQuery: string;
   locationId: string | undefined;
   isRoutePokemon: (pokemonId: number) => boolean;
+  isDuplicatePokemon: (pokemonId: number) => boolean;
   getPokemonSource: (pokemonId: number) => EncounterSource[];
   comboboxId: string;
   gameMode: "classic" | "remix" | "randomized";
@@ -29,6 +30,7 @@ interface PokemonOptionProps {
   index?: number;
   locationId: string | undefined;
   isRoutePokemon: (pokemonId: number) => boolean;
+  isDuplicatePokemon: (pokemonId: number) => boolean;
   getPokemonSource: (pokemonId: number) => EncounterSource[];
   comboboxId?: string;
   gameMode: "classic" | "remix" | "randomized";
@@ -41,6 +43,7 @@ interface PokemonOptionContentProps {
   pokemon: PokemonOptionType;
   locationId: string | undefined;
   isRoutePokemon: (pokemonId: number) => boolean;
+  isDuplicatePokemon: (pokemonId: number) => boolean;
   getPokemonSource: (pokemonId: number) => EncounterSource[];
   gameMode: "classic" | "remix" | "randomized";
   isActive?: boolean;
@@ -50,6 +53,7 @@ interface PokemonOptionContentProps {
 function PokemonOptionContent({
   pokemon,
   isRoutePokemon,
+  isDuplicatePokemon,
   getPokemonSource,
   gameMode,
   locationId,
@@ -57,6 +61,7 @@ function PokemonOptionContent({
   isSelected = false,
 }: PokemonOptionContentProps) {
   const displayName = getEncounterDisplayName(pokemon);
+  const isDuplicate = isDuplicatePokemon(pokemon.id);
 
   return (
     <div className={"gap-4 group w-full flex items-center"}>
@@ -79,6 +84,19 @@ function PokemonOptionContent({
             sources={getPokemonSource(pokemon.id)}
             locationId={locationId}
           />
+        )}
+        {isDuplicate && (
+          <span
+            className={clsx(
+              "text-xs px-1.5 py-0.5 rounded-sm font-medium leading-none",
+              "text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-900/20",
+              "border border-amber-200/60 dark:border-amber-700/40",
+              isActive && "group-hover:text-white group-hover:border-white/60",
+            )}
+            title="Already captured"
+          >
+            Dup
+          </span>
         )}
         <span
           className={clsx(
@@ -107,6 +125,7 @@ function PokemonOptionContent({
 export function PokemonOption({
   pokemon,
   isRoutePokemon,
+  isDuplicatePokemon,
   getPokemonSource,
   gameMode,
   style,
@@ -144,6 +163,7 @@ export function PokemonOption({
           locationId={locationId}
           pokemon={pokemon}
           isRoutePokemon={isRoutePokemon}
+          isDuplicatePokemon={isDuplicatePokemon}
           getPokemonSource={getPokemonSource}
           gameMode={gameMode}
           isActive={active}
@@ -158,6 +178,7 @@ export const PokemonOptions: React.FC<PokemonOptionsProps> = ({
   finalOptions,
   deferredQuery,
   isRoutePokemon,
+  isDuplicatePokemon,
   getPokemonSource,
   locationId,
   gameMode,
@@ -207,6 +228,7 @@ export const PokemonOptions: React.FC<PokemonOptionsProps> = ({
       pokemon={pokemon}
       locationId={locationId}
       isRoutePokemon={isRoutePokemon}
+      isDuplicatePokemon={isDuplicatePokemon}
       getPokemonSource={getPokemonSource}
       gameMode={gameMode}
     />

--- a/src/components/PokemonCombobox/__tests__/PokemonOptions.test.tsx
+++ b/src/components/PokemonCombobox/__tests__/PokemonOptions.test.tsx
@@ -1,0 +1,86 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PokemonOptionType } from "@/loaders/pokemon";
+import { PokemonOption } from "../PokemonOptions";
+
+vi.mock("@headlessui/react", () => ({
+  ComboboxOption: ({
+    children,
+    className,
+    value: _value,
+    ...props
+  }: {
+    children:
+      | React.ReactNode
+      | ((state: { active: boolean; selected: boolean }) => React.ReactNode);
+    className?: string | ((state: { active: boolean }) => string);
+    value?: unknown;
+  } & Omit<React.HTMLAttributes<HTMLDivElement>, "children" | "className">) => (
+    <div
+      {...props}
+      className={
+        typeof className === "function"
+          ? className({ active: false })
+          : className
+      }
+    >
+      {typeof children === "function"
+        ? children({ active: false, selected: false })
+        : children}
+    </div>
+  ),
+}));
+
+vi.mock("../SourceTag", () => ({
+  SourceTag: () => <span>Route</span>,
+}));
+
+vi.mock("@/components/PokemonSprite", () => ({
+  PokemonSprite: () => <div data-testid="pokemon-sprite" />,
+}));
+
+const mockPokemon: PokemonOptionType = {
+  id: 25,
+  name: "Pikachu",
+  nationalDexId: 25,
+};
+
+describe("PokemonOption", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the duplicate badge for already captured species", () => {
+    render(
+      <PokemonOption
+        pokemon={mockPokemon}
+        locationId="route-1"
+        isRoutePokemon={() => true}
+        isDuplicatePokemon={() => true}
+        getPokemonSource={() => []}
+        gameMode="classic"
+      />,
+    );
+
+    expect(screen.getByText("Dup")).toBeTruthy();
+    expect(screen.getByTitle("Already captured")).toBeTruthy();
+  });
+
+  it("omits the duplicate badge for uncaptured species", () => {
+    render(
+      <PokemonOption
+        pokemon={mockPokemon}
+        locationId="route-1"
+        isRoutePokemon={() => false}
+        isDuplicatePokemon={() => false}
+        getPokemonSource={() => []}
+        gameMode="classic"
+      />,
+    );
+
+    expect(screen.queryByText("Dup")).toBeNull();
+  });
+});

--- a/src/utils/__tests__/encounter-utils.test.ts
+++ b/src/utils/__tests__/encounter-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { PokemonOptionType } from "@/loaders/pokemon";
 import type { EncounterData } from "@/stores/playthroughs/types";
 import {
+  buildCapturedSpeciesIdSet,
   buildPokemonUidIndex,
   findPokemonByUid,
   findPokemonWithLocation,
@@ -274,6 +275,52 @@ describe("encounter-utils", () => {
     it("should return empty index for null encounters", () => {
       const index = buildPokemonUidIndex(null);
       expect(index.size).toBe(0);
+    });
+  });
+
+  describe("buildCapturedSpeciesIdSet", () => {
+    it("includes species captured directly or via original capture provenance", () => {
+      const encounters: Record<string, EncounterData> = {
+        route1: {
+          head: mockPikachu,
+          body: {
+            ...mockCharmander,
+            status: "deceased",
+            originalReceivalStatus: "captured",
+          },
+          isFusion: true,
+          updatedAt: Date.now(),
+        },
+      };
+
+      expect(buildCapturedSpeciesIdSet(encounters)).toEqual(new Set([25, 4]));
+    });
+
+    it("ignores non-captured provenance and hidden non-fusion body pokemon", () => {
+      const encounters: Record<string, EncounterData> = {
+        route1: {
+          head: {
+            ...mockPikachu,
+            status: "received",
+            originalReceivalStatus: "received",
+          },
+          body: mockCharmander,
+          isFusion: false,
+          updatedAt: Date.now(),
+        },
+        route2: {
+          head: {
+            ...mockBulbasaur,
+            status: "traded",
+            originalReceivalStatus: "traded",
+          },
+          body: null,
+          isFusion: false,
+          updatedAt: Date.now(),
+        },
+      };
+
+      expect(buildCapturedSpeciesIdSet(encounters)).toEqual(new Set());
     });
   });
 

--- a/src/utils/__tests__/encounter-utils.test.ts
+++ b/src/utils/__tests__/encounter-utils.test.ts
@@ -296,6 +296,27 @@ describe("encounter-utils", () => {
       expect(buildCapturedSpeciesIdSet(encounters)).toEqual(new Set([25, 4]));
     });
 
+    it("keeps legacy stored or deceased species when provenance is missing", () => {
+      const encounters: Record<string, EncounterData> = {
+        route1: {
+          head: {
+            ...mockPikachu,
+            status: "stored",
+            originalReceivalStatus: undefined,
+          },
+          body: {
+            ...mockCharmander,
+            status: "deceased",
+            originalReceivalStatus: undefined,
+          },
+          isFusion: true,
+          updatedAt: Date.now(),
+        },
+      };
+
+      expect(buildCapturedSpeciesIdSet(encounters)).toEqual(new Set([25, 4]));
+    });
+
     it("ignores non-captured provenance and hidden non-fusion body pokemon", () => {
       const encounters: Record<string, EncounterData> = {
         route1: {

--- a/src/utils/encounter-utils.ts
+++ b/src/utils/encounter-utils.ts
@@ -95,9 +95,14 @@ function wasOriginallyCaptured(
 ): pokemon is PokemonOptionType {
   if (!pokemon) return false;
 
+  if (pokemon.originalReceivalStatus) {
+    return pokemon.originalReceivalStatus === PokemonStatus.CAPTURED;
+  }
+
   return (
-    (pokemon.originalReceivalStatus ?? pokemon.status) ===
-    PokemonStatus.CAPTURED
+    pokemon.status === PokemonStatus.CAPTURED ||
+    pokemon.status === PokemonStatus.STORED ||
+    pokemon.status === PokemonStatus.DECEASED
   );
 }
 

--- a/src/utils/encounter-utils.ts
+++ b/src/utils/encounter-utils.ts
@@ -1,4 +1,4 @@
-import type { PokemonOptionType } from "@/loaders/pokemon";
+import { type PokemonOptionType, PokemonStatus } from "@/loaders/pokemon";
 import type { EncounterData } from "@/stores/playthroughs/types";
 
 export type PokemonUidIndex = Map<string, PokemonOptionType>;
@@ -88,4 +88,35 @@ export function getAllPokemonWithLocations(
 
     return pokemon;
   });
+}
+
+function wasOriginallyCaptured(
+  pokemon: PokemonOptionType | null | undefined,
+): pokemon is PokemonOptionType {
+  if (!pokemon) return false;
+
+  return (
+    (pokemon.originalReceivalStatus ?? pokemon.status) ===
+    PokemonStatus.CAPTURED
+  );
+}
+
+export function buildCapturedSpeciesIdSet(
+  encounters: Record<string, EncounterData> | null | undefined,
+): Set<number> {
+  const capturedSpeciesIds = new Set<number>();
+
+  if (!encounters) return capturedSpeciesIds;
+
+  for (const encounter of Object.values(encounters)) {
+    if (wasOriginallyCaptured(encounter.head)) {
+      capturedSpeciesIds.add(encounter.head.id);
+    }
+
+    if (encounter.isFusion && wasOriginallyCaptured(encounter.body)) {
+      capturedSpeciesIds.add(encounter.body.id);
+    }
+  }
+
+  return capturedSpeciesIds;
 }


### PR DESCRIPTION
## Summary
- add a captured-species selector over canonical playthrough encounters and use it to mark duplicate Pokemon directly inside combobox results
- preserve existing search, ordering, and keyboard behavior while keeping duplicate visibility sticky for captured Pokemon that later move to stored or deceased states
- add OpenSpec artifacts and focused regression tests for duplicate provenance and badge rendering

## Motivation
- INF-15 needs a visible duplicate signal in shared Pokemon selection so duplicate-clause checks do not rely on player memory

## Changes
- add `buildCapturedSpeciesIdSet` in `src/utils/encounter-utils.ts` and cover capture provenance edge cases in `src/utils/__tests__/encounter-utils.test.ts`
- thread duplicate lookup through `src/components/PokemonCombobox/PokemonCombobox.tsx` into `src/components/PokemonCombobox/PokemonOptions.tsx`
- add `src/components/PokemonCombobox/__tests__/PokemonOptions.test.tsx` and the OpenSpec change under `openspec/changes/inf-15-combobox-duplicate-indicator/`

## Validation
- `pnpm exec biome format --write "src/utils/encounter-utils.ts" "src/utils/__tests__/encounter-utils.test.ts" "src/components/PokemonCombobox/PokemonOptions.tsx" "src/components/PokemonCombobox/PokemonCombobox.tsx" "src/components/PokemonCombobox/__tests__/PokemonOptions.test.tsx"`
- `pnpm exec biome lint "src/utils/encounter-utils.ts" "src/utils/__tests__/encounter-utils.test.ts" "src/components/PokemonCombobox/PokemonOptions.tsx" "src/components/PokemonCombobox/PokemonCombobox.tsx" "src/components/PokemonCombobox/__tests__/PokemonOptions.test.tsx"` (existing warning in `PokemonCombobox.tsx` for a static drag/drop wrapper)
- `pnpm exec vitest run src/utils/__tests__/encounter-utils.test.ts src/components/PokemonCombobox/__tests__/PokemonOptions.test.tsx`
- `pnpm type-check`

## Linear
- Issue: INF-15