### PR TITLE
ci: redeploy preview-labeled release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
   issues: write
@@ -40,6 +41,31 @@ jobs:
           echo "Release created"
           echo "Tag: ${{ steps.release.outputs.tag_name }}"
           echo "URL: ${{ steps.release.outputs.html_url }}"
+
+  deploy-preview-prs:
+    name: Deploy Preview PRs
+    needs: release-please
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Dispatch preview deploys for labeled PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW: vercel-preview-on-demand.yml
+        run: |
+          gh pr list \
+            --repo "$REPOSITORY" \
+            --state open \
+            --label preview \
+            --json number,headRepositoryOwner \
+            --jq '.[] | select(.headRepositoryOwner.login == "${{ github.repository_owner }}") | .number' \
+            | while read -r pr_number; do
+                if [ -n "$pr_number" ]; then
+                  gh workflow run "$WORKFLOW" --repo "$REPOSITORY" --ref master -f pr_number="$pr_number"
+                fi
+              done
 
   deploy-production:
     name: Deploy to Vercel Production
@@ -128,6 +154,8 @@ jobs:
 
       - name: Publish deployment summary
         run: |
-          echo "### Production Deployment" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Tag: \`${{ needs.release-please.outputs.tag_name }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- URL: \`${{ steps.deploy.outputs.deployment_url }}\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Production Deployment"
+            echo "- Tag: \`${{ needs.release-please.outputs.tag_name }}\`"
+            echo "- URL: \`${{ steps.deploy.outputs.deployment_url }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vercel-preview-on-demand.yml
+++ b/.github/workflows/vercel-preview-on-demand.yml
@@ -20,12 +20,10 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (
+        github.event_name == 'pull_request' &&
         github.event.pull_request.draft == false &&
         github.event.pull_request.head.repo.full_name == github.repository &&
-        (
-          contains(github.event.pull_request.labels.*.name, 'preview') ||
-          startsWith(github.event.pull_request.head.ref, 'release-please--branches--master--components--')
-        )
+        contains(github.event.pull_request.labels.*.name, 'preview')
       )
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -122,10 +120,12 @@ jobs:
 
       - name: Publish deployment summary
         run: |
-          echo "### On-Demand Preview Deployment" >> "$GITHUB_STEP_SUMMARY"
-          echo "- PR: #${{ steps.pr.outputs.number }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Branch: ${{ steps.pr.outputs.head_ref }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- URL: ${{ steps.deploy.outputs.deployment_url }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### On-Demand Preview Deployment"
+            echo "- PR: #${{ steps.pr.outputs.number }}"
+            echo "- Branch: ${{ steps.pr.outputs.head_ref }}"
+            echo "- URL: ${{ steps.deploy.outputs.deployment_url }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment preview URL on PR
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
Keep Vercel previews current for PRs that carry the `preview` label, including Release Please PRs updated by `GITHUB_TOKEN`.

## Changes
- Restrict the preview workflow to explicit `preview` label gating.
- Dispatch preview deploys from the Release Please workflow for open same-repo PRs labeled `preview`.
- Clean up summary writes so workflow linting passes.

## Testing
- `nix run nixpkgs#actionlint -- .github/workflows/vercel-preview-on-demand.yml .github/workflows/release-please.yml`
- Verified the `gh pr list` filter returns PR #198.

## Manual Testing
- Add `preview` to an open same-repo PR and push a normal user commit; verify the preview workflow runs.
- Let Release Please update PR #198; verify the release workflow dispatches the preview workflow for that PR.