### PR TITLE
refactor(inf-148): deepen team identity module

### DIFF
--- a/src/stores/playthroughs/__tests__/team-identity.test.ts
+++ b/src/stores/playthroughs/__tests__/team-identity.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  findCanonicalLocationForUids,
+  getTeamMemberUids,
+} from "../encounters/team";
+import {
+  createTestPlaythrough,
+  resetPlaythroughsStore,
+  testPokemon,
+} from "./test-utils";
+
+describe("Team identity helpers", () => {
+  resetPlaythroughsStore();
+
+  it("returns team member UIDs by slot identity", () => {
+    const { activePlaythrough } = createTestPlaythrough();
+
+    activePlaythrough.team.members[1] = {
+      headPokemonUid: "pikachu_route1_123",
+      bodyPokemonUid: "charmander_route1_456",
+    };
+
+    expect(getTeamMemberUids(1)).toEqual([
+      "pikachu_route1_123",
+      "charmander_route1_456",
+    ]);
+    expect(getTeamMemberUids(-1)).toEqual([]);
+    expect(getTeamMemberUids(6)).toEqual([]);
+    expect(getTeamMemberUids(0)).toEqual([]);
+  });
+
+  it("resolves canonical encounter location for a unique UID set", () => {
+    const { activePlaythrough } = createTestPlaythrough();
+
+    activePlaythrough.encounters = {
+      route1: {
+        head: testPokemon.pikachu("pikachu_route1_123"),
+        body: testPokemon.charmander("charmander_route1_456"),
+        isFusion: true,
+        updatedAt: Date.now(),
+      },
+      route2: {
+        head: testPokemon.squirtle("squirtle_route2_789"),
+        body: null,
+        isFusion: false,
+        updatedAt: Date.now(),
+      },
+    };
+
+    expect(
+      findCanonicalLocationForUids([
+        "pikachu_route1_123",
+        "charmander_route1_456",
+      ]),
+    ).toBe("route1");
+  });
+
+  it("returns null when UID set matches multiple encounters", () => {
+    const { activePlaythrough } = createTestPlaythrough();
+
+    activePlaythrough.encounters = {
+      route1: {
+        head: testPokemon.pikachu("shared_uid"),
+        body: null,
+        isFusion: false,
+        updatedAt: Date.now(),
+      },
+      route2: {
+        head: testPokemon.charmander("shared_uid"),
+        body: null,
+        isFusion: false,
+        updatedAt: Date.now(),
+      },
+    };
+
+    expect(findCanonicalLocationForUids(["shared_uid"])).toBeNull();
+  });
+});

--- a/src/stores/playthroughs/encounters/team.ts
+++ b/src/stores/playthroughs/encounters/team.ts
@@ -3,6 +3,11 @@ import { type PokemonOptionSchema, PokemonStatus } from "@/loaders/pokemon";
 import type { EncounterData } from "../types";
 import { ensureActivePlaythroughWithEncounters } from "./shared";
 
