### PR TITLE
refactor(inf-149): deepen playthrough migration module

### DIFF
--- a/src/stores/playthroughs/__tests__/migrations.test.ts
+++ b/src/stores/playthroughs/__tests__/migrations.test.ts
@@ -269,6 +269,19 @@ describe("Migration Functions", () => {
       expect(teamMembers.every((member) => member === null)).toBe(true);
     });
 
+    it("should preserve legacy remix mode when gameMode is absent", () => {
+      const result = migratePlaythrough({
+        id: "test",
+        name: "Test",
+        remixMode: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      expect(result.gameMode).toBe("remix");
+      expect(result.remixMode).toBeUndefined();
+    });
+
     it("should handle data that needs no migration", () => {
       const data: MigrationData = {
         id: "test",
@@ -437,6 +450,18 @@ describe("Migration Functions", () => {
         isFusion: false,
         updatedAt: 1,
       });
+    });
+
+    it("leaves malformed import playthrough values for schema validation to reject", () => {
+      const malformedImport = {
+        exportedAt: "2026-05-11T00:00:00.000Z",
+        playthrough: null,
+      };
+
+      const migratedImport = migrateImportedPlaythroughData(malformedImport);
+
+      expect(migratedImport).toBe(malformedImport);
+      expect(() => ImportedPlaythroughSchema.parse(migratedImport)).toThrow();
     });
   });
 });

--- a/src/stores/playthroughs/__tests__/migrations.test.ts
+++ b/src/stores/playthroughs/__tests__/migrations.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   cleanupRemixMode,
   type MigrationData,
+  migrateImportedPlaythroughData,
   migratePlaythrough,
   migrateRemixMode,
   migrateTeamField,
   migrateVersion,
 } from "../migrations";
