### PR TITLE
INF-131: track import success/failure funnel

### DIFF
--- a/openspec/changes/inf-131-import-funnel-events/.openspec.yaml
+++ b/openspec/changes/inf-131-import-funnel-events/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/inf-131-import-funnel-events/design.md
+++ b/openspec/changes/inf-131-import-funnel-events/design.md
@@ -1,0 +1,31 @@
+## Context
+
+The import flow currently emits no dedicated events for success or failure. Existing UX toasts expose error text to users but telemetry lacks a contract for stage-level failure attribution.
+
+## Goals
+
+- Make import funnel outcomes observable through explicit success/failure events.
+- Standardize failure reporting with bounded fields so queries remain stable.
+- Keep instrumentation at canonical import operation boundaries, not scattered UI branches.
+
+## Non-Goals
+
+- Refactoring the entire import architecture.
+- Capturing raw error messages or PII in analytics payloads.
+- Introducing compatibility aliases for legacy event names.
+
+## Decisions
+
+1. Emit `playthrough_imported` exactly once per successful import completion.
+2. Emit `playthrough_import_failed` for each failed import attempt with normalized fields:
+   - `failure_stage`: one of `file_selection`, `file_read`, `json_parse`, `schema_validation`, `store_import`, `unknown`
+   - `error_category`: one of `unsupported_file_type`, `invalid_json`, `invalid_schema`, `duplicate_id`, `storage_failure`, `unexpected`
+3. Keep import source/context fields bounded (`import_source`, `has_file`, `file_extension_group`, `mime_group`) and avoid free-form strings.
+4. Reject payloads that include unbounded raw error values.
+
+## Validation Strategy
+
+- Add focused tests for import success event emission.
+- Add focused tests for failure-stage/category normalization across major failure branches.
+- Add schema-level tests ensuring invalid or unbounded failure payloads are blocked.
+- Run targeted lint, type-check, and focused analytics/import tests.

--- a/openspec/changes/inf-131-import-funnel-events/proposal.md
+++ b/openspec/changes/inf-131-import-funnel-events/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Import is a critical lifecycle entrypoint but current telemetry does not capture import success or failure outcomes. This blocks visibility into adoption, failure rates, and which failure stages create user friction.
+
+## What Changes
+
+- Add import funnel events: `playthrough_imported` and `playthrough_import_failed`.
+- Define normalized, bounded failure taxonomy fields for import failures.
+- Require import instrumentation ownership at canonical import domain flow to avoid UI-surface drift.
+
+## Capabilities
+
+### Modified Capabilities
+- `analytics-event-contract-v2`: Adds import funnel event requirements and normalized failure taxonomy fields.
+
+### New Capabilities
+- None.
+
+## Impact
+
+- Primary touched paths are import flow logic in `usePlaythroughImportExport` and/or canonical store import operations.
+- Enables reliable funnel analysis for success rate, failure stage distribution, and high-frequency error categories.
+- No persisted data migration required; telemetry contract expansion only.

--- a/openspec/changes/inf-131-import-funnel-events/specs/analytics-event-contract-v2/spec.md
+++ b/openspec/changes/inf-131-import-funnel-events/specs/analytics-event-contract-v2/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Import funnel outcomes are explicitly tracked
+The system MUST emit dedicated analytics events for import success and import failure outcomes.
+
+#### Scenario: Successful import emits canonical success event
+- **WHEN** a playthrough import completes and active playthrough state is updated successfully
+- **THEN** the system emits `playthrough_imported`
+- **AND** payload includes required shared event properties
+- **AND** payload includes bounded import context fields
+
+#### Scenario: Failed import emits canonical failure event
+- **WHEN** a playthrough import attempt fails at any supported stage
+- **THEN** the system emits `playthrough_import_failed`
+- **AND** payload includes required shared event properties where available
+- **AND** payload includes normalized `failure_stage` and `error_category` fields
+
+### Requirement: Import failure taxonomy uses bounded normalized fields
+The system MUST represent import failures with bounded enum-like values and MUST NOT include raw unbounded error text in analytics payloads.
+
+#### Scenario: Failure branch maps to normalized taxonomy values
+- **WHEN** import fails due to invalid JSON, unsupported type, schema mismatch, duplicate id, storage write failure, or unexpected exceptions
+- **THEN** emitted failure payload maps each branch to a bounded `failure_stage` and `error_category` value
+
+#### Scenario: Unbounded failure payload fields are rejected
+- **WHEN** instrumentation attempts to send failure payloads containing non-contract fields (for example raw exception messages)
+- **THEN** payload validation blocks the event and verification fails until payload contract is restored
+
+### Requirement: Canonical import operation owns emit responsibility
+The system MUST keep import telemetry emission in canonical import flow operations and not in view-specific branches.
+
+#### Scenario: Multiple UI entry surfaces remain semantically consistent
+- **WHEN** different UI surfaces trigger the same import operation
+- **THEN** emitted import success/failure semantics are identical for event identity and required fields

