### PR TITLE
fix(inf-140): default new runs to randomized

### DIFF
--- a/docs/adr/0001-default-new-playthroughs-to-randomized-mode.md
+++ b/docs/adr/0001-default-new-playthroughs-to-randomized-mode.md
@@ -1,0 +1,20 @@
+# Default New Playthroughs To Randomized Mode
+
+**Status:** accepted
+**Date:** 2026-05-08
+
+## Context
+
+Analytics shows randomized mode is the most-used game mode. New playthrough creation still defaults to classic mode, which makes the common path require an extra choice and makes accidental classic runs more likely.
+
+## Decision
+
+Default new playthroughs to randomized mode. Existing playthrough data stays unchanged, and explicit user game-mode choices during creation continue to override the default.
+
+## Alternatives Considered
+
+Keeping classic as the default preserves the historical behavior, but it no longer matches observed usage. Defaulting to the current active playthrough's mode keeps continuity between runs, but it can carry over an old choice when the user expects the recommended default.
+
+## Consequences
+
+Creating a playthrough without changing mode will create a randomized run. Existing imported, persisted, and active playthroughs should not be migrated by this decision, so compatibility work stays limited to new-run creation behavior and tests.

--- a/src/components/playthrough/CreatePlaythroughModal.tsx
+++ b/src/components/playthrough/CreatePlaythroughModal.tsx
@@ -16,20 +16,18 @@ interface CreatePlaythroughModalProps {
   isOpen: boolean;
   onClose: () => void;
   onCreate: (name: string, gameMode: GameMode) => Promise<void>;
-  currentGameMode: GameMode;
 }
 
 export default function CreatePlaythroughModal({
   isOpen,
   onClose,
   onCreate,
-  currentGameMode,
 }: CreatePlaythroughModalProps) {
   const [newPlaythroughName, setNewPlaythroughName] = useState("");
   const [selectedGameModeOverride, setSelectedGameModeOverride] =
     useState<GameMode | null>(null);
   const playthroughNameInputRef = useRef<HTMLInputElement>(null);
-  const selectedGameMode = selectedGameModeOverride ?? currentGameMode;
+  const selectedGameMode = selectedGameModeOverride ?? "randomized";
 
   useEffect(() => {
     if (isOpen === false) {

--- a/src/components/playthrough/CreatePlaythroughModal.tsx
+++ b/src/components/playthrough/CreatePlaythroughModal.tsx
@@ -10,7 +10,10 @@ import clsx from "clsx";
 import { HelpCircle, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { CursorTooltip } from "@/components/CursorTooltip";
-import type { GameMode } from "@/stores/playthroughs";
+import {
+  DEFAULT_NEW_PLAYTHROUGH_GAME_MODE,
+  type GameMode,
+} from "@/stores/playthroughs";
 
 interface CreatePlaythroughModalProps {
   isOpen: boolean;
@@ -27,7 +30,8 @@ export default function CreatePlaythroughModal({
   const [selectedGameModeOverride, setSelectedGameModeOverride] =
     useState<GameMode | null>(null);
   const playthroughNameInputRef = useRef<HTMLInputElement>(null);
-  const selectedGameMode = selectedGameModeOverride ?? "randomized";
+  const selectedGameMode =
+    selectedGameModeOverride ?? DEFAULT_NEW_PLAYTHROUGH_GAME_MODE;
 
   useEffect(() => {
     if (isOpen === false) {

--- a/src/components/playthrough/PlaythroughSelector.tsx
+++ b/src/components/playthrough/PlaythroughSelector.tsx
@@ -24,7 +24,6 @@ import {
   playthroughActions,
   useActivePlaythrough,
   useAllPlaythroughs,
-  useGameMode,
   useIsLoading,
 } from "@/stores/playthroughs";
 import CreatePlaythroughModal from "./CreatePlaythroughModal";
@@ -62,7 +61,6 @@ export default function PlaythroughSelector({
   standalone = false,
 }: PlaythroughSelectorProps) {
   const activePlaythrough = useActivePlaythrough();
-  const currentGameMode = useGameMode();
   const isLoading = useIsLoading();
   const [showCreateInput, setShowCreateInput] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -505,7 +503,6 @@ export default function PlaythroughSelector({
           const newId = playthroughActions.createPlaythrough(name, gameMode);
           await playthroughActions.setActivePlaythrough(newId);
         }}
-        currentGameMode={currentGameMode}
       />
 
       {/* Delete confirmation dialog */}

--- a/src/components/playthrough/__tests__/CreatePlaythroughModal.test.tsx
+++ b/src/components/playthrough/__tests__/CreatePlaythroughModal.test.tsx
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CreatePlaythroughModal from "../CreatePlaythroughModal";
+
+vi.mock("@/components/CursorTooltip", () => ({
+  CursorTooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe("CreatePlaythroughModal", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("creates a randomized playthrough when game mode is unchanged", async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <CreatePlaythroughModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onCreate={onCreate}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Playthrough Name"), {
+      target: { value: "Randomized Run" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Playthrough" }));
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith("Randomized Run", "randomized");
+    });
+  });
+});

--- a/src/stores/playthroughs/__tests__/default-playthrough.test.ts
+++ b/src/stores/playthroughs/__tests__/default-playthrough.test.ts
@@ -8,7 +8,7 @@ describe("createDefaultPlaythrough", () => {
 
     expect(playthrough.id.startsWith("playthrough_")).toBe(true);
     expect(playthrough.name).toBe("Playthrough");
-    expect(playthrough.gameMode).toBe("classic");
+    expect(playthrough.gameMode).toBe("randomized");
     expect(playthrough.version).toBe("1.0.0");
     expect(playthrough.team.members).toHaveLength(6);
     expect(playthrough.createdAt).toBe(playthrough.updatedAt);

--- a/src/stores/playthroughs/__tests__/store.active-playthrough.test.ts
+++ b/src/stores/playthroughs/__tests__/store.active-playthrough.test.ts
@@ -47,4 +47,24 @@ describe("active playthrough lookup", () => {
     expect(playthroughsStore.activePlaythroughId).toBeUndefined();
     expect(getActivePlaythrough()).toBeNull();
   });
+
+  it("defaults new playthroughs to randomized mode", () => {
+    const id = createPlaythrough("Randomized Run");
+
+    const playthrough = playthroughsStore.playthroughs.find(
+      (run) => run.id === id,
+    );
+
+    expect(playthrough?.gameMode).toBe("randomized");
+  });
+
+  it("preserves an explicit game mode choice for new playthroughs", () => {
+    const id = createPlaythrough("Classic Run", "classic");
+
+    const playthrough = playthroughsStore.playthroughs.find(
+      (run) => run.id === id,
+    );
+
+    expect(playthrough?.gameMode).toBe("classic");
+  });
 });

--- a/src/stores/playthroughs/defaultPlaythrough.ts
+++ b/src/stores/playthroughs/defaultPlaythrough.ts
@@ -1,8 +1,7 @@
 import { generatePrefixedId } from "@/utils/id";
-import type { Playthrough } from "./types";
+import { DEFAULT_NEW_PLAYTHROUGH_GAME_MODE, type Playthrough } from "./types";
 
 const DEFAULT_PLAYTHROUGH_NAME = "Playthrough";
-const DEFAULT_GAME_MODE = "randomized" as const;
 const DEFAULT_PLAYTHROUGH_VERSION = "1.0.0";
 
 export const createDefaultPlaythrough = (): Playthrough => {
@@ -13,7 +12,7 @@ export const createDefaultPlaythrough = (): Playthrough => {
     name: DEFAULT_PLAYTHROUGH_NAME,
     encounters: {},
     team: { members: Array.from({ length: 6 }, () => null) },
-    gameMode: DEFAULT_GAME_MODE,
+    gameMode: DEFAULT_NEW_PLAYTHROUGH_GAME_MODE,
     version: DEFAULT_PLAYTHROUGH_VERSION,
     createdAt: timestamp,
     updatedAt: timestamp,

--- a/src/stores/playthroughs/defaultPlaythrough.ts
+++ b/src/stores/playthroughs/defaultPlaythrough.ts
@@ -2,7 +2,7 @@ import { generatePrefixedId } from "@/utils/id";
 import type { Playthrough } from "./types";
 
 const DEFAULT_PLAYTHROUGH_NAME = "Playthrough";
-const DEFAULT_GAME_MODE = "classic" as const;
+const DEFAULT_GAME_MODE = "randomized" as const;
 const DEFAULT_PLAYTHROUGH_VERSION = "1.0.0";
 
 export const createDefaultPlaythrough = (): Playthrough => {

--- a/src/stores/playthroughs/index.ts
+++ b/src/stores/playthroughs/index.ts
@@ -95,6 +95,7 @@ export type {
   PlaythroughsState,
 } from "./types";
 export {
+  DEFAULT_NEW_PLAYTHROUGH_GAME_MODE,
   EncounterDataSchema,
   ExportedPlaythroughSchema,
   GameModeSchema,

--- a/src/stores/playthroughs/store.ts
+++ b/src/stores/playthroughs/store.ts
@@ -85,7 +85,7 @@ setPlaythroughsStore(playthroughsStore);
 
 const createPlaythrough = (
   name: string,
-  gameMode: GameMode = "classic",
+  gameMode: GameMode = "randomized",
 ): string => {
   const hasExistingPlaythroughs = playthroughsStore.playthroughs.length > 0;
 

--- a/src/stores/playthroughs/store.ts
+++ b/src/stores/playthroughs/store.ts
@@ -20,7 +20,12 @@ import {
   getCurrentTimestamp,
   setPlaythroughsStore,
 } from "./playthroughState";
-import type { GameMode, Playthrough, PlaythroughsState } from "./types";
+import {
+  DEFAULT_NEW_PLAYTHROUGH_GAME_MODE,
+  type GameMode,
+  type Playthrough,
+  type PlaythroughsState,
+} from "./types";
 
 // Default state
 const defaultState: PlaythroughsState = {
@@ -85,7 +90,7 @@ setPlaythroughsStore(playthroughsStore);
 
 const createPlaythrough = (
   name: string,
-  gameMode: GameMode = "randomized",
+  gameMode: GameMode = DEFAULT_NEW_PLAYTHROUGH_GAME_MODE,
 ): string => {
   const hasExistingPlaythroughs = playthroughsStore.playthroughs.length > 0;
 

--- a/src/stores/playthroughs/types.ts
+++ b/src/stores/playthroughs/types.ts
@@ -7,6 +7,8 @@ export const GameModeSchema = z.enum(["classic", "remix", "randomized"]);
 
 export type GameMode = z.infer<typeof GameModeSchema>;
 
+export const DEFAULT_NEW_PLAYTHROUGH_GAME_MODE: GameMode = "randomized";
+
 // Team member schema - represents a single team member
 export const TeamMemberSchema = z.object({
   headPokemonUid: z.string(), // Reference to head Pokémon by UID

--- a/tests/playthroughs/custom-locations.test.ts
+++ b/tests/playthroughs/custom-locations.test.ts
@@ -420,7 +420,7 @@ describe("Playthroughs Store - Custom Locations", () => {
         // Verify the playthrough structure is intact
         expect(activePlaythrough?.id).toBeTruthy();
         expect(activePlaythrough?.name).toBe("Test Run");
-        expect(activePlaythrough?.gameMode).toBe("classic");
+        expect(activePlaythrough?.gameMode).toBe("randomized");
       }
     });
   });

--- a/tests/playthroughs/hooks.test.ts
+++ b/tests/playthroughs/hooks.test.ts
@@ -513,12 +513,12 @@ describe("Playthroughs Store - React Hooks", () => {
   });
 
   describe("Playthrough Creation with Game Modes", () => {
-    it("should create playthrough with classic mode by default", () => {
+    it("should create playthrough with randomized mode by default", () => {
       const playthroughId = playthroughActions.createPlaythrough("Default Run");
       const playthrough = playthroughsStore.playthroughs.find(
         (p) => p.id === playthroughId,
       );
-      expect(playthrough?.gameMode).toBe("classic");
+      expect(playthrough?.gameMode).toBe("randomized");
     });
 
     it("should create playthrough with specified classic mode", () => {


### PR DESCRIPTION
## Summary
Default new playthrough creation to randomized mode because analytics shows it is the most-used mode. Existing run data and explicit game-mode choices remain unchanged.

## Changes
- Change store/default-playthrough creation defaults to `randomized`.
- Make the create playthrough modal use randomized as its initial mode.
- Add an ADR for the analytics-backed default-mode decision.
- Update tests for the new default and explicit mode preservation.

## Testing
- `pnpm type-check`
- `pnpm test:run`
- `pnpm validate`

## Manual Testing
- Open the create playthrough modal.
- Enter a playthrough name without changing game mode.
- Create the playthrough and verify it uses randomized mode.
- Create another playthrough after selecting classic and verify the explicit choice is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New playthroughs now default to randomized mode instead of classic mode

* **Documentation**
  * Added architecture decision record documenting the default randomized mode for new playthroughs, while preserving existing playthrough data unchanged and allowing manual mode selection during creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->