-import { PlaythroughSchema } from "../types";
+import { ImportedPlaythroughSchema, PlaythroughSchema } from "../types";
 
 type LegacyTeamMember = {
   headEncounterId: string;
@@ -364,6 +365,77 @@ describe("Migration Functions", () => {
         },
         isFusion: true,
         updatedAt: 1_700_000_000,
+      });
+    });
+  });
+
+  describe("schema validation boundary", () => {
+    it("validates current playthrough shape without performing legacy migration", () => {
+      const parsed = PlaythroughSchema.parse({
+        id: "current",
+        name: "Current Run",
+        gameMode: "classic",
+        version: "1.0.0",
+        team: { members: Array.from({ length: 6 }, () => null) },
+        encounters: {},
+        createdAt: 1,
+        updatedAt: 1,
+      });
+
+      expect(parsed).toEqual({
+        id: "current",
+        name: "Current Run",
+        gameMode: "classic",
+        version: "1.0.0",
+        team: { members: [null, null, null, null, null, null] },
+        encounters: {},
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+
+    it("normalizes legacy import payloads before current-shape validation", () => {
+      const migratedImport = migrateImportedPlaythroughData({
+        exportedAt: "2026-05-11T00:00:00.000Z",
+        playthrough: {
+          id: "legacy-import",
+          name: "Legacy Import",
+          remixMode: true,
+          gameMode: "classic",
+          team: {
+            members: {
+              0: {
+                headEncounterId: "route1:head",
+                bodyEncounterId: "route1:body",
+              },
+            },
+          },
+          encounters: {
+            route1: {
+              head: null,
+              body: null,
+              isFusion: false,
+              updatedAt: 1,
+              artworkVariant: "legacy-sprite-key",
+            },
+          },
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      });
+
+      const parsed = ImportedPlaythroughSchema.parse(migratedImport);
+
+      expect(parsed.playthrough.gameMode).toBe("remix");
+      expect(parsed.playthrough.team.members[0]).toEqual({
+        headPokemonUid: "",
+        bodyPokemonUid: "",
+      });
+      expect(parsed.playthrough.encounters?.route1).toEqual({
+        head: null,
+        body: null,
+        isFusion: false,
+        updatedAt: 1,
       });
     });
   });

--- a/src/stores/playthroughs/migrations.ts
+++ b/src/stores/playthroughs/migrations.ts
@@ -209,6 +209,30 @@ export function migrateOriginalReceivalStatus(
   return data;
 }
 
+export function cleanupEncounterArtworkVariant(
+  data: MigrationData,
+): MigrationData {
+  if (!data.encounters || typeof data.encounters !== "object") {
+    return data;
+  }
+
+  return {
+    ...data,
+    encounters: Object.fromEntries(
+      Object.entries(data.encounters).map(([locationId, encounter]) => {
+        if (!encounter || typeof encounter !== "object") {
+          return [locationId, encounter];
+        }
+
+        const { artworkVariant: _artworkVariant, ...cleanEncounter } =
+          encounter as Record<string, unknown>;
+
+        return [locationId, cleanEncounter];
+      }),
+    ),
+  };
+}
+
 /**
  * Ensure required fields exist with proper types
  */
@@ -274,7 +298,21 @@ export function migratePlaythrough(data: MigrationData): MigrationData {
   migratedData = migrateTeamField(migratedData);
   migratedData = migrateTeamMemberSchema(migratedData);
   migratedData = migrateOriginalReceivalStatus(migratedData);
+  migratedData = cleanupEncounterArtworkVariant(migratedData);
   migratedData = cleanupRemixMode(migratedData);
 
   return migratedData;
+}
+
+export function migrateImportedPlaythroughData(data: unknown): unknown {
+  if (!data || typeof data !== "object" || !("playthrough" in data)) {
+    return data;
+  }
+
+  return {
+    ...data,
+    playthrough: migratePlaythrough(
+      (data as { playthrough: MigrationData }).playthrough,
+    ),
+  };
 }

--- a/src/stores/playthroughs/migrations.ts
+++ b/src/stores/playthroughs/migrations.ts
@@ -22,7 +22,10 @@ export interface MigrationData {
  * Migrate remixMode to gameMode field
  */
 export function migrateRemixMode(data: MigrationData): MigrationData {
-  if (data.remixMode !== undefined && data.gameMode === "classic") {
+  if (
+    data.remixMode !== undefined &&
+    (data.gameMode === undefined || data.gameMode === "classic")
+  ) {
     return {
       ...data,
       gameMode: data.remixMode ? "remix" : "classic",
@@ -309,10 +312,18 @@ export function migrateImportedPlaythroughData(data: unknown): unknown {
     return data;
   }
 
+  const { playthrough } = data as { playthrough: unknown };
+
+  if (
+    !playthrough ||
+    typeof playthrough !== "object" ||
+    Array.isArray(playthrough)
+  ) {
+    return data;
+  }
+
   return {
     ...data,
-    playthrough: migratePlaythrough(
-      (data as { playthrough: MigrationData }).playthrough,
-    ),
+    playthrough: migratePlaythrough(playthrough as MigrationData),
   };
 }

--- a/src/stores/playthroughs/store.ts
+++ b/src/stores/playthroughs/store.ts
@@ -11,6 +11,7 @@ import type { PokemonOptionType } from "@/loaders/pokemon";
 import { buildPokemonUidIndex } from "@/utils/encounter-utils";
 import { generatePrefixedId } from "@/utils/id";
 import { createDefaultPlaythrough } from "./defaultPlaythrough";
+import { migrateImportedPlaythroughData } from "./migrations";
 import {
   createDebouncedSaveAll,
   deletePlaythroughFromIndexedDB,
@@ -326,9 +327,16 @@ const getGameMode = (): GameMode => {
 
 const importPlaythrough = async (importData: unknown): Promise<string> => {
   try {
-    // Validate the imported data against the schema
     const { ImportedPlaythroughSchema } = await import("./types");
-    const validatedData = ImportedPlaythroughSchema.parse(importData);
+    const migratedImportData = migrateImportedPlaythroughData(importData);
+    const validationResult =
+      ImportedPlaythroughSchema.safeParse(migratedImportData);
+
+    if (!validationResult.success) {
+      throw validationResult.error;
+    }
+
+    const validatedData = validationResult.data;
 
     // Extract the playthrough data - the transform ensures proper typing
     const importedPlaythrough = validatedData.playthrough;
@@ -348,7 +356,7 @@ const importPlaythrough = async (importData: unknown): Promise<string> => {
     const newPlaythrough: Playthrough = {
       id: finalId,
       name: importedPlaythrough.name,
-      gameMode: importedPlaythrough.gameMode as GameMode, // Type assertion since transform ensures it's GameMode
+      gameMode: importedPlaythrough.gameMode,
       version: importedPlaythrough.version || "1.0.0",
       createdAt: importedPlaythrough.createdAt,
       updatedAt: Date.now(), // Update to current time

--- a/src/stores/playthroughs/types.ts
+++ b/src/stores/playthroughs/types.ts
@@ -24,59 +24,29 @@ export const TeamSchema = z.object({
 
 export type Team = z.infer<typeof TeamSchema>;
 
-export const EncounterDataSchema = z
-  .object({
-    head: PokemonOptionSchema.nullable(),
-    body: PokemonOptionSchema.nullable(),
-    isFusion: z.boolean(),
-    updatedAt: z.number(),
-    // Keep artworkVariant for backward compatibility during migration
-    artworkVariant: z.string().optional(),
-  })
-  .transform((data) => {
-    // Migration logic: remove artworkVariant field if it exists
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { artworkVariant, ...cleanData } = data;
-    return cleanData;
-  });
+export const EncounterDataSchema = z.object({
+  head: PokemonOptionSchema.nullable(),
+  body: PokemonOptionSchema.nullable(),
+  isFusion: z.boolean(),
+  updatedAt: z.number(),
+});
 
 export type EncounterData = z.infer<typeof EncounterDataSchema>;
 
 // Zod schema for a single playthrough
-export const PlaythroughSchema = z
-  .object({
-    id: z.string(),
-    name: z.string(),
-    customLocations: z.array(CustomLocationSchema).optional(),
-    encounters: z.record(z.string(), EncounterDataSchema).optional(),
-    team: TeamSchema.default({
-      members: Array.from({ length: 6 }, () => null),
-    }), // Fixed size 6 with null values
-    gameMode: GameModeSchema.default("classic"),
-    // Keep remixMode for backward compatibility during migration
-    remixMode: z.boolean().optional(),
-    createdAt: z.number(),
-    updatedAt: z.number(),
-    version: z.string().default("1.0.0"),
-  })
-  .transform((data) => {
-    // Migration logic: if remixMode is provided and gameMode is default, use it to set gameMode
-    if (data.remixMode !== undefined && data.gameMode === "classic") {
-      const migratedData = {
-        ...data,
-        gameMode: data.remixMode ? "remix" : ("classic" as const),
-      };
-      // Remove remixMode field after migration
-      const { remixMode: _remixMode, ...cleanData } = migratedData;
-      return cleanData;
-    }
-    // Remove remixMode field even if no migration was needed (e.g., gameMode was already non-classic)
-    if (data.remixMode !== undefined) {
-      const { remixMode: _remixMode, ...cleanData } = data;
-      return cleanData;
-    }
-    return data;
-  });
+export const PlaythroughSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  customLocations: z.array(CustomLocationSchema).optional(),
+  encounters: z.record(z.string(), EncounterDataSchema).optional(),
+  team: TeamSchema.default({
+    members: Array.from({ length: 6 }, () => null),
+  }), // Fixed size 6 with null values
+  gameMode: GameModeSchema.default("classic"),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  version: z.string().default("1.0.0"),
+});
 
 // Zod schema for the playthroughs store
 export const PlaythroughsSchema = z.object({

--- a/tests/playthroughs/migration.test.ts
+++ b/tests/playthroughs/migration.test.ts
@@ -1,6 +1,7 @@
 // Import mocks first (must be at top level for Vitest hoisting)
 import "./mocks";
 
+import { migratePlaythrough } from "../../src/stores/playthroughs/migrations";
 // Import shared setup and utilities
 import {
   createMockPokemon,
@@ -17,13 +18,13 @@ describe("Playthroughs Store - Migration Tests", () => {
         id: "test-migration-1",
         name: "Legacy Remix Run",
         remixMode: true,
-        gameMode: "classic", // Default value
+        gameMode: "classic" as const, // Default value
         encounters: {},
         createdAt: Date.now(),
         updatedAt: Date.now(),
       };
 
-      const result = PlaythroughSchema.parse(legacyData);
+      const result = PlaythroughSchema.parse(migratePlaythrough(legacyData));
 
       expect(result.gameMode).toBe("remix");
       expect(result.name).toBe("Legacy Remix Run");
@@ -37,13 +38,13 @@ describe("Playthroughs Store - Migration Tests", () => {
         id: "test-migration-2",
         name: "Legacy Classic Run",
         remixMode: false,
-        gameMode: "classic", // Default value
+        gameMode: "classic" as const, // Default value
         encounters: {},
         createdAt: Date.now(),
         updatedAt: Date.now(),
       };
 
-      const result = PlaythroughSchema.parse(legacyData);
+      const result = PlaythroughSchema.parse(migratePlaythrough(legacyData));
 
       expect(result.gameMode).toBe("classic");
       expect(result.name).toBe("Legacy Classic Run");
@@ -63,7 +64,7 @@ describe("Playthroughs Store - Migration Tests", () => {
         updatedAt: Date.now(),
       };
 
-      const result = PlaythroughSchema.parse(modernData);
+      const result = PlaythroughSchema.parse(migratePlaythrough(modernData));
 
       // Should preserve explicit gameMode and remove remixMode
       expect(result.gameMode).toBe("randomized");
@@ -75,7 +76,7 @@ describe("Playthroughs Store - Migration Tests", () => {
         id: "test-migration-6",
         name: "Legacy Run with Data",
         remixMode: true,
-        gameMode: "classic",
+        gameMode: "classic" as const,
         encounters: {
           "route-1": {
             head: createMockPokemon("Pikachu", 25),
@@ -95,7 +96,9 @@ describe("Playthroughs Store - Migration Tests", () => {
         updatedAt: 1234567891,
       };
 
-      const result = PlaythroughSchema.parse(legacyDataWithEncounters);
+      const result = PlaythroughSchema.parse(
+        migratePlaythrough(legacyDataWithEncounters),
+      );
 
       expect(result.gameMode).toBe("remix");
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
Centralizes legacy playthrough normalization in the migration Module before current-shape validation, so load and import paths share the same migration ordering.

## Changes
- Remove legacy `remixMode` and `artworkVariant` transforms from current-shape Zod schemas.
- Add migration helpers for import payloads and legacy encounter artwork cleanup.
- Validate imported playthroughs after migration using `safeParse`.
- Update migration tests to separate migration behavior from current-shape schema validation.

## Validation
- `pnpm test:run tests/playthroughs/migration.test.ts src/stores/playthroughs/__tests__/migrations.test.ts src/stores/playthroughs/__tests__/persistence.initialization.test.ts`
- `pnpm type-check`
- `pnpm validate`
- Pre-push hook ran full `pnpm typecheck` and `pnpm test:run` successfully after the follow-up fix.

## Manual Testing
- Import a legacy export containing `remixMode` and confirm it loads as the expected `gameMode`.
- Load an existing browser-stored playthrough and confirm the active run, team slots, and encounters appear unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced playthrough import process with improved validation and better handling of legacy data formats from older versions.
  * Improved data normalization and cleanup during import to ensure seamless compatibility with previously exported playthroughs.

* **Tests**
  * Expanded test coverage for playthrough data migration and schema validation, including legacy format compatibility verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fbosch/infinite-fusion-nuzlocke/pull/217)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->