--- a/openspec/changes/inf-131-import-funnel-events/specs/analytics-event-contract-v2/spec.md
+++ b/openspec/changes/inf-131-import-funnel-events/specs/analytics-event-contract-v2/spec.md
@@ -12,7 +12,7 @@ The system MUST emit dedicated analytics events for import success and import fa
 #### Scenario: Failed import emits canonical failure event
 - **WHEN** a playthrough import attempt fails at any supported stage
 - **THEN** the system emits `playthrough_import_failed`
-- **AND** payload includes required shared event properties where available
+- **AND** payload includes required shared event properties
 - **AND** payload includes normalized `failure_stage` and `error_category` fields
 
 ### Requirement: Import failure taxonomy uses bounded normalized fields

--- a/openspec/changes/inf-131-import-funnel-events/tasks.md
+++ b/openspec/changes/inf-131-import-funnel-events/tasks.md
@@ -1,0 +1,17 @@
+## 1. Import funnel contract
+
+- [ ] 1.1 Extend telemetry v2 event contract with `playthrough_imported` and `playthrough_import_failed` definitions.
+- [ ] 1.2 Define bounded enums for `failure_stage` and `error_category`.
+- [ ] 1.3 Define bounded source/context fields for import payloads and prohibit raw error-message fields.
+
+## 2. Canonical instrumentation
+
+- [ ] 2.1 Instrument canonical import success path to emit `playthrough_imported` once per successful completion.
+- [ ] 2.2 Instrument canonical import failure branches to emit `playthrough_import_failed` with normalized taxonomy values.
+- [ ] 2.3 Ensure UI surfaces route through canonical instrumentation ownership (no divergent per-surface semantics).
+
+## 3. Verification
+
+- [ ] 3.1 Add tests that assert import success/failure events emit with required fields.
+- [ ] 3.2 Add tests that assert failure branches map to normalized `failure_stage` and `error_category` values.
+- [ ] 3.3 Run targeted validation for touched files (lint, type-check, and focused tests).

--- a/openspec/changes/inf-131-import-funnel-events/tasks.md
+++ b/openspec/changes/inf-131-import-funnel-events/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Import funnel contract
 
-- [ ] 1.1 Extend telemetry v2 event contract with `playthrough_imported` and `playthrough_import_failed` definitions.
-- [ ] 1.2 Define bounded enums for `failure_stage` and `error_category`.
-- [ ] 1.3 Define bounded source/context fields for import payloads and prohibit raw error-message fields.
+- [x] 1.1 Extend telemetry v2 event contract with `playthrough_imported` and `playthrough_import_failed` definitions.
+- [x] 1.2 Define bounded enums for `failure_stage` and `error_category`.
+- [x] 1.3 Define bounded source/context fields for import payloads and prohibit raw error-message fields.
 
 ## 2. Canonical instrumentation
 
