### PR TITLE
Track early funnel analytics events

### DIFF
--- a/docs/analytics/event-spec.md
+++ b/docs/analytics/event-spec.md
@@ -16,7 +16,7 @@ This document is the source of truth for analytics taxonomy, trigger points, pay
 | `landing_viewed` | Client runtime observer mounted from `src/app/layout.tsx` | Active playthrough is available after store load, once per playthrough per tab session | Store is still loading, no active playthrough, or same session already emitted |
 | `playthrough_selector_opened` | `PlaythroughSelector` header control | User opens the playthrough selector popover | Store is still loading or no active playthrough is available |
 | `create_playthrough_modal_opened` | Create action inside `PlaythroughSelector` | User opens the create playthrough modal | No active playthrough is available |
-| `first_encounter_saved` | Encounter mutation paths in `src/stores/playthroughs/encounters/crud.ts` | Encounter count changes from zero to at least one | Encounter count was already non-zero or mutation removes data |
+| `first_encounter_saved` | Encounter mutation paths in `src/stores/playthroughs/encounters/crud.ts` and `src/stores/playthroughs/encounters/fusion.ts` | Encounter count changes from zero to at least one | Encounter count was already non-zero or mutation removes data |
 | `playthrough_created` | `createPlaythrough` in `src/stores/playthroughs/store.ts` | A new playthrough is successfully appended to store state | Creation short-circuits or throws before append |
 | `run_checkpoint_reached` | Encounter mutation paths in `src/stores/playthroughs/encounters/*.ts` | Encounter count crosses any configured checkpoint threshold | Encounter count changes without crossing a new threshold |
 | `playthrough_resumed` | Client runtime observer mounted from `src/app/layout.tsx` | Active playthrough is available after store load and qualifies as a resume | Store is still loading, no active playthrough, or same session already emitted |
@@ -167,6 +167,6 @@ No additional properties beyond the shared schema.
 
 ## Implementation notes
 
-- Trigger detection belongs at action/mutation boundaries, not in presentational components.
+- Trigger detection belongs at action/mutation boundaries for mutation-backed events (for example `first_encounter_saved`), while pure UI-intent events such as `playthrough_selector_opened` and `create_playthrough_modal_opened` may emit from their presentational component.
 - Event payload builders should read canonical store state after mutation when the event requires after-state fields.
 - Any contract change in event names, property names, bucket labels, or thresholds must update this document first.

--- a/docs/analytics/event-spec.md
+++ b/docs/analytics/event-spec.md
@@ -13,6 +13,10 @@ This document is the source of truth for analytics taxonomy, trigger points, pay
 
 | Event | Trigger point | Emits when | Does not emit when |
 | --- | --- | --- | --- |
+| `landing_viewed` | Client runtime observer mounted from `src/app/layout.tsx` | Active playthrough is available after store load, once per playthrough per tab session | Store is still loading, no active playthrough, or same session already emitted |
+| `playthrough_selector_opened` | `PlaythroughSelector` header control | User opens the playthrough selector popover | Store is still loading or no active playthrough is available |
+| `create_playthrough_modal_opened` | Create action inside `PlaythroughSelector` | User opens the create playthrough modal | No active playthrough is available |
+| `first_encounter_saved` | Encounter mutation paths in `src/stores/playthroughs/encounters/crud.ts` | Encounter count changes from zero to at least one | Encounter count was already non-zero or mutation removes data |
 | `playthrough_created` | `createPlaythrough` in `src/stores/playthroughs/store.ts` | A new playthrough is successfully appended to store state | Creation short-circuits or throws before append |
 | `run_checkpoint_reached` | Encounter mutation paths in `src/stores/playthroughs/encounters/*.ts` | Encounter count crosses any configured checkpoint threshold | Encounter count changes without crossing a new threshold |
 | `playthrough_resumed` | Client runtime observer mounted from `src/app/layout.tsx` | Active playthrough is available after store load and qualifies as a resume | Store is still loading, no active playthrough, or same session already emitted |
