### PR TITLE
INF-126: define telemetry v2 OpenSpec contract

### DIFF
--- a/openspec/changes/inf-126-telemetry-v2-event-contract/.openspec.yaml
+++ b/openspec/changes/inf-126-telemetry-v2-event-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/inf-126-telemetry-v2-event-contract/design.md
+++ b/openspec/changes/inf-126-telemetry-v2-event-contract/design.md
@@ -1,0 +1,28 @@
+## Context
+
+Current analytics events already enforce flat payloads and bucketed counters, but upcoming work introduces more transition and source-specific events. The existing contract does not define strict naming and field-shape conventions for these new categories.
+
+## Goals
+
+- Prevent event payload drift as new analytics events are added.
+- Keep event design low-cardinality and queryable across lifecycle funnels.
+- Enforce contract consistency at typed schema boundaries, not only in prose docs.
+
+## Non-Goals
+
+- Implementing all downstream new events in this change.
+- Introducing nested payload objects or dynamic schema fields.
+- Adding compatibility shims for unspecified legacy event variants.
+
+## Decisions
+
+1. Keep one normative contract document for taxonomy and buckets (`docs/analytics/event-spec.md`).
+2. Require transition properties to use `previous_*` and `new_*` naming pairs for lifecycle events.
+3. Require source properties to use bounded enums (`source_surface`, `trigger_method`) with explicit allowed values.
+4. Keep payloads flat and primitive-only (`string`, `number`, `boolean`) to preserve analytics backend compatibility.
+5. Validate schema in `trackEvent` so invalid payloads fail before emission.
+
+## Validation Strategy
+
+- Add focused tests for schema acceptance/rejection around transition and source field conventions.
+- Run scoped lint/test validation for touched analytics modules.

--- a/openspec/changes/inf-126-telemetry-v2-event-contract/proposal.md
+++ b/openspec/changes/inf-126-telemetry-v2-event-contract/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Analytics instrumentation is expanding beyond the current v1 contract, but the repo lacks a single normative v2 contract for event naming, required fields, and transition/source conventions. Without a shared contract, new events can drift across payload shape, naming, and emit semantics.
+
+## What Changes
+
+- Define telemetry v2 contract rules for stable event names, required shared properties, and event-specific property constraints.
+- Standardize transition field naming (`previous_*`, `new_*`) and source field naming (`source_surface`, `trigger_method`) to prevent schema drift.
+- Define contract-first workflow expectations so any new analytics event updates the contract before code emission.
+
+## Capabilities
+
+### New Capabilities
+- `analytics-event-contract-v2`: Defines required telemetry schema conventions for event names, shared payload fields, transition/source field patterns, and contract update workflow.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Primary touched docs/types are expected in `docs/analytics/event-spec.md` and analytics schema typing in `src/lib/analytics/trackEvent.ts`.
+- Follow-up instrumentation issues depend on this contract to keep payloads consistent across domain emit points.
+- No persistence migration is required; this is a contract and schema-governance change.

--- a/openspec/changes/inf-126-telemetry-v2-event-contract/specs/analytics-event-contract-v2/spec.md
+++ b/openspec/changes/inf-126-telemetry-v2-event-contract/specs/analytics-event-contract-v2/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Telemetry v2 event naming and shape are canonical
+The system MUST define telemetry v2 event contracts with stable snake_case event names, flat property maps, and primitive-only values.
+
+#### Scenario: Event names follow canonical naming
+- **WHEN** a new telemetry event is introduced
+- **THEN** its event id is snake_case and documented in the analytics contract source of truth
+
+#### Scenario: Event payload shape remains flat
+- **WHEN** event payload schemas are defined for telemetry v2
+- **THEN** properties are flat key-value fields and do not contain nested objects or arrays
+
+### Requirement: Shared telemetry fields are explicitly required
+The system MUST define and enforce one required shared field set for telemetry v2 events.
+
+#### Scenario: Shared fields are present on every event
+- **WHEN** any telemetry v2 event is emitted
+- **THEN** the event payload includes the required shared property set defined by the contract
+
+#### Scenario: Shared fields are validated before emission
+- **WHEN** an event payload omits or mistypes a required shared field
+- **THEN** schema validation rejects the payload and prevents emission
+
+### Requirement: Transition and source semantics use normalized field conventions
+The system MUST standardize lifecycle transition fields as `previous_*` and `new_*` pairs, and source fields through explicit bounded enums.
+
+#### Scenario: Status transition event uses previous/new fields
+- **WHEN** an event describes movement between lifecycle states
+- **THEN** the payload uses paired `previous_*` and `new_*` fields for the transitioned dimension
+
+#### Scenario: Source context remains bounded
+- **WHEN** an event includes source context such as UI entrypoint or trigger mode
+- **THEN** the payload uses explicit enum-backed source fields (for example `source_surface` and `trigger_method`) with contract-defined values
+
+### Requirement: Contract-first workflow gates analytics additions
+The system MUST update contract artifacts before introducing new telemetry v2 event emissions.
+
+#### Scenario: New event requires contract update first
+- **WHEN** implementation proposes a new telemetry v2 event or property
+- **THEN** the analytics contract documentation and schema definitions are updated before or with the emit-point change
+
+#### Scenario: Drift is blocked by verification
+- **WHEN** telemetry schema or contract conventions drift from implementation
+- **THEN** focused verification fails and requires contract/schema alignment before merge

--- a/openspec/changes/inf-126-telemetry-v2-event-contract/tasks.md
+++ b/openspec/changes/inf-126-telemetry-v2-event-contract/tasks.md
@@ -1,0 +1,16 @@
+## 1. Contract taxonomy and required fields
+
+- [ ] 1.1 Define telemetry v2 naming rules for event ids and event-specific properties.
+- [ ] 1.2 Define required shared payload properties and allowed primitive value types.
+- [ ] 1.3 Define required field conventions for transition semantics (`previous_*`, `new_*`) and emit-source semantics (`source_surface`, `trigger_method`).
+
+## 2. Contract source-of-truth updates
+
+- [ ] 2.1 Update analytics contract documentation to include v2 rules, canonical fields, and examples.
+- [ ] 2.2 Update `trackEvent` schema/types so v2 rules are enforced at compile/runtime boundaries.
+- [ ] 2.3 Confirm existing events remain valid under v2 or explicitly document deltas.
+
+## 3. Verification
+
+- [ ] 3.1 Add or update focused tests that fail on contract drift for required fields and naming conventions.
+- [ ] 3.2 Run targeted validation for touched analytics files (format, lint, and targeted tests).


### PR DESCRIPTION
## Summary
- add a new OpenSpec change for INF-126 at `openspec/changes/inf-126-telemetry-v2-event-contract/`
- define telemetry v2 contract requirements for naming, shared required fields, transition/source conventions, and contract-first workflow gates
- add proposal, design, spec, and task artifacts so downstream analytics instrumentation can implement against a canonical contract

## Validation
- Automated: `openspec status --change \"inf-126-telemetry-v2-event-contract\" --json` ✅
- Automated: `openspec validate \"inf-126-telemetry-v2-event-contract\"` ✅
- Manual: reviewed generated artifact set includes all required spec-driven files (`proposal.md`, `design.md`, `specs/**/spec.md`, `tasks.md`) ✅

## Linear
- Issue: INF-126