### PR TITLE
feat(inf-127): track game mode transitions

### DIFF
--- a/src/lib/analytics/__tests__/trackEvent.test.ts
+++ b/src/lib/analytics/__tests__/trackEvent.test.ts
@@ -69,6 +69,11 @@ const VALID_EVENT_PAYLOADS: Record<
     ...BASE_SHARED_PROPERTIES,
     days_since_last_active_bucket: "d_1_2_days",
   },
+  game_mode_changed: {
+    ...BASE_SHARED_PROPERTIES,
+    previous_game_mode: "classic",
+    next_game_mode: "randomized",
+  },
   fusion_created: {
     ...BASE_SHARED_PROPERTIES,
     location_id: "route-1",

--- a/src/lib/analytics/trackEvent.ts
+++ b/src/lib/analytics/trackEvent.ts
@@ -15,6 +15,7 @@ export const ANALYTICS_EVENTS = {
   playthroughImportFailed: "playthrough_import_failed",
   runCheckpointReached: "run_checkpoint_reached",
   playthroughResumed: "playthrough_resumed",
+  gameModeChanged: "game_mode_changed",
   fusionCreated: "fusion_created",
   fusionFlipped: "fusion_flipped",
   encounterMarkedDeceased: "encounter_marked_deceased",
@@ -126,6 +127,10 @@ export type AnalyticsEventMap = {
   };
   playthrough_resumed: SharedEventProperties & {
     days_since_last_active_bucket: DormancyBucket;
+  };
+  game_mode_changed: SharedEventProperties & {
+    previous_game_mode: GameMode;
+    next_game_mode: GameMode;
   };
   fusion_created: SharedEventProperties & {
     location_id: string;
@@ -297,6 +302,12 @@ const analyticsEventSchemaMap = {
       ]),
     })
     .strict(),
