### PR TITLE
refactor(inf-146): deepen encounter transition seam

### DIFF
--- a/openspec/changes/inf-146-architecture-1-deepen-encounter-transition-module/.openspec.yaml
+++ b/openspec/changes/inf-146-architecture-1-deepen-encounter-transition-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/inf-146-architecture-1-deepen-encounter-transition-module/design.md
+++ b/openspec/changes/inf-146-architecture-1-deepen-encounter-transition-module/design.md
@@ -1,0 +1,28 @@
+## Context
+
+Current encounter behavior is correct but fragmented. Multiple files hold parts of transition logic, and callers may still need sequencing knowledge to preserve invariants. Architecture review identified this as the highest-impact deepening candidate because it governs core run-state safety rules.
+
+## Goals
+
+- Make one deep encounter transition owner responsible for rule-safe state mutations and mandatory side effects.
+- Preserve behavior for encounter creation, status transitions, fusion creation, drag/drop, cleanup, and event emission.
+- Move verification to observable outcomes at the transition seam instead of shallow internal helper behavior.
+
+## Non-Goals
+
+- Changing Nuzlocke rule semantics or user-visible outcomes.
+- Introducing new persistence contracts or API surface changes.
+- Broad unrelated refactors outside encounter transition ownership.
+
+## Decisions
+
+1. Canonical transition operations own ordering and side effects for encounter mutations.
+2. Existing operation entrypoints may delegate internally, but callers must not reconstruct transition sequencing themselves.
+3. Behavior parity is proven through observable run-state and emission outcomes, not helper-internal snapshots.
+4. If a mutation path bypasses deep transition ownership for tracked behavior, it is non-compliant.
+
+## Validation Strategy
+
+- Add focused tests that exercise encounter/team/graveyard observable outcomes through deep transition operations.
+- Replace shallow tests that only mirror implementation details and fail to protect caller-facing behavior.
+- Run type-check and targeted test validation for touched encounter transition modules.

--- a/openspec/changes/inf-146-architecture-1-deepen-encounter-transition-module/proposal.md
+++ b/openspec/changes/inf-146-architecture-1-deepen-encounter-transition-module/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Encounter transitions are currently spread across `crud.ts`, `status.ts`, `fusion.ts`, and `dragDrop.ts`. Callers use small verbs, but still depend on hidden ordering and side effects for team assignments, first encounter tracking, fusion state, run checkpoints, and event emission. This keeps high-risk Nuzlocke rules distributed instead of concentrated behind one seam.
+
+## What Changes
+
+- Deepen encounter transition ownership so one module orchestrates rule-safe encounter mutations and dependent side effects.
+- Define canonical transition operations that encapsulate creation, status updates, fusion changes, drag/drop mutations, cleanup, and required downstream effects.
+- Preserve existing behavior by treating this as ownership consolidation and test seam reshaping, not a game-rule rewrite.
+
+## Capabilities
+
+### New Capabilities
+- `encounter-transition-module`: Defines canonical encounter transition operations as the owner for encounter mutation side effects and rule ordering.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Primary touched paths are `src/stores/playthroughs/encounters/crud.ts`, `src/stores/playthroughs/encounters/status.ts`, `src/stores/playthroughs/encounters/fusion.ts`, and `src/stores/playthroughs/encounters/dragDrop.ts`.
+- Test updates will shift from shallow helper-level assertions toward observable encounter/team/graveyard outcomes through deep transition operations.
+- No persistence schema migration or user-facing behavior change is expected.

