### PR TITLE
fix(INF-115): prevent evolution animation when switching playthroughs

### DIFF
--- a/src/components/LocationTable/LocationTableRow.tsx
+++ b/src/components/LocationTable/LocationTableRow.tsx
@@ -6,6 +6,7 @@ import { addEvolutionListener } from "@/lib/events";
 import type { CombinedLocation } from "@/loaders/locations";
 import { isCustomLocation } from "@/loaders/locations";
 import { useEncounter } from "@/stores/playthroughs";
+import { useActivePlaythrough } from "@/stores/playthroughs/hooks";
 import { canFuse } from "@/utils/pokemonPredicates";
 import PokemonSummaryCard from "../PokemonSummaryCard";
 import type { FusionSpriteHandle } from "../PokemonSummaryCard/FusionSprite";
@@ -29,12 +30,17 @@ export default function LocationTableRow({ row }: LocationTableRowProps) {
   const { ref, inView } = useInView();
   const spriteRef = useRef<FusionSpriteHandle | null>(null);
   const previousFusionId = useRef<string | null>(null);
+  const activePlaythrough = useActivePlaythrough();
 
   const aboveTheFold = row.index < 8;
   const shouldLoad = inView || aboveTheFold;
 
   // Get encounter data directly - only this row will rerender when this encounter changes
   const encounterData = useEncounter(locationId) || EMPTY_ENCOUNTER;
+
+  useEffect(() => {
+    previousFusionId.current = null;
+  }, [activePlaythrough?.id]);
 
   // Play evolution animation when this location evolves, but only if the Pokémon can form an effective fusion
   useEffect(() => {

--- a/src/components/LocationTable/LocationTableRow.tsx
+++ b/src/components/LocationTable/LocationTableRow.tsx
@@ -6,7 +6,7 @@ import { addEvolutionListener } from "@/lib/events";
 import type { CombinedLocation } from "@/loaders/locations";
 import { isCustomLocation } from "@/loaders/locations";
 import { useEncounter } from "@/stores/playthroughs";
-import { useActivePlaythrough } from "@/stores/playthroughs/hooks";
+import { useActivePlaythroughId } from "@/stores/playthroughs/hooks";
 import { canFuse } from "@/utils/pokemonPredicates";
 import PokemonSummaryCard from "../PokemonSummaryCard";
 import type { FusionSpriteHandle } from "../PokemonSummaryCard/FusionSprite";
@@ -30,7 +30,7 @@ export default function LocationTableRow({ row }: LocationTableRowProps) {
   const { ref, inView } = useInView();
   const spriteRef = useRef<FusionSpriteHandle | null>(null);
   const previousFusionId = useRef<string | null>(null);
-  const activePlaythrough = useActivePlaythrough();
+  const activePlaythroughId = useActivePlaythroughId();
 
   const aboveTheFold = row.index < 8;
   const shouldLoad = inView || aboveTheFold;
@@ -40,7 +40,7 @@ export default function LocationTableRow({ row }: LocationTableRowProps) {
 
   useEffect(() => {
     previousFusionId.current = null;
-  }, [activePlaythrough?.id]);
+  }, [activePlaythroughId]);
 
   // Play evolution animation when this location evolves, but only if the Pokémon can form an effective fusion
   useEffect(() => {

--- a/src/components/pc/TeamEntryItem.tsx
+++ b/src/components/pc/TeamEntryItem.tsx
@@ -22,6 +22,7 @@ import { getLocationById } from "@/loaders/locations";
 import type { PokemonOptionType } from "@/loaders/pokemon";
 import { PokemonStatus } from "@/loaders/pokemon";
 import { playthroughActions, useEncounters } from "@/stores/playthroughs";
+import { useActivePlaythrough } from "@/stores/playthroughs/hooks";
 import { formatArtistCredits } from "@/utils/formatCredits";
 import { canFuse, isPokemonActive } from "@/utils/pokemonPredicates";
 import { scrollToLocationById } from "@/utils/scrollToLocation";
@@ -130,6 +131,7 @@ export default function TeamEntryItem({
   onTeamMemberClick,
 }: TeamEntryItemProps) {
   const encounters = useEncounters();
+  const activePlaythrough = useActivePlaythrough();
 
   // Check if this is team data (has position field) or encounter data
   const isTeamData = "position" in entry && typeof entry.position === "number";
@@ -151,6 +153,10 @@ export default function TeamEntryItem({
   // Ref for the sprite to play evolution animations
   const spriteRef = useRef<FusionSpriteHandle | null>(null);
   const previousFusionId = useRef<string | null>(null);
+
+  useEffect(() => {
+    previousFusionId.current = null;
+  }, [activePlaythrough?.id]);
 
   // Track fusion ID changes and play evolution animations
   useEffect(() => {

--- a/src/components/pc/__tests__/TeamEntryItem.test.tsx
+++ b/src/components/pc/__tests__/TeamEntryItem.test.tsx
@@ -13,18 +13,22 @@ import { PokemonStatus } from "@/loaders/pokemon";
 import TeamEntryItem from "../TeamEntryItem";
 import type { PCEntry } from "../types";
 
+let activePlaythroughId = "playthrough-1";
+
 const {
   moveTeamMemberToBoxMock,
   moveEncounterToBoxMock,
   markEncounterAsDeceasedMock,
   updatePokemonByUIDMock,
   updateTeamMemberMock,
+  playEvolutionMock,
 } = vi.hoisted(() => ({
   moveTeamMemberToBoxMock: vi.fn().mockResolvedValue(undefined),
   moveEncounterToBoxMock: vi.fn().mockResolvedValue(undefined),
   markEncounterAsDeceasedMock: vi.fn().mockResolvedValue(undefined),
   updatePokemonByUIDMock: vi.fn().mockResolvedValue(undefined),
   updateTeamMemberMock: vi.fn().mockResolvedValue(undefined),
+  playEvolutionMock: vi.fn(),
 }));
 
 vi.mock("@/assets/images/head.svg", () => ({
@@ -48,7 +52,25 @@ vi.mock("@/components/PokemonSummaryCard/ArtworkVariantButton", () => ({
 }));
 
 vi.mock("@/components/PokemonSummaryCard/FusionSprite", () => ({
-  FusionSprite: () => <div data-testid="fusion-sprite" />,
+  FusionSprite: (() => {
+    const React = require("react") as typeof import("react");
+    return React.forwardRef((props, ref) => {
+      React.useImperativeHandle(
+        ref,
+        () => ({
+          playEvolution: playEvolutionMock,
+        }),
+        [],
+      );
+
+      return <div data-testid="fusion-sprite" {...props} />;
+    });
+  })(),
+}));
+
+vi.mock("@/stores/playthroughs/hooks", () => ({
+  useActivePlaythrough: () =>
+    activePlaythroughId ? { id: activePlaythroughId } : null,
 }));
 
 vi.mock("@/components/PokemonSummaryCard/TeamMemberContextMenu", () => ({
@@ -140,11 +162,13 @@ describe("TeamEntryItem", () => {
   });
 
   beforeEach(() => {
+    activePlaythroughId = "playthrough-1";
     moveTeamMemberToBoxMock.mockClear();
     moveEncounterToBoxMock.mockClear();
     markEncounterAsDeceasedMock.mockClear();
     updatePokemonByUIDMock.mockClear();
     updateTeamMemberMock.mockClear();
+    playEvolutionMock.mockClear();
   });
 
   it("opens team assignment from empty team slot", () => {
@@ -225,5 +249,52 @@ describe("TeamEntryItem", () => {
       });
       expect(updateTeamMemberMock).toHaveBeenCalledWith(1, null, null);
     });
+  });
+
+  it("does not play evolution animation when active playthrough changes", () => {
+    const entryA: PCEntry = {
+      ...filledTeamEntry,
+    };
+    const entryB: PCEntry = {
+      ...filledTeamEntry,
+      head: {
+        ...filledTeamEntry.head!,
+        id: 1,
+        name: "Bulbasaur",
+        uid: "bulbasaur-uid",
+      },
+      body: {
+        ...filledTeamEntry.body!,
+        id: 2,
+        name: "Ivysaur",
+        uid: "ivysaur-uid",
+      },
+    };
+    const entryC: PCEntry = {
+      ...filledTeamEntry,
+      head: {
+        ...filledTeamEntry.head!,
+        id: 4,
+        name: "Charmander",
+        uid: "charmander-uid",
+      },
+      body: {
+        ...filledTeamEntry.body!,
+        id: 7,
+        name: "Squirtle",
+        uid: "squirtle-uid",
+      },
+    };
+
+    const { rerender } = render(
+      <TeamEntryItem entry={entryA} idToName={idToName} />,
+    );
+
+    rerender(<TeamEntryItem entry={entryB} idToName={idToName} />);
+    expect(playEvolutionMock).toHaveBeenCalledTimes(1);
+
+    activePlaythroughId = "playthrough-2";
+    rerender(<TeamEntryItem entry={entryC} idToName={idToName} />);
+    expect(playEvolutionMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/team/TeamSlots.tsx
+++ b/src/components/team/TeamSlots.tsx
@@ -173,6 +173,9 @@ export default function TeamSlots() {
   // Refs for team member sprites to play evolution animations
   const teamSpriteRefs = useRef<(FusionSpriteHandle | null)[]>([]);
   const previousFusionIds = useRef<(string | null)[]>([]);
+  const pendingEvolutionTimeouts = useRef<
+    Array<ReturnType<typeof setTimeout> | null>
+  >([]);
 
   const pokemonByUid = useMemo(
     () => buildPokemonUidIndex(encounters),
@@ -181,6 +184,12 @@ export default function TeamSlots() {
 
   useEffect(() => {
     previousFusionIds.current = new Array(6).fill(null);
+    pendingEvolutionTimeouts.current.forEach((timeoutId, index) => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+      pendingEvolutionTimeouts.current[index] = null;
+    });
   }, [activePlaythrough?.id]);
 
   const teamSlots = useMemo(() => {
@@ -237,6 +246,9 @@ export default function TeamSlots() {
     if (previousFusionIds.current.length !== 6) {
       previousFusionIds.current = new Array(6).fill(null);
     }
+    if (pendingEvolutionTimeouts.current.length !== 6) {
+      pendingEvolutionTimeouts.current = new Array(6).fill(null);
+    }
 
     // Use requestAnimationFrame to ensure proper timing
     const animationFrame = requestAnimationFrame(() => {
@@ -260,10 +272,14 @@ export default function TeamSlots() {
             previousFusionIds.current[index] = currentFusionId;
 
             // Add small delay to ensure ref is properly set
-            setTimeout(() => {
+            if (pendingEvolutionTimeouts.current[index] !== null) {
+              clearTimeout(pendingEvolutionTimeouts.current[index]!);
+            }
+            pendingEvolutionTimeouts.current[index] = setTimeout(() => {
               if (teamSpriteRefs.current[index]) {
                 teamSpriteRefs.current[index]?.playEvolution();
               }
+              pendingEvolutionTimeouts.current[index] = null;
             }, 50);
           }
         } else if (slot.isEmpty) {
@@ -276,6 +292,12 @@ export default function TeamSlots() {
     // Cleanup animation frame on unmount
     return () => {
       cancelAnimationFrame(animationFrame);
+      pendingEvolutionTimeouts.current.forEach((timeoutId, index) => {
+        if (timeoutId !== null) {
+          clearTimeout(timeoutId);
+        }
+        pendingEvolutionTimeouts.current[index] = null;
+      });
     };
   }, [teamSlots]);
 

--- a/src/components/team/TeamSlots.tsx
+++ b/src/components/team/TeamSlots.tsx
@@ -179,6 +179,10 @@ export default function TeamSlots() {
     [encounters],
   );
 
+  useEffect(() => {
+    previousFusionIds.current = new Array(6).fill(null);
+  }, [activePlaythrough?.id]);
+
   const teamSlots = useMemo(() => {
     if (!activePlaythrough?.team) return [];
 

--- a/src/stores/playthroughs/hooks.ts
+++ b/src/stores/playthroughs/hooks.ts
@@ -49,6 +49,11 @@ export const useActivePlaythrough = (): Playthrough | null => {
   }, [snapshot.activePlaythroughId, snapshot.playthroughs]);
 };
 
+export const useActivePlaythroughId = (): string | null => {
+  const snapshot = useSnapshot(playthroughsStore);
+  return snapshot.activePlaythroughId ?? null;
+};
+
 export const useIsRemixMode = (): boolean => {
   const snapshot = useSnapshot(playthroughsStore);
   const activePlaythrough = snapshot.playthroughs.find(


### PR DESCRIPTION
## Summary
- Reset per-component previous fusion tracking when active playthrough changes so stale fusion IDs from another playthrough do not trigger evolution animation.
- Apply the reset in `LocationTableRow`, `TeamSlots`, and `TeamEntryItem` to cover table, team slots, and PC/team entry rendering paths.
- Add a regression test in `TeamEntryItem.test.tsx` proving playthrough switches do not fire `playEvolution` while in-playthrough fusion changes still do.

## Testing
### Automated
- `pnpm test:run src/components/pc/__tests__/TeamEntryItem.test.tsx`
- `pnpm type-check`

### Manual
- Open app with at least two playthroughs that have different team/fusion compositions.
- Switch between playthroughs several times.
- Verify no evolution animation plays immediately after switching.
- Perform an actual evolution/fusion change inside the active playthrough and verify animation still plays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed fusion evolution animations to display correctly when switching between different game playthroughs. Animation state now properly resets during playthrough transitions to ensure smooth visual transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->