+const TEAM_SIZE = 6;
+
+const isValidTeamPosition = (position: number) =>
+  position >= 0 && position < TEAM_SIZE;
+
 // Update a Pokemon's properties by UID across all encounters
 export const updatePokemonByUID = async (
   pokemonUID: string,
@@ -56,7 +61,7 @@ export const updateTeamMember = async (
     return false;
   }
 
-  if (position < 0 || position >= 6) {
+  if (!isValidTeamPosition(position)) {
     return false;
   }
 
@@ -181,6 +186,49 @@ const findPokemonByUID = (
   return null;
 };
 
+export const getTeamMemberUids = (position: number): string[] => {
+  const activePlaythrough = ensureActivePlaythroughWithEncounters();
+  if (!activePlaythrough?.team) {
+    return [];
+  }
+
+  if (!isValidTeamPosition(position)) {
+    return [];
+  }
+
+  const member = activePlaythrough.team.members[position];
+  if (!member) {
+    return [];
+  }
+
+  return [member.headPokemonUid, member.bodyPokemonUid].filter(
+    (uid) => uid !== "",
+  );
+};
+
+export const findCanonicalLocationForUids = (uids: string[]) => {
+  const activePlaythrough = ensureActivePlaythroughWithEncounters();
+  if (!activePlaythrough || uids.length === 0) {
+    return null;
+  }
+
+  const matches = Object.entries(activePlaythrough.encounters).filter(
+    ([, encounter]) => {
+      const encounterUids = [encounter.head?.uid, encounter.body?.uid].filter(
+        (uid) => uid != null,
+      );
+
+      return uids.every((uid) => encounterUids.includes(uid));
+    },
+  );
+
+  if (matches.length !== 1) {
+    return null;
+  }
+
+  return matches[0][0];
+};
+
 export const removeTeamMembersWithPokemon = (pokemonUIDs: string[]) => {
   const activePlaythrough = ensureActivePlaythroughWithEncounters();
   if (!activePlaythrough?.team || pokemonUIDs.length === 0) {
@@ -216,7 +264,7 @@ export const moveTeamMemberToBox = async (position: number): Promise<void> => {
     return;
   }
 
-  if (position < 0 || position >= 6) {
+  if (!isValidTeamPosition(position)) {
     return;
   }
 

--- a/src/stores/playthroughs/encounters/teamActions.ts
+++ b/src/stores/playthroughs/encounters/teamActions.ts
@@ -2,50 +2,12 @@ import { PokemonStatus } from "@/loaders/pokemon";
 import { flipEncounterFusion } from "./fusion";
 import { ensureActivePlaythroughWithEncounters } from "./shared";
 import { markEncounterAsDeceased } from "./status";
-import { updatePokemonByUID, updateTeamMember } from "./team";
-
-const getTeamMemberUids = (position: number) => {
-  const activePlaythrough = ensureActivePlaythroughWithEncounters();
-  if (!activePlaythrough?.team) {
-    return [] as string[];
-  }
-
-  if (position < 0 || position >= activePlaythrough.team.members.length) {
-    return [] as string[];
-  }
-
-  const member = activePlaythrough.team.members[position];
-  if (!member) {
-    return [] as string[];
-  }
-
-  return [member.headPokemonUid, member.bodyPokemonUid].filter(
-    (uid) => uid !== "",
-  );
-};
-
-const findCanonicalLocationForUids = (uids: string[]) => {
-  const activePlaythrough = ensureActivePlaythroughWithEncounters();
-  if (!activePlaythrough || uids.length === 0) {
-    return null;
-  }
-
-  const matches = Object.entries(activePlaythrough.encounters).filter(
-    ([, encounter]) => {
-      const encounterUids = [encounter.head?.uid, encounter.body?.uid].filter(
-        (uid) => uid != null,
-      );
-
-      return uids.every((uid) => encounterUids.includes(uid));
-    },
-  );
-
-  if (matches.length !== 1) {
-    return null;
-  }
-
-  return matches[0][0];
-};
+import {
+  findCanonicalLocationForUids,
+  getTeamMemberUids,
+  updatePokemonByUID,
+  updateTeamMember,
+} from "./team";
 
 export const markTeamMemberAsDeceased = async (
   position: number,


### PR DESCRIPTION
## Summary
- Move team identity helpers (`getTeamMemberUids`, `findCanonicalLocationForUids`) into the team module so UID resolution and canonical location rules have one owner.
- Remove duplicated UID and encounter matching logic from team actions and reuse the shared team identity helpers.
- Add focused team identity tests to lock invariants around slot UID resolution and canonical location uniqueness.

## Validation
- `pnpm test:run src/stores/playthroughs/__tests__/team-identity.test.ts src/stores/playthroughs/__tests__/team-management.test.ts src/stores/playthroughs/__tests__/auto-assignment.test.ts src/stores/playthroughs/__tests__/encounter-cleanup.test.ts src/utils/__tests__/encounter-utils.test.ts`
- `pnpm type-check`