--- a/openspec/changes/inf-146-architecture-1-deepen-encounter-transition-module/specs/encounter-transition-module/spec.md
+++ b/openspec/changes/inf-146-architecture-1-deepen-encounter-transition-module/specs/encounter-transition-module/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Deep encounter transition operations own rule-safe mutation behavior
+The system MUST expose canonical encounter transition operations that own ordering and side effects for encounter mutation workflows.
+
+#### Scenario: Encounter mutation path uses canonical deep transition ownership
+- **WHEN** a caller initiates encounter creation, status transition, fusion change, drag/drop mutation, or cleanup behavior
+- **THEN** the path routes through canonical deep transition operations
+- **AND** callers are not required to reconstruct side-effect sequencing externally
+
+### Requirement: Deep transition behavior remains parity-safe
+The system MUST preserve current observable behavior while deepening encounter transition ownership.
+
+#### Scenario: Observable run-state outcomes remain unchanged after deepening
+- **WHEN** canonical transition operations process tracked encounter workflows
+- **THEN** encounter, team, and graveyard observable outcomes remain behaviorally equivalent to prior implementation
+- **AND** required event emission semantics remain equivalent
+
+#### Scenario: Helper-level tests do not replace behavior-level verification
+- **WHEN** verification is updated for deep transition ownership
+- **THEN** tests prioritize observable outcomes through canonical operations
+- **AND** shallow helper tests that only mirror internal implementation detail are replaced or removed

--- a/openspec/changes/inf-146-architecture-1-deepen-encounter-transition-module/tasks.md
+++ b/openspec/changes/inf-146-architecture-1-deepen-encounter-transition-module/tasks.md
@@ -1,0 +1,16 @@
+## 1. Deep transition ownership
+
+- [x] 1.1 Define or consolidate canonical encounter transition operations that own side-effect ordering across encounter CRUD, status, fusion, and drag/drop behavior.
+- [ ] 1.2 Route existing mutation paths to those deep operations so callers no longer encode rule sequencing.
+- [ ] 1.3 Keep first encounter tracking, death permanence, team effects, cleanup, and event emission behavior unchanged.
+
+## 2. Test seam reshaping
+
+- [ ] 2.1 Add focused tests that assert observable encounter/team/graveyard outcomes through deep transition operations.
+- [ ] 2.2 Replace shallow helper tests where assertions only duplicate implementation details without protecting behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run `pnpm type-check`.
+- [x] 3.2 Run `pnpm test:run`.
+- [ ] 3.3 Run broader `pnpm validate` only if scope becomes cross-cutting.

--- a/src/stores/playthroughs/encounters/crud.ts
+++ b/src/stores/playthroughs/encounters/crud.ts
@@ -1,7 +1,5 @@
 import type { z } from "zod";
 import { getEncounterCount } from "@/lib/analytics/playthroughEventData";
-import { getSharedEventProperties } from "@/lib/analytics/selectors";
-import { trackEvent } from "@/lib/analytics/trackEvent";
 import { emitEvolutionEvent } from "@/lib/events";
 import type { PokemonOptionSchema, PokemonOptionType } from "@/loaders/pokemon";
 import { getActivePlaythrough, getCurrentTimestamp } from "../playthroughState";

--- a/src/stores/playthroughs/encounters/crud.ts
+++ b/src/stores/playthroughs/encounters/crud.ts
@@ -1,10 +1,5 @@
 import type { z } from "zod";
-import { getCheckpointLabel } from "@/lib/analytics/buckets";
-import {
-  getEncounterCount,
-  getNewlyReachedCheckpoints,
-  markCheckpointEventsTracked,
-} from "@/lib/analytics/playthroughEventData";
+import { getEncounterCount } from "@/lib/analytics/playthroughEventData";
 import { getSharedEventProperties } from "@/lib/analytics/selectors";
 import { trackEvent } from "@/lib/analytics/trackEvent";
 import { emitEvolutionEvent } from "@/lib/events";
@@ -20,22 +15,7 @@ import {
   autoAssignCapturedPokemonToTeam,
   removeTeamMembersWithPokemon,
 } from "./team";
