### PR TITLE
Silence expected test suite noise

### DIFF
--- a/src/components/pc/__tests__/TeamEntryItem.test.tsx
+++ b/src/components/pc/__tests__/TeamEntryItem.test.tsx
@@ -32,6 +32,14 @@ const {
   playEvolutionMock: vi.fn(),
 }));
 
+type FusionSpriteMockProps = React.HTMLAttributes<HTMLDivElement> & {
+  headPokemon?: unknown;
+  bodyPokemon?: unknown;
+  isFusion?: boolean;
+  shouldLoad?: boolean;
+  showStatusOverlay?: boolean;
+};
+
 vi.mock("@/assets/images/head.svg", () => ({
   default: () => <svg data-testid="head-icon" />,
 }));
@@ -55,17 +63,32 @@ vi.mock("@/components/PokemonSummaryCard/ArtworkVariantButton", () => ({
 vi.mock("@/components/PokemonSummaryCard/FusionSprite", () => ({
   FusionSprite: (() => {
     const React = require("react") as typeof import("react");
-    return React.forwardRef((props, ref) => {
-      React.useImperativeHandle(
+    return React.forwardRef<
+      { playEvolution: typeof playEvolutionMock },
+      FusionSpriteMockProps
+    >(
+      (
+        {
+          headPokemon: _headPokemon,
+          bodyPokemon: _bodyPokemon,
+          isFusion: _isFusion,
+          shouldLoad: _shouldLoad,
+          showStatusOverlay: _showStatusOverlay,
+          ...props
+        },
         ref,
-        () => ({
-          playEvolution: playEvolutionMock,
-        }),
-        [],
-      );
+      ) => {
+        React.useImperativeHandle(
+          ref,
+          () => ({
+            playEvolution: playEvolutionMock,
+          }),
+          [],
+        );
 
-      return <div data-testid="fusion-sprite" {...props} />;
-    });
+        return <div data-testid="fusion-sprite" {...props} />;
+      },
+    );
   })(),
 }));
 

--- a/src/services/__tests__/encountersApiService.test.ts
+++ b/src/services/__tests__/encountersApiService.test.ts
@@ -95,6 +95,8 @@ describe("EncountersApiService", () => {
     });
 
     it("should throw error on invalid response format", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
       // Mock the schema validation to fail
       vi.mocked(RouteEncountersArraySchema.safeParse).mockReturnValueOnce({
         success: false,

--- a/src/services/__tests__/pokemonApiService.test.ts
+++ b/src/services/__tests__/pokemonApiService.test.ts
@@ -157,6 +157,8 @@ describe("PokemonApiService", () => {
     });
 
     it("should throw error on invalid response format", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
       const invalidResponse = {
         data: "invalid data",
         count: "not a number",

--- a/src/services/__tests__/searchService.test.ts
+++ b/src/services/__tests__/searchService.test.ts
@@ -82,6 +82,8 @@ describe("SearchService", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
     ({ default: searchService } = await import("../searchService"));
   });
 

--- a/src/stores/playthroughs/__tests__/persistence.initialization.test.ts
+++ b/src/stores/playthroughs/__tests__/persistence.initialization.test.ts
@@ -158,11 +158,15 @@ describe("playthrough persistence initialization regression cases", () => {
   });
 
   it("uses deterministic fallback when IndexedDB load fails", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const state = createState();
 
     idbMocks.keys.mockRejectedValue(new Error("indexeddb unavailable"));
 
     await loadFromIndexedDB(state);
+    consoleErrorSpy.mockRestore();
 
     expect(state.playthroughs).toHaveLength(1);
     expect(state.activePlaythroughId).toBeDefined();

--- a/src/stores/playthroughs/__tests__/playthrough-export-analytics.test.ts
+++ b/src/stores/playthroughs/__tests__/playthrough-export-analytics.test.ts
@@ -283,6 +283,9 @@ describe("usePlaythroughImportExport lifecycle analytics", () => {
   });
 
   it("tracks schema-validation failures with normalized taxonomy", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const { input, createElementSpy } = mockInputCreation();
     const validJsonFile = {
       name: "save.json",
@@ -315,6 +318,7 @@ describe("usePlaythroughImportExport lifecycle analytics", () => {
       },
     );
 
+    consoleErrorSpy.mockRestore();
     createElementSpy.mockRestore();
   });
 });

--- a/tests/playthroughs/import-export.test.ts
+++ b/tests/playthroughs/import-export.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { usePlaythroughImportExport } from "@/hooks/usePlaythroughImportExport";
 import type { Playthrough } from "@/stores/playthroughs";
 import { playthroughActions } from "@/stores/playthroughs";
@@ -12,12 +12,21 @@ vi.mock("@/stores/playthroughs", () => ({
 }));
 
 describe("usePlaythroughImportExport", () => {
+  let anchorClickSpy: ReturnType<typeof vi.spyOn>;
+
   const emptyTeam = {
     members: [null, null, null, null, null, null],
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    anchorClickSpy.mockRestore();
   });
 
   describe("Export functionality", () => {

--- a/tests/playthroughs/mocks.ts
+++ b/tests/playthroughs/mocks.ts
@@ -5,6 +5,7 @@ vi.mock("idb-keyval", () => ({
   get: vi.fn().mockResolvedValue(undefined),
   set: vi.fn().mockResolvedValue(undefined),
   del: vi.fn().mockResolvedValue(undefined),
+  keys: vi.fn().mockResolvedValue([]),
   createStore: vi.fn(() => ({
     // Mock store object that can be passed as second parameter
     name: "mock-store",

--- a/tests/playthroughs/preferred-variants.test.ts
+++ b/tests/playthroughs/preferred-variants.test.ts
@@ -20,6 +20,19 @@ import {
 const mockedGetPreferredVariant = vi.mocked(getPreferredVariant);
 const mockedSetPreferredVariant = vi.mocked(setPreferredVariant);
 
+const createImageConstructorMock = () =>
+  vi.fn(function MockImage(this: {
+    setAttribute: ReturnType<typeof vi.fn>;
+    src: string;
+    onload: ReturnType<typeof vi.fn>;
+    onerror: ReturnType<typeof vi.fn>;
+  }) {
+    this.setAttribute = vi.fn();
+    this.src = "";
+    this.onload = vi.fn();
+    this.onerror = vi.fn();
+  });
+
 // Import shared setup and utilities
 import {
   act,
@@ -225,6 +238,9 @@ describe("Playthroughs Store - Preferred Variants (Global System)", () => {
     });
 
     it("should handle errors gracefully", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       const sprites = await import("../../src/lib/sprites");
       vi.mocked(sprites.getArtworkVariants).mockRejectedValue(
         new Error("Service error"),
@@ -233,6 +249,7 @@ describe("Playthroughs Store - Preferred Variants (Global System)", () => {
       await act(async () => {
         await playthroughActions.cycleArtworkVariant("route-1", false);
       });
+      consoleErrorSpy.mockRestore();
 
       // Should still update encounter timestamp
       const encounter =
@@ -244,13 +261,8 @@ describe("Playthroughs Store - Preferred Variants (Global System)", () => {
   describe("prefetchAdjacentVariants", () => {
     it("should prefetch adjacent variants for better UX", async () => {
       // Mock Image constructor to track prefetch calls
-      const mockImage = vi.fn().mockImplementation(() => ({
-        setAttribute: vi.fn(),
-        src: "",
-        onload: vi.fn(),
-        onerror: vi.fn(),
-      }));
-      global.Image = mockImage;
+      const mockImage = createImageConstructorMock();
+      global.Image = mockImage as unknown as typeof Image;
 
       // Mock generateSpriteUrl to return valid URLs
       const sprites = await import("../../src/lib/sprites");
@@ -272,13 +284,11 @@ describe("Playthroughs Store - Preferred Variants (Global System)", () => {
     });
 
     it("should handle errors gracefully during prefetching", async () => {
-      const mockImage = vi.fn().mockImplementation(() => ({
-        setAttribute: vi.fn(),
-        src: "",
-        onload: vi.fn(),
-        onerror: vi.fn(),
-      }));
-      global.Image = mockImage;
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const mockImage = createImageConstructorMock();
+      global.Image = mockImage as unknown as typeof Image;
 
       // Mock generateSpriteUrl to throw error
       const sprites = await import("../../src/lib/sprites");
@@ -296,6 +306,7 @@ describe("Playthroughs Store - Preferred Variants (Global System)", () => {
 
       // Wait for async prefetch to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
+      consoleWarnSpy.mockRestore();
 
       // Should not have called Image constructor because generateSpriteUrl throws
       expect(mockImage).not.toHaveBeenCalled();
@@ -316,6 +327,9 @@ describe("Playthroughs Store - Preferred Variants (Global System)", () => {
     });
 
     it("should preload variants for all encounters in the playthrough", async () => {
+      const consoleDebugSpy = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => {});
       const sprites = await import("../../src/lib/sprites");
       vi.mocked(sprites.getArtworkVariants).mockResolvedValue([
         "",
@@ -325,6 +339,7 @@ describe("Playthroughs Store - Preferred Variants (Global System)", () => {
       await act(async () => {
         await playthroughActions.preloadArtworkVariants();
       });
+      consoleDebugSpy.mockRestore();
 
       // Should have called getArtworkVariants for both encounters
       expect(vi.mocked(sprites.getArtworkVariants)).toHaveBeenCalledWith(25); // Single Pokémon
@@ -332,6 +347,12 @@ describe("Playthroughs Store - Preferred Variants (Global System)", () => {
     });
 
     it("should handle errors gracefully for individual encounters", async () => {
+      const consoleDebugSpy = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => {});
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
       const sprites = await import("../../src/lib/sprites");
       vi.mocked(sprites.getArtworkVariants)
         .mockResolvedValueOnce(["", "variant-1"]) // Single Pokémon
@@ -340,12 +361,17 @@ describe("Playthroughs Store - Preferred Variants (Global System)", () => {
       await act(async () => {
         await playthroughActions.preloadArtworkVariants();
       });
+      consoleDebugSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
 
       // Should still have called for both encounters despite one failing
       expect(vi.mocked(sprites.getArtworkVariants)).toHaveBeenCalledTimes(2);
     });
 
     it("should handle playthroughs with no encounters", async () => {
+      const consoleDebugSpy = vi
+        .spyOn(console, "debug")
+        .mockImplementation(() => {});
       // Create a new playthrough with no encounters
       const playthroughId = playthroughActions.createPlaythrough("Empty Run");
       await playthroughActions.setActivePlaythrough(playthroughId);
@@ -353,6 +379,7 @@ describe("Playthroughs Store - Preferred Variants (Global System)", () => {
       await act(async () => {
         await playthroughActions.preloadArtworkVariants();
       });
+      consoleDebugSpy.mockRestore();
 
       const sprites = await import("../../src/lib/sprites");
       expect(vi.mocked(sprites.getArtworkVariants)).not.toHaveBeenCalled();

--- a/tests/setup.react-hooks.ts
+++ b/tests/setup.react-hooks.ts
@@ -1,3 +1,23 @@
+import { beforeEach, vi } from "vitest";
+
+const indexedDbStore = new Map<string, unknown>();
+
+vi.mock("idb-keyval", () => ({
+  createStore: vi.fn(() => ({ name: "mock-store" })),
+  del: vi.fn(async (key: string) => {
+    indexedDbStore.delete(String(key));
+  }),
+  get: vi.fn(async (key: string) => indexedDbStore.get(String(key))),
+  keys: vi.fn(async () => Array.from(indexedDbStore.keys())),
+  set: vi.fn(async (key: string, value: unknown) => {
+    indexedDbStore.set(String(key), value);
+  }),
+}));
+
+beforeEach(() => {
+  indexedDbStore.clear();
+});
+
 function hasUsableLocalStorage() {
   if (typeof globalThis.localStorage === "undefined") {
     return false;


### PR DESCRIPTION
## Summary
- Suppress expected console output in tests that intentionally exercise failure and fallback paths.
- Add react-hooks test setup coverage for `idb-keyval` so store persistence tests do not hit missing jsdom IndexedDB.
- Fix test mocks that leaked custom props to DOM nodes or used non-constructible `Image` mocks.

## Validation
- `pnpm exec vitest run`
- `pnpm type-check`
- `pnpm test:run`
- `pnpm validate`

## Manual Testing
- Ran the full verbose Vitest suite and confirmed no stderr/stdout noise from the addressed cases.