### PR TITLE
fix(inf-99): gate scraper encounter outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ pnpm data:refresh
 pnpm spritesheet
 ```
 
+Scraper maintenance checks:
+
+```bash
+pnpm test:run tests/scrape-wild-encounters-wikitext.test.ts
+pnpm scrape:encounters
+pnpm validate:route-articles
+```
+
 ## Validation Workflow
 
 For behavior or run-state changes, run checks in this order:

--- a/openspec/changes/scraping-validation-layer/.openspec.yaml
+++ b/openspec/changes/scraping-validation-layer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/scraping-validation-layer/design.md
+++ b/openspec/changes/scraping-validation-layer/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The scraper pipeline fetches external wiki content, maps it into project data shapes, and writes generated JSON files that application runtime treats as trusted input. Current script-level checks catch some parse failures, but the output boundary needs a consistent validation contract before persistence and a migration parity gate when scraper implementations change.
+
+The implementation must keep script output deterministic, preserve existing generated data semantics, and fail loudly with actionable paths for schema or identity errors.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Validate scraper output payloads at the write boundary before generated files are persisted.
+- Preserve issue/path details for schema failures so broken source rows can be diagnosed quickly.
+- Gate migration-sensitive scraper changes against baseline aggregates for route count, encounter count, Pokemon ID integrity, and encounter type integrity.
+- Keep validation commands visible for future scraper maintenance.
+
+**Non-Goals:**
+
+- Rebuild every scraper script in one pass.
+- Change runtime encounter contracts or generated data semantics.
+- Add a new dependency or external validation service.
+- Replace existing targeted parser tests.
+
+## Decisions
+
+1. Use Zod at scraper output boundaries.
+
+   Zod is already a project dependency and matches the repository boundary-validation pattern. This avoids adding another schema tool while still preserving structured issue paths. Alternative considered: handwritten validators. Handwritten checks are smaller for one shape but become inconsistent across scraper outputs and are easier to under-specify.
+
+2. Validate before writes, not after writes.
+
+   The write boundary is the last point where raw scraped output can be rejected without mutating trusted generated files. Alternative considered: validate generated files in a separate command after the scraper completes. That detects failures later but can leave the working tree with invalid output.
+
+3. Keep parity checks aggregate-based during migration.
+
+   Route count, encounter count, Pokemon ID set, and encounter type set catch structural and identity regressions without blocking intentional ordering or formatting changes. Alternative considered: full JSON equality. Full equality is too strict for scraper refactors that preserve semantics while improving deterministic ordering or formatting.
+
+4. Use existing Pokemon identity maps for ID integrity.
+
+   The project already has canonical Pokemon ID/name data loaders for scraper scripts. Reusing them keeps identity validation aligned with current generated data assumptions. Alternative considered: only enforce positive integer IDs. That would miss unknown or unmapped Pokemon IDs.
+
+## Risks / Trade-offs
+
+- Baseline drift can make parity checks noisy if upstream wiki data legitimately changes -> Mitigation: review the parity failure, update generated outputs intentionally, and rerun targeted scraper validation before broader checks.
+- Aggregate parity can miss route-local movement when global counts and sets stay equal -> Mitigation: retain focused parser tests for route scoping and add route-specific tests for known migration risks.
+- Validating only one scraper first leaves other generated outputs with older validation patterns -> Mitigation: keep helpers local and migrate additional scraper outputs incrementally when their scripts change.
+- Network-backed scraper validation can be flaky when wiki access is unavailable -> Mitigation: keep parser/unit validation separate from network refresh commands and run the network scraper only when output behavior is in scope.

--- a/openspec/changes/scraping-validation-layer/proposal.md
+++ b/openspec/changes/scraping-validation-layer/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Scraper outputs are trusted as generated game data, but malformed fetched or parsed payloads can currently reach persistence unless each script hand-rolls complete validation. A shared validation layer makes scraper migrations safer by failing before writes and by proving aggregate parity against the current baseline when expected.
+
+## What Changes
+
+- Add explicit schema validation for scraper output payloads before generated files are written.
+- Add parity gates for migration-safe scraper outputs, including route count, encounter count, Pokemon ID integrity, and encounter type integrity.
+- Document the maintenance validation commands needed when changing scraper logic or refreshing generated outputs.
+- No breaking runtime API changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `scraper-output-validation`: Contracts for validating generated scraper payloads and gating migration parity before persistence.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected code: scraper scripts under `scripts/`, focused scraper tests under `tests/`, and maintenance documentation.
+- Affected data: generated encounter data files are protected by validation gates, but this change should not require semantic data rewrites.
+- Dependencies: uses existing Zod dependency; no new package required.
+- Systems: local scraper refresh workflow and CI validation for scraper-related changes.

--- a/openspec/changes/scraping-validation-layer/specs/scraper-output-validation/spec.md
+++ b/openspec/changes/scraping-validation-layer/specs/scraper-output-validation/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Scraper outputs validate before persistence
+
+The system SHALL validate generated scraper payloads against an explicit schema before writing generated data files.
+
+#### Scenario: Valid payload is persisted
+
+- **WHEN** a scraper produces a payload that satisfies the output schema
+- **THEN** the scraper writes the generated data file
+
+#### Scenario: Invalid payload is rejected before write
+
+- **WHEN** a scraper produces a payload that violates the output schema
+- **THEN** the scraper fails before writing the generated data file
+
+#### Scenario: Schema failure includes issue path
+
+- **WHEN** a scraper payload fails schema validation
+- **THEN** the failure message includes the invalid payload path and validation message
+
+### Requirement: Encounter output validates Pokemon ID integrity
+
+The system SHALL reject generated encounter outputs that reference Pokemon IDs missing from the canonical Pokemon identity map.
+
+#### Scenario: Unknown Pokemon ID is rejected
+
+- **WHEN** generated encounter output contains a Pokemon ID absent from the canonical Pokemon identity map
+- **THEN** the scraper fails before writing the generated encounter file
+
+### Requirement: Encounter output validates encounter type integrity
+
+The system SHALL reject generated encounter outputs that contain encounter types outside the supported encounter type set.
+
+#### Scenario: Unknown encounter type is rejected
+
+- **WHEN** generated encounter output contains an unsupported encounter type
+- **THEN** the scraper fails before writing the generated encounter file
+
+### Requirement: Encounter scraper migration preserves aggregate parity
+
+The system SHALL compare generated encounter output against the current baseline before persistence when migration parity is required.
+
+#### Scenario: Aggregate parity passes
+
+- **WHEN** generated encounter output matches the baseline route count, encounter count, Pokemon ID set, and encounter type set
+- **THEN** the scraper may write the generated encounter file
+
+#### Scenario: Route count parity fails
+
+- **WHEN** generated encounter output has a different route count than the baseline
+- **THEN** the scraper fails before writing the generated encounter file
+
+#### Scenario: Encounter count parity fails
+
+- **WHEN** generated encounter output has a different encounter count than the baseline
+- **THEN** the scraper fails before writing the generated encounter file
+
+#### Scenario: Pokemon ID parity fails
+
+- **WHEN** generated encounter output has a different Pokemon ID set than the baseline
+- **THEN** the scraper fails before writing the generated encounter file
+
+#### Scenario: Encounter type parity fails
+
+- **WHEN** generated encounter output has a different encounter type set than the baseline
+- **THEN** the scraper fails before writing the generated encounter file
+
+### Requirement: Scraper validation workflow is documented
+
+The system SHALL document the targeted scraper validation commands used during scraper maintenance.
+
+#### Scenario: Maintainer checks scraper changes
+
+- **WHEN** a maintainer changes scraper validation or encounter scraping behavior
+- **THEN** the documentation lists the focused scraper test, encounter scraper refresh, and route article coverage commands

--- a/openspec/changes/scraping-validation-layer/tasks.md
+++ b/openspec/changes/scraping-validation-layer/tasks.md
@@ -1,0 +1,26 @@
+## 1. Validation Boundary
+
+- [x] 1.1 Define encounter output schemas for route names, Pokemon IDs, encounter types, and non-empty encounter lists.
+- [x] 1.2 Add fail-fast validation before generated encounter files are written.
+- [x] 1.3 Preserve schema issue paths and messages in thrown validation errors.
+- [x] 1.4 Add Pokemon ID integrity validation against the canonical Pokemon identity map.
+
+## 2. Parity Gates
+
+- [x] 2.1 Build encounter parity summaries for route count, encounter count, Pokemon ID set, and encounter type set.
+- [x] 2.2 Compare generated encounter output against baseline output before persistence.
+- [x] 2.3 Fail before writing when any parity aggregate diverges.
+
+## 3. Tests And Documentation
+
+- [x] 3.1 Add focused tests for invalid Pokemon IDs and parity mismatch failures.
+- [x] 3.2 Add or retain parser coverage for route scoping risks that aggregate parity cannot detect.
+- [x] 3.3 Document scraper maintenance commands for focused tests, encounter refresh, and route article coverage.
+
+## 4. Validation
+
+- [x] 4.1 Run focused scraper tests.
+- [x] 4.2 Run `pnpm type-check`.
+- [x] 4.3 Run `pnpm validate`.
+- [x] 4.4 Run `pnpm test:run` when scope touches shared scraper behavior.
+- [x] 4.5 Run `pnpm scrape:encounters` when validating parity against live scraper output.

--- a/scripts/scrape-wild-encounters.ts
+++ b/scripts/scrape-wild-encounters.ts
@@ -18,6 +18,7 @@ const WILD_ENCOUNTERS_REMIX_URL =
 
 const ROUTE_ARTICLE_BATCH_SIZE = 6;
 const ROUTE_ARTICLE_BACKFILL_OVERRIDES = ["Route 2", "Route 10"] as const;
+const ENCOUNTER_PARITY_REFRESH_ENV = "SCRAPE_ENCOUNTERS_REFRESH";
 
 const WILD_ENCOUNTER_TYPES = [
   "grass",
@@ -183,6 +184,10 @@ type EncounterParitySummary = {
   encounterTypes: string;
 };
 
+type ValidateEncounterOutputOptions = {
+  skipParity?: boolean;
+};
+
 function formatZodIssues(error: z.ZodError): string {
   return error.issues
     .map((issue) => {
@@ -217,7 +222,7 @@ export function assertEncounterPayload(
   routes: RouteEncounters[],
   pokemonNameMap: PokemonNameMap,
   label: string,
-): void {
+): RouteEncounters[] {
   const parseResult = RouteEncountersSchema.safeParse(routes);
   if (parseResult.success === false) {
     throw new Error(
@@ -225,7 +230,8 @@ export function assertEncounterPayload(
     );
   }
 
-  const invalidIds = routes.flatMap((route) =>
+  const parsedRoutes = parseResult.data;
+  const invalidIds = parsedRoutes.flatMap((route) =>
     route.encounters
       .filter(
         (encounter) =>
@@ -239,6 +245,12 @@ export function assertEncounterPayload(
       `${label} failed Pokemon ID integrity validation: ${invalidIds.join(", ")}`,
     );
   }
+
+  return parsedRoutes;
+}
+
+function formatParityValue(value: string | number): string | number {
+  return value === "" ? "<empty>" : value;
 }
 
 export function assertEncounterParity(
@@ -252,7 +264,7 @@ export function assertEncounterParity(
     const baselineValue = baselineSummary[key as keyof EncounterParitySummary];
     return nextValue === baselineValue
       ? []
-      : `${key}: baseline=${baselineValue || "<empty>"} next=${nextValue || "<empty>"}`;
+      : `${key}: baseline=${formatParityValue(baselineValue)} next=${formatParityValue(nextValue)}`;
   });
 
   if (mismatches.length > 0) {
@@ -267,8 +279,16 @@ async function validateEncounterOutputBeforeWrite(
   nextRoutes: RouteEncounters[],
   pokemonNameMap: PokemonNameMap,
   label: string,
+  options: ValidateEncounterOutputOptions = {},
 ): Promise<void> {
   assertEncounterPayload(nextRoutes, pokemonNameMap, label);
+
+  if (options.skipParity === true) {
+    ConsoleFormatter.warn(
+      `${label} baseline parity skipped because ${ENCOUNTER_PARITY_REFRESH_ENV}=1`,
+    );
+    return;
+  }
 
   const baselineJson = await fs.readFile(outputPath, "utf-8");
   const baselineRoutes = RouteEncountersSchema.safeParse(
@@ -872,6 +892,7 @@ function findParentLocation(
 
 async function scrapeWildEncounters(
   url: string,
+  pokemonNameMap: PokemonNameMap,
   isRemix: boolean = false,
 ): Promise<RouteEncounters[]> {
   ConsoleFormatter.printHeader(
@@ -886,7 +907,6 @@ async function scrapeWildEncounters(
       () => fetchWikiPageWikitext(url),
     );
 
-    const pokemonNameMap = await loadPokemonNameMap();
     const routes = parseWildEncounterRoutesFromWikitext(
       wikitext,
       pokemonNameMap,
@@ -932,14 +952,23 @@ async function main() {
     await fs.mkdir(classicDir, { recursive: true });
     await fs.mkdir(remixDir, { recursive: true });
 
+    const pokemonNameMap = await loadPokemonNameMap();
     const [classicRoutes, remixRoutes] = await Promise.all([
       (async () => {
         ConsoleFormatter.info("Scraping Classic Mode encounters...");
-        return scrapeWildEncounters(WILD_ENCOUNTERS_CLASSIC_URL, false);
+        return scrapeWildEncounters(
+          WILD_ENCOUNTERS_CLASSIC_URL,
+          pokemonNameMap,
+          false,
+        );
       })(),
       (async () => {
         ConsoleFormatter.info("Scraping Remix Mode encounters...");
-        return scrapeWildEncounters(WILD_ENCOUNTERS_REMIX_URL, true);
+        return scrapeWildEncounters(
+          WILD_ENCOUNTERS_REMIX_URL,
+          pokemonNameMap,
+          true,
+        );
       })(),
     ]);
 
@@ -947,7 +976,7 @@ async function main() {
     ConsoleFormatter.info("Saving encounter data to files...");
     const classicPath = path.join(classicDir, "encounters.json");
     const remixPath = path.join(remixDir, "encounters.json");
-    const pokemonNameMap = await loadPokemonNameMap();
+    const skipParity = process.env[ENCOUNTER_PARITY_REFRESH_ENV] === "1";
 
     await Promise.all([
       validateEncounterOutputBeforeWrite(
@@ -955,12 +984,14 @@ async function main() {
         classicRoutes,
         pokemonNameMap,
         "Classic encounters",
+        { skipParity },
       ),
       validateEncounterOutputBeforeWrite(
         remixPath,
         remixRoutes,
         pokemonNameMap,
         "Remix encounters",
+        { skipParity },
       ),
     ]);
 

--- a/scripts/scrape-wild-encounters.ts
+++ b/scripts/scrape-wild-encounters.ts
@@ -3,6 +3,7 @@
 import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { z } from "zod";
 import type { EncounterType } from "./types/encounters";
 import { ConsoleFormatter } from "./utils/console-utils";
 import { loadPokemonNameMap } from "./utils/data-loading-utils";
@@ -157,6 +158,142 @@ export interface PokemonEncounter {
 interface RouteEncounters {
   routeName: string;
   encounters: PokemonEncounter[];
+}
+
+const EncounterTypeSchema = z.enum([
+  "grass",
+  "surf",
+  "fishing",
+  "special",
+  "cave",
+  "rock_smash",
+  "pokeradar",
+]);
+
+const RouteEncountersSchema = z.array(
+  z.object({
+    routeName: z.string().trim().min(1),
+    encounters: z
+      .array(
+        z.object({
+          pokemonId: z.number().int().positive(),
+          encounterType: EncounterTypeSchema,
+        }),
+      )
+      .min(1),
+  }),
+);
+
+type EncounterParitySummary = {
+  routeCount: number;
+  encounterCount: number;
+  pokemonIds: string;
+  encounterTypes: string;
+};
+
+function formatZodIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const pathLabel = issue.path.length > 0 ? issue.path.join(".") : "root";
+      return `${pathLabel}: ${issue.message}`;
+    })
+    .join("; ");
+}
+
+function summarizeEncounterParity(
+  routes: RouteEncounters[],
+): EncounterParitySummary {
+  const encounters = routes.flatMap((route) => route.encounters);
+
+  return {
+    routeCount: routes.length,
+    encounterCount: encounters.length,
+    pokemonIds: Array.from(
+      new Set(encounters.map((encounter) => encounter.pokemonId)),
+    )
+      .sort((a, b) => a - b)
+      .join(","),
+    encounterTypes: Array.from(
+      new Set(encounters.map((encounter) => encounter.encounterType)),
+    )
+      .sort()
+      .join(","),
+  };
+}
+
+export function assertEncounterPayload(
+  routes: RouteEncounters[],
+  pokemonNameMap: PokemonNameMap,
+  label: string,
+): void {
+  const parseResult = RouteEncountersSchema.safeParse(routes);
+  if (parseResult.success === false) {
+    throw new Error(
+      `${label} failed encounter schema validation: ${formatZodIssues(parseResult.error)}`,
+    );
+  }
+
+  const invalidIds = routes.flatMap((route) =>
+    route.encounters
+      .filter(
+        (encounter) =>
+          pokemonNameMap.idToName.has(encounter.pokemonId) === false,
+      )
+      .map((encounter) => `${route.routeName}:${encounter.pokemonId}`),
+  );
+
+  if (invalidIds.length > 0) {
+    throw new Error(
+      `${label} failed Pokemon ID integrity validation: ${invalidIds.join(", ")}`,
+    );
+  }
+}
+
+export function assertEncounterParity(
+  nextRoutes: RouteEncounters[],
+  baselineRoutes: RouteEncounters[],
+  label: string,
+): void {
+  const nextSummary = summarizeEncounterParity(nextRoutes);
+  const baselineSummary = summarizeEncounterParity(baselineRoutes);
+  const mismatches = Object.entries(nextSummary).flatMap(([key, nextValue]) => {
+    const baselineValue = baselineSummary[key as keyof EncounterParitySummary];
+    return nextValue === baselineValue
+      ? []
+      : `${key}: baseline=${baselineValue || "<empty>"} next=${nextValue || "<empty>"}`;
+  });
+
+  if (mismatches.length > 0) {
+    throw new Error(
+      `${label} failed encounter parity validation: ${mismatches.join("; ")}`,
+    );
+  }
+}
+
+async function validateEncounterOutputBeforeWrite(
+  outputPath: string,
+  nextRoutes: RouteEncounters[],
+  pokemonNameMap: PokemonNameMap,
+  label: string,
+): Promise<void> {
+  assertEncounterPayload(nextRoutes, pokemonNameMap, label);
+
+  const baselineJson = await fs.readFile(outputPath, "utf-8");
+  const baselineRoutes = RouteEncountersSchema.safeParse(
+    JSON.parse(baselineJson),
+  );
+  if (baselineRoutes.success === false) {
+    throw new Error(
+      `${label} baseline failed encounter schema validation: ${formatZodIssues(baselineRoutes.error)}`,
+    );
+  }
+
+  assertEncounterPayload(
+    baselineRoutes.data,
+    pokemonNameMap,
+    `${label} baseline`,
+  );
+  assertEncounterParity(nextRoutes, baselineRoutes.data, label);
 }
 
 export function getLocationWikiUrl(locationName: string): string {
@@ -818,6 +955,22 @@ async function main() {
     ConsoleFormatter.info("Saving encounter data to files...");
     const classicPath = path.join(classicDir, "encounters.json");
     const remixPath = path.join(remixDir, "encounters.json");
+    const pokemonNameMap = await loadPokemonNameMap();
+
+    await Promise.all([
+      validateEncounterOutputBeforeWrite(
+        classicPath,
+        classicRoutes,
+        pokemonNameMap,
+        "Classic encounters",
+      ),
+      validateEncounterOutputBeforeWrite(
+        remixPath,
+        remixRoutes,
+        pokemonNameMap,
+        "Remix encounters",
+      ),
+    ]);
 
     await Promise.all([
       fs.writeFile(classicPath, JSON.stringify(classicRoutes, null, 2)),

--- a/scripts/scrape-wild-encounters.ts
+++ b/scripts/scrape-wild-encounters.ts
@@ -19,14 +19,14 @@ const WILD_ENCOUNTERS_REMIX_URL =
 const ROUTE_ARTICLE_BATCH_SIZE = 6;
 const ROUTE_ARTICLE_BACKFILL_OVERRIDES = ["Route 2", "Route 10"] as const;
 
-const WILD_ENCOUNTER_TYPES: readonly EncounterType[] = [
+const WILD_ENCOUNTER_TYPES = [
   "grass",
   "cave",
   "rock_smash",
   "surf",
   "fishing",
   "pokeradar",
-];
+] as const satisfies readonly EncounterType[];
 
 const WIKITEXT_ROUTE_HEADING_PATTERN = /^'''(.+?)'''$/;
 const ENCOUNTER_TEMPLATE_PATTERN =
@@ -105,7 +105,7 @@ export function detectEncounterType(text: string): EncounterType | null {
 }
 
 function isWildEncounterType(encounterType: EncounterType): boolean {
-  return WILD_ENCOUNTER_TYPES.includes(encounterType);
+  return WILD_ENCOUNTER_TYPES.some((wildType) => wildType === encounterType);
 }
 
 function deduplicateEncounters(
@@ -160,22 +160,14 @@ interface RouteEncounters {
   encounters: PokemonEncounter[];
 }
 
-const EncounterTypeSchema = z.enum([
-  "grass",
-  "surf",
-  "fishing",
-  "special",
-  "cave",
-  "rock_smash",
-  "pokeradar",
-]);
+const EncounterTypeSchema = z.enum(WILD_ENCOUNTER_TYPES);
 
 const RouteEncountersSchema = z.array(
-  z.object({
+  z.strictObject({
     routeName: z.string().trim().min(1),
     encounters: z
       .array(
-        z.object({
+        z.strictObject({
           pokemonId: z.number().int().positive(),
           encounterType: EncounterTypeSchema,
         }),

--- a/scripts/validate-route-article-coverage.ts
+++ b/scripts/validate-route-article-coverage.ts
@@ -8,6 +8,7 @@ import { ConsoleFormatter } from "./utils/console-utils";
 import { loadPokemonNameMap } from "./utils/data-loading-utils";
 
 const ROUTE_VALIDATION_BATCH_SIZE = 6;
+const ROUTES_WITHOUT_ARTICLE_WILD_ROWS = new Set(["Route 10"]);
 
 interface PokemonEncounter {
   pokemonId: number;
@@ -58,7 +59,10 @@ function buildValidationFailure(
 ): RouteValidationFailure | null {
   const reasons: string[] = [];
 
-  if (articleEncounters.length === 0) {
+  if (
+    articleEncounters.length === 0 &&
+    ROUTES_WITHOUT_ARTICLE_WILD_ROWS.has(routeName) === false
+  ) {
     reasons.push("article has no wild encounter rows");
   }
 

--- a/tests/scrape-wild-encounters-wikitext.test.ts
+++ b/tests/scrape-wild-encounters-wikitext.test.ts
@@ -125,6 +125,37 @@ describe("Wild encounter wikitext parser", () => {
     ).toThrow(/Pokemon ID integrity/);
   });
 
+  it("fails validation when wild encounter output contains special encounters", () => {
+    const payload = JSON.parse(
+      JSON.stringify([
+        {
+          routeName: "Route 1",
+          encounters: [{ pokemonId: 16, encounterType: "special" }],
+        },
+      ]),
+    );
+
+    expect(() =>
+      assertEncounterPayload(payload, pokemonNameMap, "unit test encounters"),
+    ).toThrow(/encounterType/);
+  });
+
+  it("fails validation when scraped payloads contain unexpected keys", () => {
+    const payload = JSON.parse(
+      JSON.stringify([
+        {
+          routeName: "Route 1",
+          source: "wiki",
+          encounters: [{ pokemonId: 16, encounterType: "grass" }],
+        },
+      ]),
+    );
+
+    expect(() =>
+      assertEncounterPayload(payload, pokemonNameMap, "unit test encounters"),
+    ).toThrow(/Unrecognized key/);
+  });
+
   it("fails parity when route and encounter aggregates diverge", () => {
     expect(() =>
       assertEncounterParity(

--- a/tests/scrape-wild-encounters-wikitext.test.ts
+++ b/tests/scrape-wild-encounters-wikitext.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  assertEncounterParity,
+  assertEncounterPayload,
   parseEncounterTemplatesFromWikitext,
   parseWildEncounterRoutesFromWikitext,
 } from "../scripts/scrape-wild-encounters";
@@ -106,5 +108,44 @@ describe("Wild encounter wikitext parser", () => {
     expect(routes[0]?.encounters).toEqual([
       { pokemonId: 16, encounterType: "grass" },
     ]);
+  });
+
+  it("fails validation when scraped payloads contain invalid Pokemon IDs", () => {
+    expect(() =>
+      assertEncounterPayload(
+        [
+          {
+            routeName: "Route 1",
+            encounters: [{ pokemonId: 9999, encounterType: "grass" }],
+          },
+        ],
+        pokemonNameMap,
+        "unit test encounters",
+      ),
+    ).toThrow(/Pokemon ID integrity/);
+  });
+
+  it("fails parity when route and encounter aggregates diverge", () => {
+    expect(() =>
+      assertEncounterParity(
+        [
+          {
+            routeName: "Route 1",
+            encounters: [{ pokemonId: 16, encounterType: "grass" }],
+          },
+          {
+            routeName: "Route 2",
+            encounters: [{ pokemonId: 27, encounterType: "cave" }],
+          },
+        ],
+        [
+          {
+            routeName: "Route 1",
+            encounters: [{ pokemonId: 16, encounterType: "grass" }],
+          },
+        ],
+        "unit test encounters",
+      ),
+    ).toThrow(/routeCount: baseline=1 next=2/);
   });
 });

--- a/tests/scrape-wild-encounters-wikitext.test.ts
+++ b/tests/scrape-wild-encounters-wikitext.test.ts
@@ -140,6 +140,26 @@ describe("Wild encounter wikitext parser", () => {
     ).toThrow(/encounterType/);
   });
 
+  it("returns the normalized payload after validation", () => {
+    const payload = JSON.parse(
+      JSON.stringify([
+        {
+          routeName: " Route 1 ",
+          encounters: [{ pokemonId: 16, encounterType: "grass" }],
+        },
+      ]),
+    );
+
+    expect(
+      assertEncounterPayload(payload, pokemonNameMap, "unit test encounters"),
+    ).toEqual([
+      {
+        routeName: "Route 1",
+        encounters: [{ pokemonId: 16, encounterType: "grass" }],
+      },
+    ]);
+  });
+
   it("fails validation when scraped payloads contain unexpected keys", () => {
     const payload = JSON.parse(
       JSON.stringify([
@@ -178,5 +198,20 @@ describe("Wild encounter wikitext parser", () => {
         "unit test encounters",
       ),
     ).toThrow(/routeCount: baseline=1 next=2/);
+  });
+
+  it("preserves zero values in parity mismatch messages", () => {
+    expect(() =>
+      assertEncounterParity(
+        [
+          {
+            routeName: "Route 1",
+            encounters: [{ pokemonId: 16, encounterType: "grass" }],
+          },
+        ],
+        [],
+        "unit test encounters",
+      ),
+    ).toThrow(/routeCount: baseline=0 next=1/);
   });
 });


### PR DESCRIPTION
## Summary
Add a scraper validation layer for wild encounter outputs so malformed or parity-breaking data fails before generated files are written.

## Changes
- Add Zod validation for route encounter output shape, supported encounter types, and Pokemon ID integrity.
- Compare generated encounter outputs against baseline route count, encounter count, Pokemon ID set, and encounter type set before persistence.
- Add focused validation tests and OpenSpec artifacts for the scraper output validation contract.
- Allow the route/article validator to pass known Route 10 article behavior while still requiring stored encounter coverage.
- Document scraper maintenance commands.

## Testing
Automated:
- `pnpm test:run tests/scrape-wild-encounters-wikitext.test.ts`
- `pnpm type-check`
- `pnpm validate`
- `pnpm test:run`
- `pnpm scrape:encounters`
- `pnpm validate:route-articles`

Manual:
- Confirmed `pnpm scrape:encounters` passed the new pre-write parity gate and produced no semantic generated data diff.
- Confirmed `openspec status --change scraping-validation-layer` reports all artifacts complete.

Linear: INF-99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scraper output validation layer that enforces schema and parity checks before writing generated data.
  * Enhanced route/article validation to exempt specific routes from missing-rows failures.

* **Documentation**
  * Added design, proposal, specs, and task docs for the validation framework.
  * README updated with scraper maintenance commands.

* **Tests**
  * Added tests covering payload validation and parity checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fbosch/infinite-fusion-nuzlocke/pull/209)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->