### PR TITLE
INF-130: add analytics event QA test coverage

### DIFF
--- a/src/lib/analytics/__tests__/playthroughEventData.test.ts
+++ b/src/lib/analytics/__tests__/playthroughEventData.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../buckets";
 import {
   getCheckpointLabel,
+  getCheckpointStorageKey,
   getDaysSinceLastActive,
   getNewlyReachedCheckpoints,
   markCheckpointEventsTracked,
@@ -175,6 +176,21 @@ describe("playthroughEventData", () => {
 
     expect(getNewlyReachedCheckpoints("playthrough-1", 9, 10, storage)).toEqual(
       [],
+    );
+  });
+
+  it("respects checkpoint markers restored from storage", () => {
+    const storage = createStorage();
+    storage.setItem(
+      getCheckpointStorageKey("playthrough-1"),
+      JSON.stringify([1, 5]),
+    );
+
+    expect(getNewlyReachedCheckpoints("playthrough-1", 0, 6, storage)).toEqual(
+      [],
+    );
+    expect(getNewlyReachedCheckpoints("playthrough-1", 0, 10, storage)).toEqual(
+      [10],
     );
   });
 

--- a/src/lib/analytics/__tests__/trackEvent.test.ts
+++ b/src/lib/analytics/__tests__/trackEvent.test.ts
@@ -1,12 +1,67 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ANALYTICS_EVENTS,
+  type AnalyticsEventName,
   getAnalyticsDebugCounters,
   hasAnalyticsConsent,
   isAnalyticsProductionEnvironment,
   resetAnalyticsDebugCounters,
   trackEvent,
 } from "../trackEvent";
+
+type AnalyticsPrimitive = string | number | boolean;
+
+const BASE_SHARED_PROPERTIES = {
+  playthrough_id: "pt-1",
+  game_mode: "classic",
+  encounter_count_bucket: "e_1",
+  deceased_count_bucket: "c_0",
+  boxed_count_bucket: "c_0",
+  fusion_count_bucket: "c_0",
+  viable_roster_bucket: "v_6_plus",
+} as const;
+
+const VALID_EVENT_PAYLOADS: Record<
+  AnalyticsEventName,
+  Record<string, AnalyticsPrimitive>
+> = {
+  playthrough_created: {
+    ...BASE_SHARED_PROPERTIES,
+    has_existing_playthroughs: false,
+  },
+  run_checkpoint_reached: {
+    ...BASE_SHARED_PROPERTIES,
+    checkpoint: 5,
+    checkpoint_label: "cp_5",
+  },
+  playthrough_resumed: {
+    ...BASE_SHARED_PROPERTIES,
+    days_since_last_active_bucket: "d_1_2_days",
+  },
+  fusion_created: {
+    ...BASE_SHARED_PROPERTIES,
+    location_id: "route-1",
+    creation_method: "create_fusion",
+  },
+  fusion_flipped: {
+    ...BASE_SHARED_PROPERTIES,
+    location_id: "route-1",
+  },
+  encounter_marked_deceased: {
+    ...BASE_SHARED_PROPERTIES,
+    location_id: "route-1",
+    was_fused: true,
+    team_size_after: 5,
+    viable_roster_bucket_after: "v_4_5",
+  },
+  playthrough_exported: {
+    ...BASE_SHARED_PROPERTIES,
+  },
+};
+
+const eventPayloadEntries = Object.entries(VALID_EVENT_PAYLOADS) as Array<
+  [AnalyticsEventName, Record<string, AnalyticsPrimitive>]
+>;
 
 const analyticsMock = vi.hoisted(() => ({
   track: vi.fn(),
@@ -233,6 +288,42 @@ describe("analytics transport wrapper", () => {
       expect.objectContaining({ checkpoint: 5, checkpoint_label: "cp_5" }),
     );
     expect(getAnalyticsDebugCounters().sent).toBe(1);
+  });
+
+  it.each(
+    eventPayloadEntries,
+  )("accepts contract-valid payload for %s", (eventName, payload) => {
+    localStorage.setItem(
+      "cookie-preferences",
+      JSON.stringify({ analytics: true }),
+    );
+    setEnvironment("production", "production");
+
+    trackEvent(eventName, payload as never);
+
+    expect(analyticsMock.track).toHaveBeenCalledTimes(1);
+    expect(analyticsMock.track).toHaveBeenCalledWith(eventName, payload);
+    expect(getAnalyticsDebugCounters().sent).toBe(1);
+  });
+
+  it.each(
+    eventPayloadEntries,
+  )("rejects payload when shared contract field is missing for %s", (eventName, payload) => {
+    localStorage.setItem(
+      "cookie-preferences",
+      JSON.stringify({ analytics: true }),
+    );
+    setEnvironment("production", "production");
+
+    const invalidPayload = { ...payload };
+    delete invalidPayload.playthrough_id;
+
+    trackEvent(eventName, invalidPayload as never);
+
+    const counters = getAnalyticsDebugCounters();
+    expect(analyticsMock.track).not.toHaveBeenCalled();
+    expect(counters.blockReasons.invalid_payload).toBe(1);
+    expect(counters.byEvent[eventName].blocked).toBe(1);
   });
 
   it("blocks invalid payload shapes without logging payload values", () => {


### PR DESCRIPTION
## Summary
Add regression-focused analytics QA tests to lock event-contract behavior and checkpoint dedupe semantics.

## Motivation
INF-130 requires stronger QA coverage so telemetry contract regressions and dedupe drift fail fast in CI.

## Changes
- add table-driven contract tests in `trackEvent.test.ts` that verify every analytics event accepts valid payloads and rejects payloads missing required shared fields
- add storage-restore dedupe test in `playthroughEventData.test.ts` to verify previously tracked checkpoints are not re-emitted
- keep existing gating assertions intact while expanding coverage around schema-level failures

## Testing
- `pnpm test:run -- src/lib/analytics/__tests__/trackEvent.test.ts src/lib/analytics/__tests__/playthroughEventData.test.ts`
- `pnpm type-check`
- `pnpm exec biome lint src/lib/analytics/__tests__/trackEvent.test.ts src/lib/analytics/__tests__/playthroughEventData.test.ts`

## Linear
- INF-130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for checkpoint state recovery from persistent storage with deduplication validation
  * Added analytics contract-coverage tests to verify valid event payloads are transported correctly and invalid payloads are blocked

<!-- end of auto-generated comment: release notes by coderabbit.ai -->