@@ -36,6 +40,30 @@ Every event includes these shared properties unless noted otherwise.
 | `viable_roster_bucket` | `ViableRosterBucket` | Bucketed viable roster size at emit time |
 
 ## Event-specific properties
+
+### `landing_viewed`
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `entry_route` | `"home" \| "locations" \| "other"` | Low-cardinality route bucket at emit time |
+
+### `playthrough_selector_opened`
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `source_surface` | `"header"` | UI surface that opened the selector |
+
+### `create_playthrough_modal_opened`
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `source_surface` | `"header"` | UI surface that opened the modal |
+
+### `first_encounter_saved`
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `location_id` | `string` | Encounter location identifier |
 
 ### `playthrough_created`
 
@@ -125,6 +153,10 @@ No additional properties beyond the shared schema.
 
 | Event | Dedupe strategy |
 | --- | --- |
+| `landing_viewed` | Session dedupe per playthrough using session storage (once per tab session) |
+| `playthrough_selector_opened` | No storage dedupe required; emit each successful open intent |
+| `create_playthrough_modal_opened` | No storage dedupe required; emit each successful modal open intent |
+| `first_encounter_saved` | Transition dedupe only; emit when encounter count crosses from zero to one or more |
 | `playthrough_created` | No storage dedupe required; emit once per successful `createPlaythrough` call |
 | `run_checkpoint_reached` | Monotonic threshold dedupe per playthrough using persistent local storage keyed by playthrough id |
 | `playthrough_resumed` | Session dedupe per playthrough using session storage (once per tab session) |

--- a/src/components/playthrough/PlaythroughSelector.tsx
+++ b/src/components/playthrough/PlaythroughSelector.tsx
@@ -16,6 +16,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
 import { CursorTooltip } from "@/components/CursorTooltip";
 import { usePlaythroughImportExport } from "@/hooks/usePlaythroughImportExport";