-- [ ] 2.1 Instrument canonical import success path to emit `playthrough_imported` once per successful completion.
-- [ ] 2.2 Instrument canonical import failure branches to emit `playthrough_import_failed` with normalized taxonomy values.
-- [ ] 2.3 Ensure UI surfaces route through canonical instrumentation ownership (no divergent per-surface semantics).
+- [x] 2.1 Instrument canonical import success path to emit `playthrough_imported` once per successful completion.
+- [x] 2.2 Instrument canonical import failure branches to emit `playthrough_import_failed` with normalized taxonomy values.
+- [x] 2.3 Ensure UI surfaces route through canonical instrumentation ownership (no divergent per-surface semantics).
 
 ## 3. Verification
 
-- [ ] 3.1 Add tests that assert import success/failure events emit with required fields.
-- [ ] 3.2 Add tests that assert failure branches map to normalized `failure_stage` and `error_category` values.
-- [ ] 3.3 Run targeted validation for touched files (lint, type-check, and focused tests).
+- [x] 3.1 Add tests that assert import success/failure events emit with required fields.
+- [x] 3.2 Add tests that assert failure branches map to normalized `failure_stage` and `error_category` values.
+- [x] 3.3 Run targeted validation for touched files (lint, type-check, and focused tests).

--- a/src/hooks/usePlaythroughImportExport.ts
+++ b/src/hooks/usePlaythroughImportExport.ts
@@ -1,12 +1,155 @@
 import { useCallback, useState } from "react";
 import { getSharedEventProperties } from "@/lib/analytics/selectors";
-import { trackEvent } from "@/lib/analytics/trackEvent";
+import {
+  type FileExtensionGroup,
+  type ImportErrorCategory,
+  type ImportFailureStage,
+  type MimeGroup,
+  trackEvent,
+} from "@/lib/analytics/trackEvent";
 import {
   type ExportedPlaythrough,
   type GameMode,
   type Playthrough,
   playthroughActions,
 } from "@/stores/playthroughs";
