### PR TITLE
test: cover chained playthrough migrations

### DIFF
--- a/src/stores/playthroughs/__tests__/migrations.test.ts
+++ b/src/stores/playthroughs/__tests__/migrations.test.ts
@@ -7,6 +7,7 @@ import {
   migrateTeamField,
   migrateVersion,
 } from "../migrations";
+import { PlaythroughSchema } from "../types";
 
 type LegacyTeamMember = {
   headEncounterId: string;
@@ -285,6 +286,85 @@ describe("Migration Functions", () => {
       expect(result.version).toBe("2.0.0");
       expect(result.team).toBeDefined();
       expect(result.remixMode).toBeUndefined(); // Should still be cleaned up
+    });
+
+    it("should migrate an old persisted shape through the full pipeline into a valid playthrough", () => {
+      const legacyData: MigrationData = {
+        id: "",
+        name: "",
+        remixMode: true,
+        gameMode: "classic",
+        createdAt: Number.NaN,
+        updatedAt: Number.POSITIVE_INFINITY,
+        encounters: {
+          route1: {
+            head: {
+              id: 25,
+              name: "Pikachu",
+              nationalDexId: 25,
+              status: "stored",
+              uid: "pikachu-route1",
+            },
+            body: {
+              id: 4,
+              name: "Charmander",
+              nationalDexId: 4,
+              status: "deceased",
+              uid: "charmander-route1",
+            },
+            isFusion: true,
+            updatedAt: 1_700_000_000,
+            artworkVariant: "legacy-sprite-key",
+          },
+        },
+        team: {
+          members: {
+            0: {
+              headEncounterId: "route1:head",
+              bodyEncounterId: "route1:body",
+            },
+          },
+        },
+      };
+
+      const migrated = migratePlaythrough(legacyData);
+      const parsed = PlaythroughSchema.parse(migrated);
+
+      expect(parsed.id).toMatch(/^playthrough_/);
+      expect(parsed.name).toBe("Playthrough");
+      expect(parsed.createdAt).toBeGreaterThan(0);
+      expect(parsed.updatedAt).toBeGreaterThan(0);
+      expect(parsed.gameMode).toBe("remix");
+      expect("remixMode" in parsed).toBe(false);
+      expect(parsed.version).toBe("1.0.0");
+      expect(parsed.team.members).toEqual([
+        { headPokemonUid: "", bodyPokemonUid: "" },
+        null,
+        null,
+        null,
+        null,
+        null,
+      ]);
+      expect(parsed.encounters?.route1).toEqual({
+        head: {
+          id: 25,
+          name: "Pikachu",
+          nationalDexId: 25,
+          status: "stored",
+          originalReceivalStatus: "captured",
+          uid: "pikachu-route1",
+        },
+        body: {
+          id: 4,
+          name: "Charmander",
+          nationalDexId: 4,
+          status: "deceased",
+          originalReceivalStatus: "captured",
+          uid: "charmander-route1",
+        },
+        isFusion: true,
+        updatedAt: 1_700_000_000,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
Add an end-to-end migration-chain test for old persisted playthrough data so the full migration pipeline is checked against the current schema.

## Changes
- Add a legacy payload that exercises required-field recovery, remix mode migration, version defaulting, team member shape migration, `originalReceivalStatus` backfill, and artwork variant cleanup.
- Parse the migrated result with `PlaythroughSchema` to prove the pipeline output is current-schema valid.

## Testing
- `rtk vitest src/stores/playthroughs/__tests__/migrations.test.ts`
- `pnpm type-check`
- `pnpm validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the data migration pipeline to validate proper handling and normalization of legacy data structures and malformed values during migration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fbosch/infinite-fusion-nuzlocke/pull/212)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->