+  game_mode_changed: sharedEventPropertiesSchema
+    .extend({
+      previous_game_mode: z.enum(["classic", "remix", "randomized"]),
+      next_game_mode: z.enum(["classic", "remix", "randomized"]),
+    })
+    .strict(),
   fusion_created: sharedEventPropertiesSchema
     .extend({
       location_id: z.string().min(1),
@@ -368,6 +379,7 @@ const createByEventCounter = (): Record<AnalyticsEventName, EventCounter> => {
     playthrough_import_failed: { sent: 0, blocked: 0 },
     run_checkpoint_reached: { sent: 0, blocked: 0 },
     playthrough_resumed: { sent: 0, blocked: 0 },
+    game_mode_changed: { sent: 0, blocked: 0 },
     fusion_created: { sent: 0, blocked: 0 },
     fusion_flipped: { sent: 0, blocked: 0 },
     encounter_marked_deceased: { sent: 0, blocked: 0 },

--- a/src/stores/playthroughs/__tests__/analytics-events.test.ts
+++ b/src/stores/playthroughs/__tests__/analytics-events.test.ts
@@ -10,7 +10,14 @@ import {
   updateEncounter,
   updateTeamMember,
 } from "../encounters";
-import { createPlaythrough, playthroughsStore } from "../store";
+import {
+  createPlaythrough,
+  cycleGameMode,
+  playthroughsStore,
+  setGameMode,
+  setRemixMode,
+  toggleRemixMode,
+} from "../store";
 import {
   createTestPlaythrough,
   resetPlaythroughsStore,
@@ -52,6 +59,36 @@ describe("analytics event instrumentation", () => {
     });
     expect(createdEvents[1]?.[1]).toMatchObject({
       has_existing_playthroughs: true,
+    });
+  });
+
+  it("tracks game_mode_changed only on real transitions", () => {
+    const { activePlaythrough } = createTestPlaythrough();
+    activePlaythrough.gameMode = "classic";
+    analyticsMocks.trackEvent.mockClear();
+
+    setGameMode("classic");
+    setGameMode("remix");
+    setRemixMode(true);
+    toggleRemixMode();
+    cycleGameMode();
+
+    const modeEvents = getTrackedEvents("game_mode_changed");
+    expect(modeEvents).toHaveLength(3);
+    expect(modeEvents[0]?.[1]).toMatchObject({
+      game_mode: "remix",
+      previous_game_mode: "classic",
+      next_game_mode: "remix",
+    });
+    expect(modeEvents[1]?.[1]).toMatchObject({
+      game_mode: "classic",
+      previous_game_mode: "remix",
+      next_game_mode: "classic",
+    });
+    expect(modeEvents[2]?.[1]).toMatchObject({
+      game_mode: "remix",
+      previous_game_mode: "classic",
+      next_game_mode: "remix",
     });
   });
 

--- a/src/stores/playthroughs/store.ts
+++ b/src/stores/playthroughs/store.ts
@@ -40,6 +40,14 @@ const generatePlaythroughId = (): string => {
   return generatePrefixedId("playthrough");
 };
 
+const toGameMode = (gameMode: string): GameMode => {
+  if (gameMode === "remix" || gameMode === "randomized") {
+    return gameMode;
+  }
+
+  return "classic";
+};
+
 // Create the playthroughs store with proper SSR handling
 let playthroughsStore: PlaythroughsState;
 
@@ -140,6 +148,29 @@ const setActivePlaythrough = async (playthroughId: string) => {
   }
 };
 
+const changeActiveGameMode = (
+  nextGameMode: GameMode,
+  shouldUpdateTimestamp: boolean,
+) => {
+  const activePlaythrough = getActivePlaythrough();
+  if (!activePlaythrough || activePlaythrough.gameMode === nextGameMode) {
+    return;
+  }
+
+  const previousGameMode = toGameMode(activePlaythrough.gameMode);
+  activePlaythrough.gameMode = nextGameMode;
+
+  if (shouldUpdateTimestamp) {
+    activePlaythrough.updatedAt = getCurrentTimestamp();
+  }
+
+  trackEvent("game_mode_changed", {
+    ...getSharedEventProperties(activePlaythrough),
+    previous_game_mode: previousGameMode,
+    next_game_mode: nextGameMode,
+  });
+};
+
 const cycleGameMode = () => {
   const activePlaythrough = getActivePlaythrough();
   if (activePlaythrough) {
@@ -149,7 +180,7 @@ const cycleGameMode = () => {
     );
     const nextIndex = (currentIndex + 1) % modes.length;
     const nextMode = modes[nextIndex];
-    activePlaythrough.gameMode = nextMode;
+    changeActiveGameMode(nextMode, false);
     // Don't update timestamp immediately for UI toggles - let the debounced save handle it
     // This makes the UI more responsive for rapid toggles
   }
@@ -160,25 +191,17 @@ const toggleRemixMode = () => {
   if (activePlaythrough) {
     // Convert current mode to boolean logic for backward compatibility
     const isRemix = activePlaythrough.gameMode === "remix";
-    activePlaythrough.gameMode = isRemix ? "classic" : "remix";
+    changeActiveGameMode(isRemix ? "classic" : "remix", false);
     // Don't update timestamp immediately for UI toggles - let the debounced save handle it
   }
 };
 
 const setGameMode = (gameMode: GameMode) => {
-  const activePlaythrough = getActivePlaythrough();
-  if (activePlaythrough) {
-    activePlaythrough.gameMode = gameMode;
-    activePlaythrough.updatedAt = getCurrentTimestamp();
-  }
+  changeActiveGameMode(gameMode, true);
 };
 
 const setRemixMode = (enabled: boolean) => {
-  const activePlaythrough = getActivePlaythrough();
-  if (activePlaythrough) {
-    activePlaythrough.gameMode = enabled ? "remix" : "classic";
-    activePlaythrough.updatedAt = getCurrentTimestamp();
-  }
+  changeActiveGameMode(enabled ? "remix" : "classic", true);
 };
 
 const updatePlaythroughName = (playthroughId: string, name: string) => {

--- a/src/stores/playthroughs/store.ts
+++ b/src/stores/playthroughs/store.ts
@@ -23,6 +23,7 @@ import {
 import {
   DEFAULT_NEW_PLAYTHROUGH_GAME_MODE,
   type GameMode,
+  GameModeSchema,
   type Playthrough,
   type PlaythroughsState,
 } from "./types";
@@ -38,14 +39,6 @@ const defaultState: PlaythroughsState = {
 // Helper functions
 const generatePlaythroughId = (): string => {
   return generatePrefixedId("playthrough");
-};
-
-const toGameMode = (gameMode: string): GameMode => {
-  if (gameMode === "remix" || gameMode === "randomized") {
-    return gameMode;
-  }
-
-  return "classic";
 };
 
 // Create the playthroughs store with proper SSR handling
@@ -157,7 +150,18 @@ const changeActiveGameMode = (
     return;
   }
 
-  const previousGameMode = toGameMode(activePlaythrough.gameMode);
+  const previousGameModeResult = GameModeSchema.safeParse(
+    activePlaythrough.gameMode,
+  );
+  if (!previousGameModeResult.success) {
+    return;
+  }
+
+  const previousGameMode = previousGameModeResult.data;
+  if (previousGameMode === nextGameMode) {
+    return;
+  }
+
   activePlaythrough.gameMode = nextGameMode;
 
   if (shouldUpdateTimestamp) {


### PR DESCRIPTION
## Summary
Add `game_mode_changed` analytics for real game-mode transitions so mode pivots can be measured against run progression context.

## Changes
- Add a typed `game_mode_changed` event contract with previous and next mode fields.
- Route game-mode mutation helpers through a shared transition helper to avoid same-mode emits.
- Cover the event schema and transition-only store behavior with focused tests.

## Testing
- `rtk vitest src/stores/playthroughs/__tests__/analytics-events.test.ts src/lib/analytics/__tests__/trackEvent.test.ts`
- `pnpm type-check`
- `pnpm format:check`
- `rtk proxy pnpm lint`

Closes INF-127