+
+const IMPORT_SOURCE = "file_picker" as const;
+
+type ImportFileContext = {
+  hasFile: boolean;
+  fileExtensionGroup: FileExtensionGroup;
+  mimeGroup: MimeGroup;
+};
+
+const getFileExtensionGroup = (fileName?: string): FileExtensionGroup => {
+  if (!fileName) {
+    return "other";
+  }
+
+  return fileName.toLowerCase().endsWith(".json") ? "json" : "other";
+};
+
+const getMimeGroup = (mimeType?: string): MimeGroup => {
+  if (!mimeType) {
+    return "empty";
+  }
+
+  if (mimeType === "application/json") {
+    return "application_json";
+  }
+
+  if (mimeType === "text/plain") {
+    return "text_plain";
+  }
+
+  return "other";
+};
+
+const createFileContext = (file?: File): ImportFileContext => {
+  if (!file) {
+    return {
+      hasFile: false,
+      fileExtensionGroup: "other",
+      mimeGroup: "empty",
+    };
+  }
+
+  return {
+    hasFile: true,
+    fileExtensionGroup: getFileExtensionGroup(file.name),
+    mimeGroup: getMimeGroup(file.type),
+  };
+};
+
+const isStorageFailureMessage = (message: string) => {
+  const normalizedMessage = message.toLowerCase();
+
+  return (
+    normalizedMessage.includes("quota") ||
+    normalizedMessage.includes("storage") ||
+    normalizedMessage.includes("indexeddb")
+  );
+};
+
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+
+  return fallback;
+};
+
+const resolvePlaythroughForImportAnalytics = async (playthroughId?: string) => {
+  if (
+    playthroughId &&
+    typeof playthroughActions.getAllPlaythroughs === "function"
+  ) {
+    const importedPlaythroughs = await playthroughActions.getAllPlaythroughs();
+    const importedPlaythrough = importedPlaythroughs.find(
+      (playthrough) => playthrough.id === playthroughId,
+    );
+
+    if (importedPlaythrough) {
+      return importedPlaythrough;
+    }
+  }
+
+  if (typeof playthroughActions.getActivePlaythrough === "function") {
+    return playthroughActions.getActivePlaythrough();
+  }
+
+  return null;
+};
+
+const trackImportFailure = async ({
+  failureStage,
+  errorCategory,
+  fileContext,
+  playthroughId,
+}: {
+  failureStage: ImportFailureStage;
+  errorCategory: ImportErrorCategory;
+  fileContext: ImportFileContext;
+  playthroughId?: string;
+}) => {
+  const analyticsPlaythrough =
+    await resolvePlaythroughForImportAnalytics(playthroughId);
+  if (!analyticsPlaythrough) {
+    return;
+  }
+
+  trackEvent("playthrough_import_failed", {
+    ...getSharedEventProperties(analyticsPlaythrough),
+    import_source: IMPORT_SOURCE,
+    failure_stage: failureStage,
+    error_category: errorCategory,
+    has_file: fileContext.hasFile,
+    file_extension_group: fileContext.fileExtensionGroup,
+    mime_group: fileContext.mimeGroup,
+  });
+};
+
+const trackImportSuccess = async ({
+  playthroughId,
+  fileContext,
+}: {
+  playthroughId: string;
+  fileContext: ImportFileContext;
+}) => {
+  const analyticsPlaythrough =
+    await resolvePlaythroughForImportAnalytics(playthroughId);
+  if (!analyticsPlaythrough) {
+    return;
+  }
+
+  trackEvent("playthrough_imported", {
+    ...getSharedEventProperties(analyticsPlaythrough),
+    import_source: IMPORT_SOURCE,
+    file_extension_group: fileContext.fileExtensionGroup,
+    mime_group: fileContext.mimeGroup,
+  });
+};
 
 // Helper function to export playthrough data as JSON
 const exportPlaythrough = (playthrough: Playthrough) => {
@@ -86,9 +229,13 @@ export function usePlaythroughImportExport() {
       input.accept = ".json,application/json,text/plain";
 
       input.onchange = async (e) => {
+        let importFailureStage: ImportFailureStage = "unknown";
+        let importErrorCategory: ImportErrorCategory = "unexpected";
+
         try {
           const target = e.target as HTMLInputElement;
           const file = target.files?.[0];
+          const fileContext = createFileContext(file);
 
           if (!file) {
             input.remove();
@@ -97,6 +244,14 @@ export function usePlaythroughImportExport() {
 
           // Check file extension
           if (!file.name.toLowerCase().endsWith(".json")) {
+            importFailureStage = "file_selection";
+            importErrorCategory = "unsupported_file_type";
+            await trackImportFailure({
+              failureStage: importFailureStage,
+              errorCategory: importErrorCategory,
+              fileContext,
+            });
+
             setImportErrorMessage("File must have a .json extension");
             setShowImportError(true);
             input.remove();
@@ -109,19 +264,36 @@ export function usePlaythroughImportExport() {
             file.type !== "application/json" &&
             file.type !== "text/plain"
           ) {
+            importFailureStage = "file_selection";
+            importErrorCategory = "unsupported_file_type";
+            await trackImportFailure({
+              failureStage: importFailureStage,
+              errorCategory: importErrorCategory,
+              fileContext,
+            });
+
             setImportErrorMessage("File is not a valid JSON file");
             setShowImportError(true);
             input.remove();
             return;
           }
 
+          importFailureStage = "file_read";
           const text = await file.text();
 
           // Try to parse as JSON first to catch JSON syntax errors
+          importFailureStage = "json_parse";
           let data: unknown;
           try {
             data = JSON.parse(text);
           } catch {
+            importErrorCategory = "invalid_json";
+            await trackImportFailure({
+              failureStage: importFailureStage,
+              errorCategory: importErrorCategory,
+              fileContext,
+            });
+
             setImportErrorMessage("Invalid JSON syntax");
             setShowImportError(true);
             input.remove();
@@ -129,19 +301,46 @@ export function usePlaythroughImportExport() {
           }
 
           // Import the playthrough
+          importFailureStage = "store_import";
           const newId = await playthroughActions.importPlaythrough(data);
-          console.log("Successfully imported playthrough:", newId);
+          await trackImportSuccess({
+            playthroughId: newId,
+            fileContext,
+          });
 
           // Clean up
           input.remove();
         } catch (error) {
           console.error("Failed to import playthrough:", error);
 
+          const file = (e.target as HTMLInputElement).files?.[0];
+          const fileContext = createFileContext(file);
+
           let errorMessage = "Import failed";
 
           if (error instanceof Error) {
             errorMessage = error.message;
+
+            if (importFailureStage === "store_import") {
+              if (error.message.startsWith("Validation failed:")) {
+                importFailureStage = "schema_validation";
+                importErrorCategory = "invalid_schema";
+              } else if (isStorageFailureMessage(error.message)) {
+                importErrorCategory = "storage_failure";
+              }
+            } else if (
+              importFailureStage === "file_read" &&
+              isStorageFailureMessage(error.message)
+            ) {
+              importErrorCategory = "storage_failure";
+            }
           }
+
+          await trackImportFailure({
+            failureStage: importFailureStage,
+            errorCategory: importErrorCategory,
+            fileContext,
+          });
 
           setImportErrorMessage(errorMessage);
           setShowImportError(true);
@@ -152,7 +351,15 @@ export function usePlaythroughImportExport() {
       input.click();
     } catch (error) {
       console.error("Import failed:", error);
-      setImportErrorMessage("Import failed. Please try again.");
+      await trackImportFailure({
+        failureStage: "unknown",
+        errorCategory: "unexpected",
+        fileContext: createFileContext(),
+      });
+
+      setImportErrorMessage(
+        getErrorMessage(error, "Import failed. Please try again."),
+      );
       setShowImportError(true);
     }
   }, []);

--- a/src/lib/analytics/__tests__/trackEvent.test.ts
+++ b/src/lib/analytics/__tests__/trackEvent.test.ts
@@ -235,6 +235,66 @@ describe("analytics transport wrapper", () => {
     expect(getAnalyticsDebugCounters().sent).toBe(1);
   });
 
+  it("tracks normalized import failure payloads", () => {
+    localStorage.setItem(
+      "cookie-preferences",
+      JSON.stringify({ analytics: true }),
+    );
+    setEnvironment("production", "production");
+
+    trackEvent(ANALYTICS_EVENTS.playthroughImportFailed, {
+      playthrough_id: "pt-1",
+      game_mode: "classic",
+      encounter_count_bucket: "e_1",
+      deceased_count_bucket: "c_0",
+      boxed_count_bucket: "c_0",
+      fusion_count_bucket: "c_0",
+      viable_roster_bucket: "v_6_plus",
+      import_source: "file_picker",
+      failure_stage: "json_parse",
+      error_category: "invalid_json",
+      has_file: true,
+      file_extension_group: "json",
+      mime_group: "application_json",
+    });
+
+    expect(analyticsMock.track).toHaveBeenCalledWith(
+      "playthrough_import_failed",
+      expect.objectContaining({
+        failure_stage: "json_parse",
+        error_category: "invalid_json",
+      }),
+    );
+  });
+
+  it("rejects import failure payloads with raw error text fields", () => {
+    localStorage.setItem(
+      "cookie-preferences",
+      JSON.stringify({ analytics: true }),
+    );
+    setEnvironment("production", "production");
+
+    trackEvent(ANALYTICS_EVENTS.playthroughImportFailed, {
+      playthrough_id: "pt-1",
+      game_mode: "classic",
+      encounter_count_bucket: "e_1",
+      deceased_count_bucket: "c_0",
+      boxed_count_bucket: "c_0",
+      fusion_count_bucket: "c_0",
+      viable_roster_bucket: "v_6_plus",
+      import_source: "file_picker",
+      failure_stage: "store_import",
+      error_category: "unexpected",
+      has_file: true,
+      file_extension_group: "json",
+      mime_group: "application_json",
+      raw_error_message: "schema exploded",
+    } as never);
+
+    expect(analyticsMock.track).not.toHaveBeenCalled();
+    expect(getAnalyticsDebugCounters().blockReasons.invalid_payload).toBe(1);
+  });
+
   it("blocks invalid payload shapes without logging payload values", () => {
     localStorage.setItem(
       "cookie-preferences",

--- a/src/lib/analytics/trackEvent.ts
+++ b/src/lib/analytics/trackEvent.ts
@@ -7,6 +7,8 @@ export type AnalyticsProperties = Record<string, AnalyticsPrimitive>;
 
 export const ANALYTICS_EVENTS = {
   playthroughCreated: "playthrough_created",
+  playthroughImported: "playthrough_imported",
+  playthroughImportFailed: "playthrough_import_failed",
   runCheckpointReached: "run_checkpoint_reached",
   playthroughResumed: "playthrough_resumed",
   fusionCreated: "fusion_created",
@@ -67,9 +69,40 @@ export type CheckpointLabel =
   | "cp_40"
   | "cp_80";
 
+export type ImportSource = "file_picker";
+export type FileExtensionGroup = "json" | "other";
+export type MimeGroup = "application_json" | "text_plain" | "empty" | "other";
+export type ImportFailureStage =
+  | "file_selection"
+  | "file_read"
+  | "json_parse"
+  | "schema_validation"
+  | "store_import"
+  | "unknown";
+export type ImportErrorCategory =
+  | "unsupported_file_type"
+  | "invalid_json"
+  | "invalid_schema"
+  | "duplicate_id"
+  | "storage_failure"
+  | "unexpected";
+
 export type AnalyticsEventMap = {
   playthrough_created: SharedEventProperties & {
     has_existing_playthroughs: boolean;
+  };
+  playthrough_imported: SharedEventProperties & {
+    import_source: ImportSource;
+    file_extension_group: FileExtensionGroup;
+    mime_group: MimeGroup;
+  };
+  playthrough_import_failed: SharedEventProperties & {
+    import_source: ImportSource;
+    failure_stage: ImportFailureStage;
+    error_category: ImportErrorCategory;
+    has_file: boolean;
+    file_extension_group: FileExtensionGroup;
+    mime_group: MimeGroup;
   };
   run_checkpoint_reached: SharedEventProperties & {
     checkpoint: Checkpoint;
@@ -163,6 +196,37 @@ const analyticsEventSchemaMap = {
   playthrough_created: sharedEventPropertiesSchema
     .extend({
       has_existing_playthroughs: z.boolean(),
+    })
+    .strict(),
+  playthrough_imported: sharedEventPropertiesSchema
+    .extend({
+      import_source: z.literal("file_picker"),
+      file_extension_group: z.enum(["json", "other"]),
+      mime_group: z.enum(["application_json", "text_plain", "empty", "other"]),
+    })
+    .strict(),
+  playthrough_import_failed: sharedEventPropertiesSchema
+    .extend({
+      import_source: z.literal("file_picker"),
+      failure_stage: z.enum([
+        "file_selection",
+        "file_read",
+        "json_parse",
+        "schema_validation",
+        "store_import",
+        "unknown",
+      ]),
+      error_category: z.enum([
+        "unsupported_file_type",
+        "invalid_json",
+        "invalid_schema",
+        "duplicate_id",
+        "storage_failure",
+        "unexpected",
+      ]),
+      has_file: z.boolean(),
+      file_extension_group: z.enum(["json", "other"]),
+      mime_group: z.enum(["application_json", "text_plain", "empty", "other"]),
     })
     .strict(),
   run_checkpoint_reached: sharedEventPropertiesSchema
@@ -260,6 +324,8 @@ const ANALYTICS_PRODUCTION_HOSTNAMES = new Set([
 const createByEventCounter = (): Record<AnalyticsEventName, EventCounter> => {
   return {
     playthrough_created: { sent: 0, blocked: 0 },
+    playthrough_imported: { sent: 0, blocked: 0 },
+    playthrough_import_failed: { sent: 0, blocked: 0 },
     run_checkpoint_reached: { sent: 0, blocked: 0 },
     playthrough_resumed: { sent: 0, blocked: 0 },
     fusion_created: { sent: 0, blocked: 0 },

--- a/src/stores/playthroughs/__tests__/playthrough-export-analytics.test.ts
+++ b/src/stores/playthroughs/__tests__/playthrough-export-analytics.test.ts
@@ -8,10 +8,14 @@ const analyticsMocks = vi.hoisted(() => ({
   trackEvent: vi.fn(),
 }));
 
+const playthroughActionMocks = vi.hoisted(() => ({
+  importPlaythrough: vi.fn(),
+  getActivePlaythrough: vi.fn(),
+  getAllPlaythroughs: vi.fn(),
+}));
+
 vi.mock("@/stores/playthroughs", () => ({
-  playthroughActions: {
-    importPlaythrough: vi.fn(),
-  },
+  playthroughActions: playthroughActionMocks,
 }));
 
 vi.mock("@/lib/analytics/selectors", () => ({
@@ -44,10 +48,64 @@ const createPlaythrough = (): Playthrough => ({
 });
 
 describe("usePlaythroughImportExport lifecycle analytics", () => {
+  const basePlaythrough = createPlaythrough();
+
+  const originalCreateElement = document.createElement.bind(document);
+
+  const mockInputCreation = () => {
+    const input = {
+      type: "",
+      accept: "",
+      onchange: null,
+      click: vi.fn(),
+      remove: vi.fn(),
+      files: null,
+    } as unknown as HTMLInputElement;
+
+    const createElementSpy = vi
+      .spyOn(document, "createElement")
+      .mockImplementation(((
+        tagName: string,
+        options?: ElementCreationOptions,
+      ) => {
+        if (tagName === "input") {
+          return input as unknown as HTMLElement;
+        }
+
+        return originalCreateElement(tagName, options);
+      }) as typeof document.createElement);
+
+    return { input, createElementSpy };
+  };
+
+  const triggerInputChange = async (input: HTMLInputElement, file: File) => {
+    await act(async () => {
+      if (!input.onchange) {
+        throw new Error("Expected input onchange handler to be set");
+      }
+
+      await input.onchange({
+        target: {
+          files: [file],
+        },
+      } as unknown as Event);
+    });
+  };
+
   beforeEach(() => {
     analyticsMocks.trackEvent.mockReset();
     analyticsMocks.getSharedEventProperties.mockReset();
     analyticsMocks.getSharedEventProperties.mockReturnValue(sharedProperties);
+    playthroughActionMocks.importPlaythrough.mockReset();
+    playthroughActionMocks.getActivePlaythrough.mockReset();
+    playthroughActionMocks.getAllPlaythroughs.mockReset();
+
+    playthroughActionMocks.getActivePlaythrough.mockReturnValue(
+      basePlaythrough,
+    );
+    playthroughActionMocks.getAllPlaythroughs.mockReturnValue([
+      basePlaythrough,
+    ]);
   });
 
   it("tracks playthrough_exported after successful export", () => {
@@ -112,5 +170,151 @@ describe("usePlaythroughImportExport lifecycle analytics", () => {
 
     errorSpy.mockRestore();
     createObjectUrlSpy.mockRestore();
+  });
+
+  it("tracks playthrough_imported after successful import", async () => {
+    const { input, createElementSpy } = mockInputCreation();
+    const importedPlaythrough = {
+      ...basePlaythrough,
+      id: "imported-playthrough",
+    };
+    const importFile = {
+      name: "save.json",
+      type: "application/json",
+      text: vi.fn().mockResolvedValue('{"playthrough":{}}'),
+    } as unknown as File;
+
+    playthroughActionMocks.importPlaythrough.mockResolvedValue(
+      importedPlaythrough.id,
+    );
+    playthroughActionMocks.getAllPlaythroughs.mockReturnValue([
+      basePlaythrough,
+      importedPlaythrough,
+    ]);
+
+    const { result } = renderHook(() => usePlaythroughImportExport());
+
+    await act(async () => {
+      await result.current.handleImportClick();
+    });
+
+    await triggerInputChange(input, importFile);
+
+    expect(playthroughActionMocks.importPlaythrough).toHaveBeenCalledWith({
+      playthrough: {},
+    });
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith(
+      "playthrough_imported",
+      {
+        ...sharedProperties,
+        import_source: "file_picker",
+        file_extension_group: "json",
+        mime_group: "application_json",
+      },
+    );
+
+    createElementSpy.mockRestore();
+  });
+
+  it("tracks file-selection failures with normalized taxonomy", async () => {
+    const { input, createElementSpy } = mockInputCreation();
+    const invalidFile = {
+      name: "save.txt",
+      type: "text/plain",
+      text: vi.fn().mockResolvedValue("not-used"),
+    } as unknown as File;
+
+    const { result } = renderHook(() => usePlaythroughImportExport());
+
+    await act(async () => {
+      await result.current.handleImportClick();
+    });
+
+    await triggerInputChange(input, invalidFile);
+
+    expect(playthroughActionMocks.importPlaythrough).not.toHaveBeenCalled();
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith(
+      "playthrough_import_failed",
+      {
+        ...sharedProperties,
+        import_source: "file_picker",
+        failure_stage: "file_selection",
+        error_category: "unsupported_file_type",
+        has_file: true,
+        file_extension_group: "other",
+        mime_group: "text_plain",
+      },
+    );
+
+    createElementSpy.mockRestore();
+  });
+
+  it("tracks json parse failures with normalized taxonomy", async () => {
+    const { input, createElementSpy } = mockInputCreation();
+    const malformedJsonFile = {
+      name: "save.json",
+      type: "application/json",
+      text: vi.fn().mockResolvedValue("{oops"),
+    } as unknown as File;
+
+    const { result } = renderHook(() => usePlaythroughImportExport());
+
+    await act(async () => {
+      await result.current.handleImportClick();
+    });
+
+    await triggerInputChange(input, malformedJsonFile);
+
+    expect(playthroughActionMocks.importPlaythrough).not.toHaveBeenCalled();
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith(
+      "playthrough_import_failed",
+      {
+        ...sharedProperties,
+        import_source: "file_picker",
+        failure_stage: "json_parse",
+        error_category: "invalid_json",
+        has_file: true,
+        file_extension_group: "json",
+        mime_group: "application_json",
+      },
+    );
+
+    createElementSpy.mockRestore();
+  });
+
+  it("tracks schema-validation failures with normalized taxonomy", async () => {
+    const { input, createElementSpy } = mockInputCreation();
+    const validJsonFile = {
+      name: "save.json",
+      type: "application/json",
+      text: vi.fn().mockResolvedValue('{"playthrough":{}}'),
+    } as unknown as File;
+
+    playthroughActionMocks.importPlaythrough.mockRejectedValue(
+      new Error("Validation failed:\n\n- invalid schema"),
+    );
+
+    const { result } = renderHook(() => usePlaythroughImportExport());
+
+    await act(async () => {
+      await result.current.handleImportClick();
+    });
+
+    await triggerInputChange(input, validJsonFile);
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith(
+      "playthrough_import_failed",
+      {
+        ...sharedProperties,
+        import_source: "file_picker",
+        failure_stage: "schema_validation",
+        error_category: "invalid_schema",
+        has_file: true,
+        file_extension_group: "json",
+        mime_group: "application_json",
+      },
+    );
+
+    createElementSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- add telemetry contract support for `playthrough_imported` and `playthrough_import_failed` with bounded import context, stage, and category fields
- instrument the canonical import flow in `usePlaythroughImportExport` to emit normalized success/failure events across file selection, parse, and store-validation branches
- add analytics and hook tests that verify required payload fields, normalized taxonomy mapping, and strict rejection of unbounded failure payload fields

## Validation
- `pnpm exec biome lint src/hooks/usePlaythroughImportExport.ts src/lib/analytics/trackEvent.ts src/lib/analytics/__tests__/trackEvent.test.ts src/stores/playthroughs/__tests__/playthrough-export-analytics.test.ts`
- `pnpm type-check`
- `pnpm test:run -- src/lib/analytics/__tests__/trackEvent.test.ts src/stores/playthroughs/__tests__/playthrough-export-analytics.test.ts tests/playthroughs/import-export.test.ts`
- `openspec status --change \"inf-131-import-funnel-events\" --json`
- `openspec validate \"inf-131-import-funnel-events\"`

## Linear
- INF-131
- https://linear.app/infinite-fusion-nuzlocke/issue/INF-131/track-import-successfailure-funnel