+import { getSharedEventProperties } from "@/lib/analytics/playthroughEventData";
+import { trackEvent } from "@/lib/analytics/trackEvent";
 import {
   type GameMode,
   type Playthrough,
@@ -122,6 +124,31 @@ export default function PlaythroughSelector({
     setPlaythroughToDelete(null);
   };
 
+  const trackSelectorOpened = useCallback(() => {
+    if (!activePlaythrough) {
+      return;
+    }
+
+    trackEvent("playthrough_selector_opened", {
+      ...getSharedEventProperties(activePlaythrough),
+      source_surface: "header",
+    });
+  }, [activePlaythrough]);
+
+  const handleCreateClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      if (activePlaythrough) {
+        trackEvent("create_playthrough_modal_opened", {
+          ...getSharedEventProperties(activePlaythrough),
+          source_surface: "header",
+        });
+      }
+      setShowCreateInput(true);
+    },
+    [activePlaythrough],
+  );
+
   // Handle arrow key navigation using refs
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent, currentIndex: number) => {
@@ -176,6 +203,11 @@ export default function PlaythroughSelector({
                   "h-[40px] sm:h-[44px]",
                 )}
                 disabled={isLoading}
+                onClick={() => {
+                  if (!open) {
+                    trackSelectorOpened();
+                  }
+                }}
               >
                 <div className="flex items-center gap-3 min-w-0 flex-1 overflow-hidden">
                   <div className="flex items-center justify-center size-6 rounded-lg bg-gradient-to-br ">
@@ -437,10 +469,7 @@ export default function PlaythroughSelector({
                 >
                   <div className="relative">
                     <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        setShowCreateInput(true);
-                      }}
+                      onClick={handleCreateClick}
                       className={clsx(
                         "group flex w-full items-center gap-3 px-4 py-3.5 text-sm",
                         "text-gray-700 dark:text-gray-300 transition-all duration-200",

--- a/src/components/playthrough/__tests__/PlaythroughSelector.test.tsx
+++ b/src/components/playthrough/__tests__/PlaythroughSelector.test.tsx
@@ -11,8 +11,9 @@ import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import PlaythroughSelector from "../PlaythroughSelector";
 
-const { setActivePlaythroughMock } = vi.hoisted(() => ({
+const { setActivePlaythroughMock, trackEventMock } = vi.hoisted(() => ({
   setActivePlaythroughMock: vi.fn().mockResolvedValue(undefined),
+  trackEventMock: vi.fn(),
 }));
 
 const playthroughs = [
@@ -43,7 +44,7 @@ type PopoverChildren =
 vi.mock("@headlessui/react", () => ({
   Popover: ({ children }: { children: PopoverChildren }) => {
     if (typeof children === "function") {
-      return <div>{children({ open: true })}</div>;
+      return <div>{children({ open: false })}</div>;
     }
 
     return <div>{children}</div>;
@@ -78,6 +79,22 @@ vi.mock("@/hooks/usePlaythroughImportExport", () => ({
   }),
 }));
 
+vi.mock("@/lib/analytics/playthroughEventData", () => ({
+  getSharedEventProperties: () => ({
+    playthrough_id: "older",
+    game_mode: "classic",
+    encounter_count_bucket: "e_0",
+    deceased_count_bucket: "c_0",
+    boxed_count_bucket: "c_0",
+    fusion_count_bucket: "c_0",
+    viable_roster_bucket: "v_0",
+  }),
+}));
+
+vi.mock("@/lib/analytics/trackEvent", () => ({
+  trackEvent: trackEventMock,
+}));
+
 vi.mock("../CreatePlaythroughModal", () => ({
   default: () => null,
 }));
@@ -105,6 +122,29 @@ describe("PlaythroughSelector", () => {
 
   beforeEach(() => {
     setActivePlaythroughMock.mockClear();
+    trackEventMock.mockClear();
+  });
+
+  it("tracks when the playthrough selector opens", () => {
+    render(<PlaythroughSelector />);
+
+    fireEvent.click(screen.getAllByText("Older Run")[0]!.closest("button")!);
+
+    expect(trackEventMock).toHaveBeenCalledWith(
+      "playthrough_selector_opened",
+      expect.objectContaining({ source_surface: "header" }),
+    );
+  });
+
+  it("tracks when the create playthrough modal opens", () => {
+    render(<PlaythroughSelector />);
+
+    fireEvent.click(screen.getByRole("button", { name: /create new/i }));
+
+    expect(trackEventMock).toHaveBeenCalledWith(
+      "create_playthrough_modal_opened",
+      expect.objectContaining({ source_surface: "header" }),
+    );
   });
 
   it("supports arrow/home/end keyboard navigation between playthrough rows", () => {

--- a/src/components/playthrough/__tests__/PlaythroughSelector.test.tsx
+++ b/src/components/playthrough/__tests__/PlaythroughSelector.test.tsx
@@ -128,7 +128,7 @@ describe("PlaythroughSelector", () => {
   it("tracks when the playthrough selector opens", () => {
     render(<PlaythroughSelector />);
 
-    fireEvent.click(screen.getAllByText("Older Run")[0]!.closest("button")!);
+    fireEvent.click(screen.getByRole("button", { name: /^older run$/i }));
 
     expect(trackEventMock).toHaveBeenCalledWith(
       "playthrough_selector_opened",

--- a/src/lib/analytics/__tests__/trackEvent.test.ts
+++ b/src/lib/analytics/__tests__/trackEvent.test.ts
@@ -25,6 +25,22 @@ const VALID_EVENT_PAYLOADS: Record<
   AnalyticsEventName,
   Record<string, AnalyticsPrimitive>
 > = {
+  landing_viewed: {
+    ...BASE_SHARED_PROPERTIES,
+    entry_route: "home",
+  },
+  playthrough_selector_opened: {
+    ...BASE_SHARED_PROPERTIES,
+    source_surface: "header",
+  },
+  create_playthrough_modal_opened: {
+    ...BASE_SHARED_PROPERTIES,
+    source_surface: "header",
+  },
+  first_encounter_saved: {
+    ...BASE_SHARED_PROPERTIES,
+    location_id: "route-1",
+  },
   playthrough_created: {
     ...BASE_SHARED_PROPERTIES,
     has_existing_playthroughs: false,

--- a/src/lib/analytics/playthroughEventData.ts
+++ b/src/lib/analytics/playthroughEventData.ts
@@ -2,6 +2,7 @@ import type { Checkpoint } from "./trackEvent";
 
 const CHECKPOINTS: readonly Checkpoint[] = [1, 5, 10, 20, 40, 80];
 const CHECKPOINT_STORAGE_KEY_PREFIX = "analytics:checkpoints:";
+const LANDING_STORAGE_KEY_PREFIX = "analytics:landing-viewed:";
 const RESUME_STORAGE_KEY_PREFIX = "analytics:playthrough-resumed:";
 
 type StorageValue = Storage | null | undefined;
@@ -39,6 +40,10 @@ export const getCheckpointStorageKey = (playthroughId: string): string => {
 
 export const getResumeStorageKey = (playthroughId: string): string => {
   return `${RESUME_STORAGE_KEY_PREFIX}${playthroughId}`;
+};
+
+export const getLandingStorageKey = (playthroughId: string): string => {
+  return `${LANDING_STORAGE_KEY_PREFIX}${playthroughId}`;
 };
 
 const parseStoredCheckpoints = (value: string | null): Set<Checkpoint> => {
@@ -156,6 +161,17 @@ export const shouldTrackPlaythroughResumed = (
   return safeGetItem(storage, key) !== "1";
 };
 
+export const shouldTrackLandingViewed = (
+  playthroughId: string,
+  storage: StorageValue = globalThis.sessionStorage,
+): boolean => {
+  if (!isUsableStorage(storage)) {
+    return true;
+  }
+
+  return safeGetItem(storage, getLandingStorageKey(playthroughId)) !== "1";
+};
+
 export const markPlaythroughResumedTracked = (
   playthroughId: string,
   storage: StorageValue = globalThis.sessionStorage,
@@ -165,6 +181,17 @@ export const markPlaythroughResumedTracked = (
   }
 
   safeSetItem(storage, getResumeStorageKey(playthroughId), "1");
+};
+
+export const markLandingViewedTracked = (
+  playthroughId: string,
+  storage: StorageValue = globalThis.sessionStorage,
+): void => {
+  if (!isUsableStorage(storage)) {
+    return;
+  }
+
+  safeSetItem(storage, getLandingStorageKey(playthroughId), "1");
 };
 
 export const getDaysSinceLastActive = (

--- a/src/lib/analytics/trackEvent.ts
+++ b/src/lib/analytics/trackEvent.ts
@@ -6,6 +6,10 @@ type AnalyticsPrimitive = string | number | boolean;
 export type AnalyticsProperties = Record<string, AnalyticsPrimitive>;
 
 export const ANALYTICS_EVENTS = {
+  landingViewed: "landing_viewed",
+  playthroughSelectorOpened: "playthrough_selector_opened",
+  createPlaythroughModalOpened: "create_playthrough_modal_opened",
+  firstEncounterSaved: "first_encounter_saved",
   playthroughCreated: "playthrough_created",
   runCheckpointReached: "run_checkpoint_reached",
   playthroughResumed: "playthrough_resumed",
@@ -68,6 +72,18 @@ export type CheckpointLabel =
   | "cp_80";
 
 export type AnalyticsEventMap = {
+  landing_viewed: SharedEventProperties & {
+    entry_route: "home" | "locations" | "other";
+  };
+  playthrough_selector_opened: SharedEventProperties & {
+    source_surface: "header";
+  };
+  create_playthrough_modal_opened: SharedEventProperties & {
+    source_surface: "header";
+  };
+  first_encounter_saved: SharedEventProperties & {
+    location_id: string;
+  };
   playthrough_created: SharedEventProperties & {
     has_existing_playthroughs: boolean;
   };
@@ -160,6 +176,26 @@ const sharedEventPropertiesSchema = z
   .strict();
 
 const analyticsEventSchemaMap = {
+  landing_viewed: sharedEventPropertiesSchema
+    .extend({
+      entry_route: z.enum(["home", "locations", "other"]),
+    })
+    .strict(),
+  playthrough_selector_opened: sharedEventPropertiesSchema
+    .extend({
+      source_surface: z.literal("header"),
+    })
+    .strict(),
+  create_playthrough_modal_opened: sharedEventPropertiesSchema
+    .extend({
+      source_surface: z.literal("header"),
+    })
+    .strict(),
+  first_encounter_saved: sharedEventPropertiesSchema
+    .extend({
+      location_id: z.string().min(1),
+    })
+    .strict(),
   playthrough_created: sharedEventPropertiesSchema
     .extend({
       has_existing_playthroughs: z.boolean(),
@@ -259,6 +295,10 @@ const ANALYTICS_PRODUCTION_HOSTNAMES = new Set([
 
 const createByEventCounter = (): Record<AnalyticsEventName, EventCounter> => {
   return {
+    landing_viewed: { sent: 0, blocked: 0 },
+    playthrough_selector_opened: { sent: 0, blocked: 0 },
+    create_playthrough_modal_opened: { sent: 0, blocked: 0 },
+    first_encounter_saved: { sent: 0, blocked: 0 },
     playthrough_created: { sent: 0, blocked: 0 },
     run_checkpoint_reached: { sent: 0, blocked: 0 },
     playthrough_resumed: { sent: 0, blocked: 0 },

--- a/src/stores/playthroughs/PlaythroughResumeObserver.tsx
+++ b/src/stores/playthroughs/PlaythroughResumeObserver.tsx
@@ -5,7 +5,9 @@ import { useLocalStorage } from "@/hooks/useLocalStorage";
 import {
   getDaysSinceLastActive,
   getSharedEventProperties,
+  markLandingViewedTracked,
   markPlaythroughResumedTracked,
+  shouldTrackLandingViewed,
   shouldTrackPlaythroughResumed,
   toDormancyBucket,
 } from "@/lib/analytics/playthroughEventData";
@@ -25,12 +27,46 @@ const DEFAULT_CONSENT_PREFERENCES: ConsentPreferences = {
 export function PlaythroughResumeObserver() {
   const activePlaythrough = useActivePlaythrough();
   const isLoading = useIsLoading();
+  const lastTrackedLandingPlaythroughId = useRef<string | null>(null);
   const lastTrackedPlaythroughId = useRef<string | null>(null);
   const [preferences] = useLocalStorage<ConsentPreferences>(
     "cookie-preferences",
     DEFAULT_CONSENT_PREFERENCES,
   );
   const hasAnalyticsConsent = preferences.analytics;
+
+  useEffect(() => {
+    if (isLoading || !activePlaythrough) {
+      return;
+    }
+
+    if (lastTrackedLandingPlaythroughId.current === activePlaythrough.id) {
+      return;
+    }
+
+    if (!shouldTrackLandingViewed(activePlaythrough.id)) {
+      lastTrackedLandingPlaythroughId.current = activePlaythrough.id;
+      return;
+    }
+
+    const pathname = globalThis.location?.pathname;
+    const entryRoute =
+      pathname === "/"
+        ? "home"
+        : pathname === "/locations"
+          ? "locations"
+          : "other";
+
+    const wasTracked = trackEvent("landing_viewed", {
+      ...getSharedEventProperties(activePlaythrough),
+      entry_route: entryRoute,
+    });
+
+    if (wasTracked) {
+      markLandingViewedTracked(activePlaythrough.id);
+      lastTrackedLandingPlaythroughId.current = activePlaythrough.id;
+    }
+  }, [activePlaythrough, hasAnalyticsConsent, isLoading]);
 
   useEffect(() => {
     if (isLoading || !activePlaythrough) {

--- a/src/stores/playthroughs/__tests__/analytics-events.test.ts
+++ b/src/stores/playthroughs/__tests__/analytics-events.test.ts
@@ -81,6 +81,12 @@ describe("analytics event instrumentation", () => {
       checkpoint: 5,
       checkpoint_label: "cp_5",
     });
+
+    const firstEncounterEvents = getTrackedEvents("first_encounter_saved");
+    expect(firstEncounterEvents).toHaveLength(1);
+    expect(firstEncounterEvents[0]?.[1]).toMatchObject({
+      location_id: "route1",
+    });
   });
 
   it("tracks fusion_created for update, create, and drag-drop transitions", async () => {
@@ -137,6 +143,23 @@ describe("analytics event instrumentation", () => {
     expect(fusionCreatedEvents[0]?.[1]).toMatchObject({
       creation_method: "drag_drop",
       location_id: "route4",
+    });
+  });
+
+  it("tracks first encounter when a fusion creates the first saved encounter", async () => {
+    createTestPlaythrough();
+    analyticsMocks.trackEvent.mockClear();
+
+    await createFusion(
+      "route1",
+      testPokemon.pikachu("first-fusion-head"),
+      testPokemon.charmander("first-fusion-body"),
+    );
+
+    const firstEncounterEvents = getTrackedEvents("first_encounter_saved");
+    expect(firstEncounterEvents).toHaveLength(1);
+    expect(firstEncounterEvents[0]?.[1]).toMatchObject({
+      location_id: "route1",
     });
   });
 

--- a/src/stores/playthroughs/__tests__/playthrough-resume-observer.test.ts
+++ b/src/stores/playthroughs/__tests__/playthrough-resume-observer.test.ts
@@ -95,6 +95,33 @@ describe("PlaythroughResumeObserver", () => {
     ).toHaveLength(1);
   });
 
+  it("emits landing view once for an active playthrough in a session", async () => {
+    const { activePlaythrough } = createTestPlaythrough();
+    playthroughsStore.isLoading = false;
+    analyticsMocks.trackEvent.mockClear();
+
+    const view = render(createElement(PlaythroughResumeObserver));
+
+    await waitFor(() => {
+      expect(analyticsMocks.trackEvent).toHaveBeenCalledWith(
+        "landing_viewed",
+        expect.objectContaining({
+          playthrough_id: activePlaythrough.id,
+          entry_route: "home",
+        }),
+      );
+    });
+
+    view.rerender(createElement(PlaythroughResumeObserver));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(
+      analyticsMocks.trackEvent.mock.calls.filter(
+        (call) => call[0] === "landing_viewed",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("emits for a different playthrough in same session", async () => {
     const first = createTestPlaythrough("First");
     first.activePlaythrough.updatedAt = Date.now() - 86_400_000;
@@ -136,7 +163,11 @@ describe("PlaythroughResumeObserver", () => {
     render(createElement(PlaythroughResumeObserver));
 
     await waitFor(() => {
-      expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+      expect(
+        analyticsMocks.trackEvent.mock.calls.filter(
+          (call) => call[0] === "landing_viewed",
+        ),
+      ).toHaveLength(1);
     });
 
     localStorage.setItem(
@@ -154,9 +185,15 @@ describe("PlaythroughResumeObserver", () => {
     await waitFor(() => {
       expect(
         analyticsMocks.trackEvent.mock.calls.filter(
-          (call) => call[0] === "playthrough_resumed",
+          (call) => call[0] === "landing_viewed",
         ),
       ).toHaveLength(2);
     });
+
+    expect(
+      analyticsMocks.trackEvent.mock.calls.filter(
+        (call) => call[0] === "playthrough_resumed",
+      ),
+    ).toHaveLength(1);
   });
 });

--- a/src/stores/playthroughs/encounters/crud.ts
+++ b/src/stores/playthroughs/encounters/crud.ts
@@ -21,6 +21,22 @@ import {
   removeTeamMembersWithPokemon,
 } from "./team";
 
+const trackFirstEncounterSaved = (
+  activePlaythrough: Playthrough,
+  locationId: string,
+  previousEncounterCount: number,
+  nextEncounterCount: number,
+) => {
+  if (previousEncounterCount !== 0 || nextEncounterCount === 0) {
+    return;
+  }
+
+  trackEvent("first_encounter_saved", {
+    ...getSharedEventProperties(activePlaythrough),
+    location_id: locationId,
+  });
+};
+
 // Create encounter data (variants are managed globally)
 export const createEncounterData = async (
   pokemon: PokemonOption | null,
@@ -107,6 +123,12 @@ export const updateEncounter = async (
     }
 
     const nextEncounterCount = getEncounterCount(activePlaythrough);
+    trackFirstEncounterSaved(
+      activePlaythrough,
+      locationId,
+      previousEncounterCount,
+      nextEncounterCount,
+    );
     const newlyReachedCheckpoints = getNewlyReachedCheckpoints(
       activePlaythrough.id,
       previousEncounterCount,
@@ -212,6 +234,12 @@ export const updateEncounter = async (
     }
 
     const nextEncounterCount = getEncounterCount(activePlaythrough);
+    trackFirstEncounterSaved(
+      activePlaythrough,
+      locationId,
+      previousEncounterCount,
+      nextEncounterCount,
+    );
     const newlyReachedCheckpoints = getNewlyReachedCheckpoints(
       activePlaythrough.id,
       previousEncounterCount,

--- a/src/stores/playthroughs/encounters/fusion.ts
+++ b/src/stores/playthroughs/encounters/fusion.ts
@@ -122,6 +122,13 @@ export const createFusion = async (
   }
 
   const nextEncounterCount = getEncounterCount(activePlaythrough);
+  if (previousEncounterCount === 0 && nextEncounterCount > 0) {
+    trackEvent("first_encounter_saved", {
+      ...getSharedEventProperties(activePlaythrough),
+      location_id: locationId,
+    });
+  }
+
   const newlyReachedCheckpoints = getNewlyReachedCheckpoints(
     activePlaythrough.id,
     previousEncounterCount,


### PR DESCRIPTION
## Summary
Adds early-funnel analytics so bounce-rate work can measure whether visitors reach the first meaningful tracker actions.

## Changes
- Add typed analytics contract entries for landing views, selector opens, create-modal opens, and first encounter saves.
- Emit `landing_viewed` once per playthrough per tab session after store load.
- Emit selector and create-modal open events from the header playthrough control.
- Emit `first_encounter_saved` when encounter count crosses from zero to one through both normal encounter edits and fusion creation.
- Update analytics docs and coverage for the new events.

## Reviewer Focus
- Event semantics and dedupe behavior for `landing_viewed` and `first_encounter_saved`.
- Whether the new event names/properties are low-cardinality enough for dashboards.
- Whether header interaction events are emitted at the right intent points.

## Risk
- Analytics-only behavior change; app state and UI flows should remain unchanged.
- Event counts are still gated by production environment and analytics consent, so funnels remain partial by design.

## Testing
- `pnpm type-check`
- `pnpm test:run`
- `pnpm validate`

## Manual Testing
- Not run. Change is covered by unit tests and uses existing analytics transport gating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced analytics tracking for key user interactions, including landing page views, playthrough selection, and first encounter creation.

* **Documentation**
  * Updated analytics event specifications to document newly tracked user actions and their event properties.

* **Tests**
  * Expanded test coverage for new analytics events and tracking behaviors across components and utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->