### PR TITLE
Add encounter progress summary

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,32 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Nuzlocke players actively tracking a Pokemon Infinite Fusion run while playing. They need fast, low-friction updates for encounters, locations, team state, misses, deaths, and captures.
+
+## Product Purpose
+
+This product helps players keep strict run-state records without slowing down play. Success means the current run state is visible at a glance, status changes are easy to make correctly, and the UI reinforces Nuzlocke constraints without becoming a dashboard.
+
+## Brand Personality
+
+Precise, calm, fast. The interface should feel trustworthy and focused, with enough visual guidance to prevent mistakes but no decorative clutter.
+
+## Anti-references
+
+Avoid busy dashboard clutter, noisy analytics patterns, and raw spreadsheet plainness. The UI should not feel like a toy game skin or a generic SaaS admin surface.
+
+## Design Principles
+
+- Preserve play flow: common run updates should be quick and obvious.
+- Make state legible: captures, deaths, misses, and untouched locations must be distinguishable without extra reading.
+- Respect density: the tracker can be compact, but important state changes need clear affordances.
+- Avoid decoration: color and motion should communicate state, not style for its own sake.
+
+## Accessibility & Inclusion
+
+Use semantic HTML, sufficient contrast, and visible labels or tooltips where color carries meaning. Avoid relying on color alone for critical state.

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -4,7 +4,7 @@ Local rules for UI and component work.
 
 ## Constraints
 
-- Use `lucide-react` icons only; do not use UTF symbols as icons.
+- Prefer `lucide-react` for generic UI icons; established custom SVG icons from `src/assets/images/` are allowed for Pokemon/domain-specific UI. Do not use UTF symbols as icons.
 - Keep icon sizing consistent with existing component patterns (`h-4 w-4`, `h-5 w-5`, `h-6 w-6`).
 - Apply `web-accessibility` skill for keyboard parity and ARIA behavior on interactive UI.
 - Treat UI as a consumer of validated run state; do not bypass store validations in component logic.

--- a/src/components/CursorTooltip.tsx
+++ b/src/components/CursorTooltip.tsx
@@ -20,6 +20,7 @@ import {
   cloneElement,
   isValidElement,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -56,6 +57,7 @@ interface CursorTooltipProps {
   delay?: number;
   disabled?: boolean;
   placement?: Placement;
+  tooltipId?: string;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
   offset?: {
@@ -72,9 +74,11 @@ export function CursorTooltip(props: CursorTooltipProps) {
     delay = 0,
     disabled = false,
     placement = "bottom-start",
+    tooltipId,
     onMouseEnter,
     onMouseLeave,
   } = props;
+  const instanceId = useId();
   const [isOpen, setIsOpen] = useState(false);
   const [animationState, setAnimationState] = useState<
     "entering" | "entered" | "exiting" | null
@@ -107,6 +111,13 @@ export function CursorTooltip(props: CursorTooltipProps) {
       }
 
       if (open) {
+        if (tooltipId) {
+          window.dispatchEvent(
+            new CustomEvent("cursor-tooltip-open", {
+              detail: { tooltipId, instanceId },
+            }),
+          );
+        }
         setIsOpen(true);
         setAnimationState("entering");
       } else {
@@ -176,6 +187,27 @@ export function CursorTooltip(props: CursorTooltipProps) {
       return cleanup;
     },
   });
+
+  useEffect(() => {
+    if (!tooltipId) return;
+
+    const handleTooltipOpen = (event: Event) => {
+      const detail = (event as CustomEvent).detail as
+        | { tooltipId?: string; instanceId?: string }
+        | undefined;
+      if (detail?.tooltipId !== tooltipId || detail.instanceId === instanceId) {
+        return;
+      }
+
+      setIsOpen(false);
+      setAnimationState(null);
+    };
+
+    window.addEventListener("cursor-tooltip-open", handleTooltipOpen);
+    return () => {
+      window.removeEventListener("cursor-tooltip-open", handleTooltipOpen);
+    };
+  }, [instanceId, tooltipId]);
 
   // Register tooltip with global state when it opens/closes
   useEffect(() => {

--- a/src/components/LocationTable/LocationTableHeader.tsx
+++ b/src/components/LocationTable/LocationTableHeader.tsx
@@ -1,5 +1,6 @@
 import type { HeaderGroup } from "@tanstack/react-table";
 import type { CombinedLocation } from "@/loaders/locations";
+import ProgressBar from "@/components/ProgressBar";
 import SortableHeaderCell from "./SortableHeaderCell";
 
 interface LocationTableHeaderProps {
@@ -18,6 +19,11 @@ export default function LocationTableHeader({
           ))}
         </tr>
       ))}
+      <tr aria-hidden="true">
+        <th colSpan={headerGroups[0]?.headers.length ?? 1} className="p-0">
+          <ProgressBar />
+        </th>
+      </tr>
     </thead>
   );
 }