-
-const trackFirstEncounterSaved = (
-  activePlaythrough: Playthrough,
-  locationId: string,
-  previousEncounterCount: number,
-  nextEncounterCount: number,
-) => {
-  if (previousEncounterCount !== 0 || nextEncounterCount === 0) {
-    return;
-  }
-
-  trackEvent("first_encounter_saved", {
-    ...getSharedEventProperties(activePlaythrough),
-    location_id: locationId,
-  });
-};
+import { trackEncounterProgress, trackFusionCreatedIfNew } from "./transition";
 
 // Create encounter data (variants are managed globally)
 export const createEncounterData = async (
@@ -122,36 +102,10 @@ export const updateEncounter = async (
       await autoAssignCapturedPokemonToTeam(locationId);
     }
 
-    const nextEncounterCount = getEncounterCount(activePlaythrough);
-    trackFirstEncounterSaved(
+    trackEncounterProgress(
       activePlaythrough,
       locationId,
       previousEncounterCount,
-      nextEncounterCount,
-    );
-    const newlyReachedCheckpoints = getNewlyReachedCheckpoints(
-      activePlaythrough.id,
-      previousEncounterCount,
-      nextEncounterCount,
-    );
-    const trackedCheckpoints: typeof newlyReachedCheckpoints = [];
-
-    for (const checkpoint of newlyReachedCheckpoints) {
-      const wasTracked = trackEvent("run_checkpoint_reached", {
-        ...getSharedEventProperties(activePlaythrough),
-        checkpoint,
-        checkpoint_label: getCheckpointLabel(checkpoint),
-      });
-
-      if (wasTracked) {
-        trackedCheckpoints.push(checkpoint);
-      }
-    }
-
-    markCheckpointEventsTracked(
-      activePlaythrough.id,
-      newlyReachedCheckpoints,
-      trackedCheckpoints,
     );
 
     return;
@@ -225,44 +179,18 @@ export const updateEncounter = async (
     const isCompleteFusion = Boolean(
       encounter.isFusion && encounter.head && encounter.body,
     );
-    if (!wasCompleteFusion && isCompleteFusion) {
-      trackEvent("fusion_created", {
-        ...getSharedEventProperties(activePlaythrough),
-        location_id: locationId,
-        creation_method: "update_encounter",
-      });
-    }
+    trackFusionCreatedIfNew(
+      activePlaythrough,
+      locationId,
+      wasCompleteFusion,
+      isCompleteFusion,
+      "update_encounter",
+    );
 
-    const nextEncounterCount = getEncounterCount(activePlaythrough);
-    trackFirstEncounterSaved(
+    trackEncounterProgress(
       activePlaythrough,
       locationId,
       previousEncounterCount,
-      nextEncounterCount,
-    );
-    const newlyReachedCheckpoints = getNewlyReachedCheckpoints(
-      activePlaythrough.id,
-      previousEncounterCount,
-      nextEncounterCount,
-    );
-    const trackedCheckpoints: typeof newlyReachedCheckpoints = [];
-
-    for (const checkpoint of newlyReachedCheckpoints) {
-      const wasTracked = trackEvent("run_checkpoint_reached", {
-        ...getSharedEventProperties(activePlaythrough),
-        checkpoint,
-        checkpoint_label: getCheckpointLabel(checkpoint),
-      });
-
-      if (wasTracked) {
-        trackedCheckpoints.push(checkpoint);
-      }
-    }
-
-    markCheckpointEventsTracked(
-      activePlaythrough.id,
-      newlyReachedCheckpoints,
-      trackedCheckpoints,
     );
 
     return;
@@ -278,31 +206,7 @@ export const updateEncounter = async (
 
   removeTeamMembersWithPokemon(removedUIDs);
 
-  const nextEncounterCount = getEncounterCount(activePlaythrough);
-  const newlyReachedCheckpoints = getNewlyReachedCheckpoints(
-    activePlaythrough.id,
-    previousEncounterCount,
-    nextEncounterCount,
-  );
-  const trackedCheckpoints: typeof newlyReachedCheckpoints = [];
-
-  for (const checkpoint of newlyReachedCheckpoints) {
-    const wasTracked = trackEvent("run_checkpoint_reached", {
-      ...getSharedEventProperties(activePlaythrough),
-      checkpoint,
-      checkpoint_label: getCheckpointLabel(checkpoint),
-    });
-
-    if (wasTracked) {
-      trackedCheckpoints.push(checkpoint);
-    }
-  }
-
-  markCheckpointEventsTracked(
-    activePlaythrough.id,
-    newlyReachedCheckpoints,
-    trackedCheckpoints,
-  );
+  trackEncounterProgress(activePlaythrough, locationId, previousEncounterCount);
 };
 
 // Reset encounter for a location

--- a/src/stores/playthroughs/encounters/dragDrop.ts
+++ b/src/stores/playthroughs/encounters/dragDrop.ts
@@ -10,6 +10,7 @@ import {
   ensureActivePlaythroughWithEncounters,
 } from "./shared";
 import { removeTeamMembersWithPokemon } from "./team";
+import { trackFusionCreatedIfNew } from "./transition";
 
 // Clear encounter from a specific location (replaces clearCombobox event)
 export const clearEncounterFromLocation = async (
@@ -107,17 +108,20 @@ export const moveEncounterAtomic = async (
   };
 
   activePlaythrough.encounters[targetLocationId] = newEncounter;
-  if (newEncounter.isFusion && newEncounter.head && newEncounter.body) {
+  const isCompleteFusion = Boolean(
+    newEncounter.isFusion && newEncounter.head && newEncounter.body,
+  );
+  if (isCompleteFusion) {
     emitEvolutionEvent(targetLocationId);
-
-    if (!targetWasCompleteFusion) {
-      trackEvent("fusion_created", {
-        ...getSharedEventProperties(activePlaythrough),
-        location_id: targetLocationId,
-        creation_method: "drag_drop",
-      });
-    }
   }
+
+  trackFusionCreatedIfNew(
+    activePlaythrough,
+    targetLocationId,
+    targetWasCompleteFusion,
+    isCompleteFusion,
+    "drag_drop",
+  );
 };
 
 // Move encounter from one location to another

--- a/src/stores/playthroughs/encounters/fusion.ts
+++ b/src/stores/playthroughs/encounters/fusion.ts
@@ -1,9 +1,4 @@
-import { getCheckpointLabel } from "@/lib/analytics/buckets";
-import {
-  getEncounterCount,
-  getNewlyReachedCheckpoints,
-  markCheckpointEventsTracked,
-} from "@/lib/analytics/playthroughEventData";
+import { getEncounterCount } from "@/lib/analytics/playthroughEventData";
 import { getSharedEventProperties } from "@/lib/analytics/selectors";
 import { trackEvent } from "@/lib/analytics/trackEvent";
 import { emitEvolutionEvent } from "@/lib/events";
@@ -14,6 +9,7 @@ import {
   getFusionSpriteIdFromEncounter,
   type PokemonOption,
 } from "./shared";
+import { trackEncounterProgress, trackFusionCreatedIfNew } from "./transition";
 
 // Toggle fusion mode for an encounter
 export const toggleEncounterFusion = async (locationId: string) => {
@@ -111,46 +107,17 @@ export const createFusion = async (
   };
 
   activePlaythrough.encounters[locationId] = encounter;
-  if (encounter.head && encounter.body) {
+  const isCompleteFusion = Boolean(encounter.head && encounter.body);
+  if (isCompleteFusion) {
     emitEvolutionEvent(locationId);
-
-    trackEvent("fusion_created", {
-      ...getSharedEventProperties(activePlaythrough),
-      location_id: locationId,
-      creation_method: "create_fusion",
-    });
   }
 
-  const nextEncounterCount = getEncounterCount(activePlaythrough);
-  if (previousEncounterCount === 0 && nextEncounterCount > 0) {
-    trackEvent("first_encounter_saved", {
-      ...getSharedEventProperties(activePlaythrough),
-      location_id: locationId,
-    });
-  }
-
-  const newlyReachedCheckpoints = getNewlyReachedCheckpoints(
-    activePlaythrough.id,
-    previousEncounterCount,
-    nextEncounterCount,
+  trackFusionCreatedIfNew(
+    activePlaythrough,
+    locationId,
+    false,
+    isCompleteFusion,
+    "create_fusion",
   );
-  const trackedCheckpoints: typeof newlyReachedCheckpoints = [];
-
-  for (const checkpoint of newlyReachedCheckpoints) {
-    const wasTracked = trackEvent("run_checkpoint_reached", {
-      ...getSharedEventProperties(activePlaythrough),
-      checkpoint,
-      checkpoint_label: getCheckpointLabel(checkpoint),
-    });
-
-    if (wasTracked) {
-      trackedCheckpoints.push(checkpoint);
-    }
-  }
-
-  markCheckpointEventsTracked(
-    activePlaythrough.id,
-    newlyReachedCheckpoints,
-    trackedCheckpoints,
-  );
+  trackEncounterProgress(activePlaythrough, locationId, previousEncounterCount);
 };

--- a/src/stores/playthroughs/encounters/transition.ts
+++ b/src/stores/playthroughs/encounters/transition.ts
@@ -1,0 +1,67 @@
+import { getCheckpointLabel } from "@/lib/analytics/buckets";
+import {
+  getEncounterCount,
+  getNewlyReachedCheckpoints,
+  markCheckpointEventsTracked,
+} from "@/lib/analytics/playthroughEventData";
+import { getSharedEventProperties } from "@/lib/analytics/selectors";
+import { trackEvent } from "@/lib/analytics/trackEvent";
+import type { Playthrough } from "../types";
+
+export const trackEncounterProgress = (
+  activePlaythrough: Playthrough,
+  locationId: string,
+  previousEncounterCount: number,
+) => {
+  const nextEncounterCount = getEncounterCount(activePlaythrough);
+
+  if (previousEncounterCount === 0 && nextEncounterCount > 0) {
+    trackEvent("first_encounter_saved", {
+      ...getSharedEventProperties(activePlaythrough),
+      location_id: locationId,
+    });
+  }
+
+  const newlyReachedCheckpoints = getNewlyReachedCheckpoints(
+    activePlaythrough.id,
+    previousEncounterCount,
+    nextEncounterCount,
+  );
+  const trackedCheckpoints: typeof newlyReachedCheckpoints = [];
+
+  for (const checkpoint of newlyReachedCheckpoints) {
+    const wasTracked = trackEvent("run_checkpoint_reached", {
+      ...getSharedEventProperties(activePlaythrough),
+      checkpoint,
+      checkpoint_label: getCheckpointLabel(checkpoint),
+    });
+
+    if (wasTracked) {
+      trackedCheckpoints.push(checkpoint);
+    }
+  }
+
+  markCheckpointEventsTracked(
+    activePlaythrough.id,
+    newlyReachedCheckpoints,
+    trackedCheckpoints,
+  );
+};
+
+export const trackFusionCreatedIfNew = (
+  activePlaythrough: Playthrough,
+  locationId: string,
+  wasCompleteFusion: boolean,
+  isCompleteFusion: boolean,
+  creationMethod: "update_encounter" | "create_fusion" | "drag_drop",
+) => {
+  if (wasCompleteFusion || !isCompleteFusion) {
+    return;
+  }
+
+  trackEvent("fusion_created", {
+    ...getSharedEventProperties(activePlaythrough),
+    location_id: locationId,
+    creation_method: creationMethod,
+  });
+};


### PR DESCRIPTION
## Summary
- centralize encounter transition side-effect tracking by adding a shared transition helper for first-encounter/checkpoint progression and fusion-created telemetry
- route encounter CRUD, fusion creation, and drag-drop fusion paths through the canonical helper so equivalent transitions emit consistent analytics behavior
- add OpenSpec change artifacts for INF-146 and update task tracking with completed validation steps

## Validation
- pnpm type-check
- pnpm test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture design and specification documents for encounter transition improvements.

* **Refactor**
  * Reorganized encounter transition logic to consolidate analytics tracking across multiple modules for improved code maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fbosch/infinite-fusion-nuzlocke/pull/215)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->