--- a/src/components/LocationTable/LocationTableHeader.tsx
+++ b/src/components/LocationTable/LocationTableHeader.tsx
@@ -11,7 +11,7 @@ export default function LocationTableHeader({
   headerGroups,
 }: LocationTableHeaderProps) {
   return (
-    <thead className="bg-gray-50 dark:bg-gray-800 sticky top-0 z-50">
+    <thead className="bg-gray-50 dark:bg-gray-800 sticky top-0 z-50 shadow-[0_0.5px_0_0_rgb(229,231,235)] dark:shadow-[0_0.5px_0_0_rgb(55,65,81)]">
       {headerGroups.map((headerGroup) => (
         <tr key={headerGroup.id}>
           {headerGroup.headers.map((header) => (
@@ -21,7 +21,7 @@ export default function LocationTableHeader({
       ))}
       <tr>
         <th colSpan={headerGroups[0]?.headers.length ?? 1} className="p-0">
-          <ProgressBar />
+          <ProgressBar className="translate-y-px" />
         </th>
       </tr>
     </thead>

--- a/src/components/LocationTable/LocationTableHeader.tsx
+++ b/src/components/LocationTable/LocationTableHeader.tsx
@@ -1,6 +1,6 @@
 import type { HeaderGroup } from "@tanstack/react-table";
-import type { CombinedLocation } from "@/loaders/locations";
 import ProgressBar from "@/components/ProgressBar";
+import type { CombinedLocation } from "@/loaders/locations";
 import SortableHeaderCell from "./SortableHeaderCell";
 
 interface LocationTableHeaderProps {
@@ -11,7 +11,7 @@ export default function LocationTableHeader({
   headerGroups,
 }: LocationTableHeaderProps) {
   return (
-    <thead className="bg-gray-50 dark:bg-gray-800 sticky top-0 z-50 shadow-[0_0.5px_0_0_rgb(229,231,235)] dark:shadow-[0_0.5px_0_0_rgb(55,65,81)]">
+    <thead className="bg-gray-50 dark:bg-gray-800 sticky top-0 z-50">
       {headerGroups.map((headerGroup) => (
         <tr key={headerGroup.id}>
           {headerGroup.headers.map((header) => (
@@ -19,7 +19,7 @@ export default function LocationTableHeader({
           ))}
         </tr>
       ))}
-      <tr aria-hidden="true">
+      <tr>
         <th colSpan={headerGroups[0]?.headers.length ?? 1} className="p-0">
           <ProgressBar />
         </th>

--- a/src/components/LocationTable/__tests__/LocationTableScrollButton.test.tsx
+++ b/src/components/LocationTable/__tests__/LocationTableScrollButton.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/stores/playthroughs", () => ({
     getEncounters: vi.fn(() => ({})),
   },
   useCustomLocations: vi.fn(() => []),
+  useEncounters: vi.fn(() => ({})),
   useIsLoading: vi.fn(() => false),
 }));
 

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -16,57 +16,62 @@ interface ProgressBarProps {
 
 type ProgressSegment = "captured" | "deceased" | "missed" | "untouched";
 
+const progressTooltipClassName = "px-2 py-1 text-xs leading-none";
+
 export default function ProgressBar({ className }: ProgressBarProps) {
   const encounters = useEncounters();
   const customLocations = useCustomLocations();
-  const [hoveredSegment, setHoveredSegment] =
-    useState<ProgressSegment | null>(null);
+  const [hoveredSegment, setHoveredSegment] = useState<ProgressSegment | null>(
+    null,
+  );
 
-  const { capturedCount, deceasedCount, missedCount, totalCount } = useMemo(() => {
-    const allLocations = getLocationsSortedWithCustom(customLocations);
-    const total = allLocations.length;
+  const { capturedCount, deceasedCount, missedCount, totalCount } =
+    useMemo(() => {
+      const allLocations = getLocationsSortedWithCustom(customLocations);
+      const total = allLocations.length;
 
-    let captured = 0;
-    let deceased = 0;
-    let missed = 0;
+      let captured = 0;
+      let deceased = 0;
+      let missed = 0;
 
-    for (const location of allLocations) {
-      const encounter = encounters?.[location.id];
-      if (!encounter || (!encounter.head && !encounter.body)) {
-        continue;
+      for (const location of allLocations) {
+        const encounter = encounters?.[location.id];
+        if (!encounter || (!encounter.head && !encounter.body)) {
+          continue;
+        }
+
+        const statuses = [encounter.head?.status, encounter.body?.status];
+        const hasMissed = statuses.includes(PokemonStatus.MISSED);
+        const hasDeceased = statuses.includes(PokemonStatus.DECEASED);
+
+        if (hasMissed) {
+          missed += 1;
+          continue;
+        }
+
+        if (hasDeceased) {
+          deceased += 1;
+          continue;
+        }
+
+        captured += 1;
       }
 
-      const statuses = [encounter.head?.status, encounter.body?.status];
-      const hasMissed = statuses.includes(PokemonStatus.MISSED);
-      const hasDeceased = statuses.includes(PokemonStatus.DECEASED);
-
-      if (hasMissed) {
-        missed += 1;
-        continue;
-      }
-
-      if (hasDeceased) {
-        deceased += 1;
-        continue;
-      }
-
-      captured += 1;
-    }
-
-    return {
-      capturedCount: captured,
-      deceasedCount: deceased,
-      missedCount: missed,
-      totalCount: total,
-    };
-  }, [encounters, customLocations]);
+      return {
+        capturedCount: captured,
+        deceasedCount: deceased,
+        missedCount: missed,
+        totalCount: total,
+      };
+    }, [encounters, customLocations]);
 
   const completedCount = capturedCount + deceasedCount + missedCount;
   const untouchedCount = Math.max(totalCount - completedCount, 0);
   const capturedWidth = totalCount > 0 ? (capturedCount / totalCount) * 100 : 0;
   const deceasedWidth = totalCount > 0 ? (deceasedCount / totalCount) * 100 : 0;
   const missedWidth = totalCount > 0 ? (missedCount / totalCount) * 100 : 0;
-  const untouchedWidth = totalCount > 0 ? (untouchedCount / totalCount) * 100 : 0;
+  const untouchedWidth =
+    totalCount > 0 ? (untouchedCount / totalCount) * 100 : 0;
 
   const shouldDimOthers =
     hoveredSegment === "captured" ||
@@ -74,7 +79,8 @@ export default function ProgressBar({ className }: ProgressBarProps) {
     hoveredSegment === "missed";
 
   const getBg = (segment: ProgressSegment): string => {
-    const dimNeutral = "light-dark(var(--color-gray-100), var(--color-gray-800))";
+    const dimNeutral =
+      "light-dark(var(--color-gray-100), var(--color-gray-800))";
     const isHovered = hoveredSegment === segment;
     if (!shouldDimOthers || isHovered) {
       if (segment === "captured") return "var(--color-emerald-600)";
@@ -114,10 +120,15 @@ export default function ProgressBar({ className }: ProgressBarProps) {
             </span>
           }
           placement="bottom"
+          tooltipId="encounter-progress-bar"
+          className={progressTooltipClassName}
           onMouseEnter={() => setHoveredSegment("captured")}
           onMouseLeave={() => setHoveredSegment(null)}
         >
-          <div className="relative h-full" style={{ width: `${capturedWidth}%` }}>
+          <div
+            className="relative h-full"
+            style={{ width: `${capturedWidth}%` }}
+          >
             <div
               className="absolute left-0 right-0 top-1/2 h-0.5 -translate-y-1/2 origin-center transition-[background-color,transform] duration-150 ease-out"
               style={{
@@ -136,10 +147,15 @@ export default function ProgressBar({ className }: ProgressBarProps) {
             </span>
           }
           placement="bottom"
+          tooltipId="encounter-progress-bar"
+          className={progressTooltipClassName}
           onMouseEnter={() => setHoveredSegment("deceased")}
           onMouseLeave={() => setHoveredSegment(null)}
         >
-          <div className="relative h-full" style={{ width: `${deceasedWidth}%` }}>
+          <div
+            className="relative h-full"
+            style={{ width: `${deceasedWidth}%` }}
+          >
             <div
               className="absolute left-0 right-0 top-1/2 h-0.5 -translate-y-1/2 origin-center transition-[background-color,transform] duration-150 ease-out"
               style={{
@@ -158,6 +174,8 @@ export default function ProgressBar({ className }: ProgressBarProps) {
             </span>
           }
           placement="bottom"
+          tooltipId="encounter-progress-bar"
+          className={progressTooltipClassName}
           onMouseEnter={() => setHoveredSegment("missed")}
           onMouseLeave={() => setHoveredSegment(null)}
         >
@@ -180,10 +198,15 @@ export default function ProgressBar({ className }: ProgressBarProps) {
             </span>
           }
           placement="bottom"
+          tooltipId="encounter-progress-bar"
+          className={progressTooltipClassName}
           onMouseEnter={() => setHoveredSegment("untouched")}
           onMouseLeave={() => setHoveredSegment(null)}
         >
-          <div className="relative h-full" style={{ width: `${untouchedWidth}%` }}>
+          <div
+            className="relative h-full"
+            style={{ width: `${untouchedWidth}%` }}
+          >
             <div
               className="absolute left-0 right-0 top-1/2 h-0.5 -translate-y-1/2 origin-center transition-[background-color,transform] duration-150 ease-out"
               style={{

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,65 +1,199 @@
 "use client";
 
 import clsx from "clsx";
-import { useMemo } from "react";
+import { CircleIcon, SkullIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+import EscapeIcon from "@/assets/images/escape-cloud.svg";
+import PokeballIcon from "@/assets/images/pokeball.svg";
 import { getLocationsSortedWithCustom } from "@/loaders";
+import { PokemonStatus } from "@/loaders/pokemon";
 import { useCustomLocations, useEncounters } from "@/stores/playthroughs";
+import { CursorTooltip } from "./CursorTooltip";
 
 interface ProgressBarProps {
   className?: string;
 }
 
+type ProgressSegment = "captured" | "deceased" | "missed" | "untouched";
+
 export default function ProgressBar({ className }: ProgressBarProps) {
   const encounters = useEncounters();
   const customLocations = useCustomLocations();
+  const [hoveredSegment, setHoveredSegment] =
+    useState<ProgressSegment | null>(null);
 
-  const { completedCount, totalCount, percentage } = useMemo(() => {
+  const { capturedCount, deceasedCount, missedCount, totalCount } = useMemo(() => {
     const allLocations = getLocationsSortedWithCustom(customLocations);
     const total = allLocations.length;
 
-    const completed = allLocations.filter((location) => {
-      const encounter = encounters?.[location.id];
-      return encounter && (encounter.head || encounter.body);
-    }).length;
+    let captured = 0;
+    let deceased = 0;
+    let missed = 0;
 
-    const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+    for (const location of allLocations) {
+      const encounter = encounters?.[location.id];
+      if (!encounter || (!encounter.head && !encounter.body)) {
+        continue;
+      }
+
+      const statuses = [encounter.head?.status, encounter.body?.status];
+      const hasMissed = statuses.includes(PokemonStatus.MISSED);
+      const hasDeceased = statuses.includes(PokemonStatus.DECEASED);
+
+      if (hasMissed) {
+        missed += 1;
+        continue;
+      }
+
+      if (hasDeceased) {
+        deceased += 1;
+        continue;
+      }
+
+      captured += 1;
+    }
 
     return {
-      completedCount: completed,
+      capturedCount: captured,
+      deceasedCount: deceased,
+      missedCount: missed,
       totalCount: total,
-      percentage: percent,
     };
   }, [encounters, customLocations]);
 
+  const completedCount = capturedCount + deceasedCount + missedCount;
+  const untouchedCount = Math.max(totalCount - completedCount, 0);
+  const capturedWidth = totalCount > 0 ? (capturedCount / totalCount) * 100 : 0;
+  const deceasedWidth = totalCount > 0 ? (deceasedCount / totalCount) * 100 : 0;
+  const missedWidth = totalCount > 0 ? (missedCount / totalCount) * 100 : 0;
+  const untouchedWidth = totalCount > 0 ? (untouchedCount / totalCount) * 100 : 0;
+
+  const shouldDimOthers =
+    hoveredSegment === "captured" ||
+    hoveredSegment === "deceased" ||
+    hoveredSegment === "missed";
+
+  const getBg = (segment: ProgressSegment): string => {
+    const dimNeutral = "light-dark(var(--color-gray-100), var(--color-gray-800))";
+    const isHovered = hoveredSegment === segment;
+    if (!shouldDimOthers || isHovered) {
+      if (segment === "captured") return "var(--color-emerald-600)";
+      if (segment === "deceased") return "var(--color-rose-600)";
+      if (segment === "missed") return "var(--color-amber-600)";
+      return "light-dark(var(--color-gray-300), var(--color-gray-700))";
+    }
+
+    if (segment === "captured") {
+      return `color-mix(in oklab, var(--color-emerald-600) 25%, ${dimNeutral})`;
+    }
+    if (segment === "deceased") {
+      return `color-mix(in oklab, var(--color-rose-600) 25%, ${dimNeutral})`;
+    }
+    if (segment === "missed") {
+      return `color-mix(in oklab, var(--color-amber-600) 25%, ${dimNeutral})`;
+    }
+    return `color-mix(in oklab, light-dark(var(--color-gray-300), var(--color-gray-700)) 45%, ${dimNeutral})`;
+  };
+
   return (
-    <div className={clsx("w-full", className)}>
-      <div className="text-sm text-gray-600 dark:text-gray-400 mb-2 flex items-center gap-2">
-        <span>
-          {completedCount} / {totalCount} locations
-        </span>
-        <span className="text-gray-400 dark:text-gray-600">
-          ({percentage}%)
-        </span>
-      </div>
-
-      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3 overflow-hidden">
-        <div
-          className={clsx(
-            "h-full rounded-full transition-all duration-500 ease-out",
-            "bg-gradient-to-r from-blue-500 to-blue-600",
-            "dark:from-blue-400 dark:to-blue-500",
-          )}
-          style={{ width: `${percentage}%` }}
-        />
-      </div>
-
-      {percentage === 100 && (
-        <div className="text-center mt-2">
-          <span className="text-sm  text-green-600 dark:text-green-400">
-            🎉 Congratulations! You&apos;ve completed all locations!
-          </span>
-        </div>
+    <div
+      className={clsx(
+        "group relative w-full h-0.5 overflow-visible",
+        className,
       )}
+      role="img"
+      aria-label={`Encounter progress: ${capturedCount} captured, ${deceasedCount} deceased, ${missedCount} missed, ${untouchedCount} untouched`}
+    >
+      <div className="group/bar absolute left-0 right-0 top-1/2 flex h-10 -translate-y-1/2 overflow-visible">
+        <CursorTooltip
+          content={
+            <span className="inline-flex items-center gap-1.5 leading-none">
+              <PokeballIcon className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+              <span>Captured</span>
+              <span className="tabular-nums">{capturedCount}</span>
+            </span>
+          }
+          placement="bottom"
+          onMouseEnter={() => setHoveredSegment("captured")}
+          onMouseLeave={() => setHoveredSegment(null)}
+        >
+          <div className="relative h-full" style={{ width: `${capturedWidth}%` }}>
+            <div
+              className="absolute left-0 right-0 top-1/2 h-0.5 -translate-y-1/2 origin-center transition-[background-color,transform] duration-150 ease-out"
+              style={{
+                backgroundColor: getBg("captured"),
+                transform: `translateY(-50%) scaleY(${hoveredSegment ? 7 : 1})`,
+              }}
+            />
+          </div>
+        </CursorTooltip>
+        <CursorTooltip
+          content={
+            <span className="inline-flex items-center gap-1.5 leading-none">
+              <SkullIcon className="h-4 w-4 shrink-0 text-rose-600 dark:text-rose-400" />
+              <span>Deceased</span>
+              <span className="tabular-nums">{deceasedCount}</span>
+            </span>
+          }
+          placement="bottom"
+          onMouseEnter={() => setHoveredSegment("deceased")}
+          onMouseLeave={() => setHoveredSegment(null)}
+        >
+          <div className="relative h-full" style={{ width: `${deceasedWidth}%` }}>
+            <div
+              className="absolute left-0 right-0 top-1/2 h-0.5 -translate-y-1/2 origin-center transition-[background-color,transform] duration-150 ease-out"
+              style={{
+                backgroundColor: getBg("deceased"),
+                transform: `translateY(-50%) scaleY(${hoveredSegment ? 7 : 1})`,
+              }}
+            />
+          </div>
+        </CursorTooltip>
+        <CursorTooltip
+          content={
+            <span className="inline-flex items-center gap-1.5 leading-none">
+              <EscapeIcon className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <span>Missed</span>
+              <span className="tabular-nums">{missedCount}</span>
+            </span>
+          }
+          placement="bottom"
+          onMouseEnter={() => setHoveredSegment("missed")}
+          onMouseLeave={() => setHoveredSegment(null)}
+        >
+          <div className="relative h-full" style={{ width: `${missedWidth}%` }}>
+            <div
+              className="absolute left-0 right-0 top-1/2 h-0.5 -translate-y-1/2 origin-center transition-[background-color,transform] duration-150 ease-out"
+              style={{
+                backgroundColor: getBg("missed"),
+                transform: `translateY(-50%) scaleY(${hoveredSegment ? 7 : 1})`,
+              }}
+            />
+          </div>
+        </CursorTooltip>
+        <CursorTooltip
+          content={
+            <span className="inline-flex items-center gap-1.5 leading-none">
+              <CircleIcon className="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
+              <span>Untouched</span>
+              <span className="tabular-nums">{untouchedCount}</span>
+            </span>
+          }
+          placement="bottom"
+          onMouseEnter={() => setHoveredSegment("untouched")}
+          onMouseLeave={() => setHoveredSegment(null)}
+        >
+          <div className="relative h-full" style={{ width: `${untouchedWidth}%` }}>
+            <div
+              className="absolute left-0 right-0 top-1/2 h-0.5 -translate-y-1/2 origin-center transition-[background-color,transform] duration-150 ease-out"
+              style={{
+                backgroundColor: getBg("untouched"),
+                transform: `translateY(-50%) scaleY(${hoveredSegment ? 7 : 1})`,
+              }}
+            />
+          </div>
+        </CursorTooltip>
+      </div>
     </div>
   );
 }

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -43,6 +43,13 @@ export default function ProgressBar({ className }: ProgressBarProps) {
         const statuses = [encounter.head?.status, encounter.body?.status];
         const hasMissed = statuses.includes(PokemonStatus.MISSED);
         const hasDeceased = statuses.includes(PokemonStatus.DECEASED);
+        const hasSuccessfulEncounter = statuses.some(
+          (status) =>
+            status === PokemonStatus.CAPTURED ||
+            status === PokemonStatus.RECEIVED ||
+            status === PokemonStatus.TRADED ||
+            status === PokemonStatus.STORED,
+        );
 
         if (hasMissed) {
           missed += 1;
@@ -54,7 +61,9 @@ export default function ProgressBar({ className }: ProgressBarProps) {
           continue;
         }
 
-        captured += 1;
+        if (hasSuccessfulEncounter) {
+          captured += 1;
+        }
       }
 
       return {

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -14,7 +14,7 @@ interface ProgressBarProps {
   className?: string;
 }
 
-type ProgressSegment = "captured" | "deceased" | "missed" | "untouched";
+type ProgressSegment = "captured" | "deceased" | "missed" | "unencountered";
 
 const progressTooltipClassName = "px-2 py-1 text-xs leading-none";
 
@@ -66,12 +66,12 @@ export default function ProgressBar({ className }: ProgressBarProps) {
     }, [encounters, customLocations]);
 
   const completedCount = capturedCount + deceasedCount + missedCount;
-  const untouchedCount = Math.max(totalCount - completedCount, 0);
+  const unencounteredCount = Math.max(totalCount - completedCount, 0);
   const capturedWidth = totalCount > 0 ? (capturedCount / totalCount) * 100 : 0;
   const deceasedWidth = totalCount > 0 ? (deceasedCount / totalCount) * 100 : 0;
   const missedWidth = totalCount > 0 ? (missedCount / totalCount) * 100 : 0;
-  const untouchedWidth =
-    totalCount > 0 ? (untouchedCount / totalCount) * 100 : 0;
+  const unencounteredWidth =
+    totalCount > 0 ? (unencounteredCount / totalCount) * 100 : 0;
 
   const shouldDimOthers =
     hoveredSegment === "captured" ||
@@ -108,7 +108,7 @@ export default function ProgressBar({ className }: ProgressBarProps) {
         className,
       )}
       role="img"
-      aria-label={`Encounter progress: ${capturedCount} captured, ${deceasedCount} deceased, ${missedCount} missed, ${untouchedCount} untouched`}
+      aria-label={`Encounter progress: ${capturedCount} captured, ${deceasedCount} deceased, ${missedCount} missed, ${unencounteredCount} unencountered`}
     >
       <div className="group/bar absolute left-0 right-0 top-1/2 flex h-10 -translate-y-1/2 overflow-visible">
         <CursorTooltip
@@ -193,24 +193,24 @@ export default function ProgressBar({ className }: ProgressBarProps) {
           content={
             <span className="inline-flex items-center gap-1.5 leading-none">
               <CircleIcon className="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
-              <span>Untouched</span>
-              <span className="tabular-nums">{untouchedCount}</span>
+              <span>Unencountered</span>
+              <span className="tabular-nums">{unencounteredCount}</span>
             </span>
           }
           placement="bottom"
           tooltipId="encounter-progress-bar"
           className={progressTooltipClassName}
-          onMouseEnter={() => setHoveredSegment("untouched")}
+          onMouseEnter={() => setHoveredSegment("unencountered")}
           onMouseLeave={() => setHoveredSegment(null)}
         >
           <div
             className="relative h-full"
-            style={{ width: `${untouchedWidth}%` }}
+            style={{ width: `${unencounteredWidth}%` }}
           >
             <div
               className="absolute left-0 right-0 top-1/2 h-0.5 -translate-y-1/2 origin-center transition-[background-color,transform] duration-150 ease-out"
               style={{
-                backgroundColor: getBg("untouched"),
+                backgroundColor: getBg("unencountered"),
                 transform: `translateY(-50%) scaleY(${hoveredSegment ? 7 : 1})`,
               }}
             />

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import clsx from "clsx";
-import {
-  CheckCircleIcon,
-  CircleIcon,
-  SkullIcon,
-  XCircleIcon,
-} from "lucide-react";
+import { CircleIcon, SkullIcon } from "lucide-react";
 import { useMemo, useState } from "react";
+import EscapeIcon from "@/assets/images/escape-cloud.svg";
+import PokeballIcon from "@/assets/images/pokeball.svg";
 import { getLocationsSortedWithCustom } from "@/loaders";
 import { PokemonStatus } from "@/loaders/pokemon";
 import { useCustomLocations, useEncounters } from "@/stores/playthroughs";
@@ -126,7 +123,7 @@ export default function ProgressBar({ className }: ProgressBarProps) {
         <CursorTooltip
           content={
             <span className="inline-flex items-center gap-1.5 leading-none">
-              <CheckCircleIcon className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+              <PokeballIcon className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
               <span>Captured</span>
               <span className="tabular-nums">{capturedCount}</span>
             </span>
@@ -180,7 +177,7 @@ export default function ProgressBar({ className }: ProgressBarProps) {
         <CursorTooltip
           content={
             <span className="inline-flex items-center gap-1.5 leading-none">
-              <XCircleIcon className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <EscapeIcon className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
               <span>Missed</span>
               <span className="tabular-nums">{missedCount}</span>
             </span>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import clsx from "clsx";
-import { CircleIcon, SkullIcon } from "lucide-react";
+import {
+  CheckCircleIcon,
+  CircleIcon,
+  SkullIcon,
+  XCircleIcon,
+} from "lucide-react";
 import { useMemo, useState } from "react";
-import EscapeIcon from "@/assets/images/escape-cloud.svg";
-import PokeballIcon from "@/assets/images/pokeball.svg";
 import { getLocationsSortedWithCustom } from "@/loaders";
 import { PokemonStatus } from "@/loaders/pokemon";
 import { useCustomLocations, useEncounters } from "@/stores/playthroughs";
@@ -123,7 +126,7 @@ export default function ProgressBar({ className }: ProgressBarProps) {
         <CursorTooltip
           content={
             <span className="inline-flex items-center gap-1.5 leading-none">
-              <PokeballIcon className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+              <CheckCircleIcon className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
               <span>Captured</span>
               <span className="tabular-nums">{capturedCount}</span>
             </span>
@@ -177,7 +180,7 @@ export default function ProgressBar({ className }: ProgressBarProps) {
         <CursorTooltip
           content={
             <span className="inline-flex items-center gap-1.5 leading-none">
-              <EscapeIcon className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <XCircleIcon className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
               <span>Missed</span>
               <span className="tabular-nums">{missedCount}</span>
             </span>


### PR DESCRIPTION
## Summary
- Adds a segmented encounter progress line to the sticky location table header.
- Breaks run progress into captured, deceased, missed, and unencountered locations with CursorTooltip details.
- Adds shared tooltip identity support so progress segment tooltips replace each other instead of stacking.

## Validation
- pnpm type-check
- pnpm test:run src/components/LocationTable/__tests__/LocationTableScrollButton.test.tsx
- pre-push validation passed during git push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive product definition and design guidelines.

* **New Features**
  * Progress bar redesigned with segmented encounter-status display showing captured, defeated, and missed Pokémon counts with interactive hover effects.
  * Improved tooltip behavior for better multi-tooltip interactions.

* **Tests**
  * Updated test coverage for table scroll functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->