### PR TITLE
Refactor deep playthrough modules

### DIFF
--- a/src/components/PokemonCombobox/DraggableComboboxSprite.tsx
+++ b/src/components/PokemonCombobox/DraggableComboboxSprite.tsx
@@ -25,8 +25,8 @@ import { settingsStore } from "@/stores/settings";
 import usePokemonTypes from "../../hooks/usePokemonTypes";
 import ContextMenu, { type ContextMenuItem } from "../ContextMenu";
 import { CursorTooltip } from "../CursorTooltip";
-import { DraggableSpriteTooltipContent } from "./DraggableSpriteTooltipContent";
 import { PokemonSprite } from "../PokemonSprite";
+import { DraggableSpriteTooltipContent } from "./DraggableSpriteTooltipContent";
 
 const LocationSelector = dynamic(
   () =>
@@ -135,35 +135,12 @@ export function DraggableComboboxSprite({
   ) => {
     if (!value || !locationId) return;
 
-    // Check if there's already a Pokemon in the target slot
-    const activePlaythrough = getActivePlaythrough();
-    const targetEncounter = (
-      activePlaythrough?.encounters as Record<string, EncounterData> | undefined
-    )?.[targetLocationId];
-    const existingPokemon = targetEncounter
-      ? targetField === "head"
-        ? targetEncounter.head
-        : targetEncounter.body
-      : null;
-
-    if (existingPokemon) {
-      // If there's already a Pokemon in the target slot, swap them
-      await playthroughActions.swapEncounters(
-        locationId,
-        targetLocationId,
-        field,
-        targetField,
-      );
-    } else {
-      // If the target slot is empty, use atomic move to preserve other Pokemon at source
-      await playthroughActions.moveEncounterAtomic(
-        locationId,
-        field,
-        targetLocationId,
-        targetField,
-        value,
-      );
-    }
+    await playthroughActions.relocateEncounterSlot({
+      sourceLocationId: locationId,
+      sourceField: field,
+      targetLocationId,
+      targetField,
+    });
   };
 
   // Handle move to original location

--- a/src/components/PokemonCombobox/useComboboxDragAndDrop.ts
+++ b/src/components/PokemonCombobox/useComboboxDragAndDrop.ts
@@ -79,13 +79,12 @@ export function useComboboxDragAndDrop({
       const sourceLocation = getLocationInfo(dragSnapshot.currentDragSource);
       const targetLocation = getLocationInfo(comboboxId);
 
-      playthroughActions.moveEncounterAtomic(
-        sourceLocation.locationId,
-        sourceLocation.field,
-        targetLocation.locationId,
-        targetLocation.field,
-        pokemon,
-      );
+      playthroughActions.relocateEncounterSlot({
+        sourceLocationId: sourceLocation.locationId,
+        sourceField: sourceLocation.field,
+        targetLocationId: targetLocation.locationId,
+        targetField: targetLocation.field,
+      });
     },
     [dragSnapshot.currentDragSource, comboboxId, onChange, getLocationInfo],
   );
@@ -97,12 +96,12 @@ export function useComboboxDragAndDrop({
     const sourceLocation = getLocationInfo(dragSnapshot.currentDragSource);
     const targetLocation = getLocationInfo(comboboxId);
 
-    playthroughActions.swapEncounters(
-      sourceLocation.locationId,
-      targetLocation.locationId,
-      sourceLocation.field,
-      targetLocation.field,
-    );
+    playthroughActions.relocateEncounterSlot({
+      sourceLocationId: sourceLocation.locationId,
+      sourceField: sourceLocation.field,
+      targetLocationId: targetLocation.locationId,
+      targetField: targetLocation.field,
+    });
   }, [dragSnapshot.currentDragSource, comboboxId, getLocationInfo]);
 
   // Memoize drag state calculations

--- a/src/components/PokemonSummaryCard/PokemonContextMenu.tsx
+++ b/src/components/PokemonSummaryCard/PokemonContextMenu.tsx
@@ -118,73 +118,27 @@ export function PokemonContextMenu({
   // Handler for moving head Pokemon
   const handleMoveHead = useCallback(
     async (targetLocationId: string, targetField: "head" | "body") => {
-      if (!encounterData?.head) return;
-
-      // Check if there's already a Pokemon in the target slot
-      const activePlaythrough = playthroughActions.getActivePlaythrough();
-      const targetEncounter = activePlaythrough?.encounters?.[targetLocationId];
-      const existingPokemon = targetEncounter
-        ? targetField === "head"
-          ? targetEncounter.head
-          : targetEncounter.body
-        : null;
-
-      if (existingPokemon) {
-        // If there's already a Pokemon in the target slot, swap them
-        await playthroughActions.swapEncounters(
-          locationId,
-          targetLocationId,
-          "head",
-          targetField,
-        );
-      } else {
-        // If the target slot is empty, use atomic move to preserve other Pokemon at source
-        await playthroughActions.moveEncounterAtomic(
-          locationId,
-          "head",
-          targetLocationId,
-          targetField,
-          encounterData.head,
-        );
-      }
+      await playthroughActions.relocateEncounterSlot({
+        sourceLocationId: locationId,
+        sourceField: "head",
+        targetLocationId,
+        targetField,
+      });
     },
-    [encounterData, locationId],
+    [locationId],
   );
 
   // Handler for moving body Pokemon
   const handleMoveBody = useCallback(
     async (targetLocationId: string, targetField: "head" | "body") => {
-      if (!encounterData?.body) return;
-
-      // Check if there's already a Pokemon in the target slot
-      const activePlaythrough = playthroughActions.getActivePlaythrough();
-      const targetEncounter = activePlaythrough?.encounters?.[targetLocationId];
-      const existingPokemon = targetEncounter
-        ? targetField === "head"
-          ? targetEncounter.head
-          : targetEncounter.body
-        : null;
-
-      if (existingPokemon) {
-        // If there's already a Pokemon in the target slot, swap them
-        await playthroughActions.swapEncounters(
-          locationId,
-          targetLocationId,
-          "body",
-          targetField,
-        );
-      } else {
-        // If the target slot is empty, use atomic move to preserve other Pokemon at source
-        await playthroughActions.moveEncounterAtomic(
-          locationId,
-          "body",
-          targetLocationId,
-          targetField,
-          encounterData.body,
-        );
-      }
+      await playthroughActions.relocateEncounterSlot({
+        sourceLocationId: locationId,
+        sourceField: "body",
+        targetLocationId,
+        targetField,
+      });
     },
-    [encounterData, locationId],
+    [locationId],
   );
 
   const contextItems = useMemo<ContextMenuItem[]>(() => {

--- a/src/components/team/TeamMemberSelectionContext.tsx
+++ b/src/components/team/TeamMemberSelectionContext.tsx
@@ -20,6 +20,7 @@ import {
   findPokemonWithLocation,
   getAllPokemonWithLocations,
 } from "@/utils/encounter-utils";
+import { getTeamSelectionNickname } from "./teamMemberSelectionDomain";
 
 // Action types
 type TeamMemberSelectionAction =
@@ -149,20 +150,16 @@ function teamMemberSelectionReducer(
         action.payload;
 
       let updatedState = { ...state };
+      const selectionNickname = getTeamSelectionNickname(
+        headPokemon,
+        bodyPokemon,
+      );
 
       if (headPokemon && headLocationId) {
         updatedState = {
           ...updatedState,
           selectedHead: { pokemon: headPokemon, locationId: headLocationId },
         };
-        // Always prioritize head Pokémon's nickname
-        if (headPokemon.nickname) {
-          updatedState = {
-            ...updatedState,
-            nickname: headPokemon.nickname,
-            previewNickname: headPokemon.nickname,
-          };
-        }
       }
 
       if (bodyPokemon && bodyLocationId) {
@@ -170,17 +167,13 @@ function teamMemberSelectionReducer(
           ...updatedState,
           selectedBody: { pokemon: bodyPokemon, locationId: bodyLocationId },
         };
-        // Only set body Pokémon's nickname if head Pokémon doesn't have one
-        if (bodyPokemon.nickname && !headPokemon?.nickname) {
-          updatedState = {
-            ...updatedState,
-            nickname: bodyPokemon.nickname,
-            previewNickname: bodyPokemon.nickname,
-          };
-        }
       }
 
-      return updatedState;
+      return {
+        ...updatedState,
+        nickname: selectionNickname,
+        previewNickname: selectionNickname,
+      };
     }
     default:
       return state;
@@ -251,68 +244,12 @@ export function TeamMemberSelectionProvider({
 
   // Update nickname whenever the fusion order changes (head/body swap)
   useEffect(() => {
-    // Update nickname when fusion order changes
-    if (selectedHead?.pokemon && selectedBody?.pokemon) {
-      // For fusions, always prioritize head Pokémon's nickname
-      if (selectedHead.pokemon.nickname) {
-        dispatch({
-          type: "SET_NICKNAME",
-          payload: selectedHead.pokemon.nickname,
-        });
-        dispatch({
-          type: "SET_PREVIEW_NICKNAME",
-          payload: selectedHead.pokemon.nickname,
-        });
-      } else if (selectedBody.pokemon.nickname) {
-        // Fallback to body Pokémon's nickname if head doesn't have one
-        dispatch({
-          type: "SET_NICKNAME",
-          payload: selectedBody.pokemon.nickname,
-        });
-        dispatch({
-          type: "SET_PREVIEW_NICKNAME",
-          payload: selectedBody.pokemon.nickname,
-        });
-      } else {
-        // No nickname available
-        dispatch({ type: "SET_NICKNAME", payload: "" });
-        dispatch({ type: "SET_PREVIEW_NICKNAME", payload: "" });
-      }
-    } else if (selectedHead?.pokemon) {
-      // Single head Pokémon
-      if (selectedHead.pokemon.nickname) {
-        dispatch({
-          type: "SET_NICKNAME",
-          payload: selectedHead.pokemon.nickname,
-        });
-        dispatch({
-          type: "SET_PREVIEW_NICKNAME",
-          payload: selectedHead.pokemon.nickname,
-        });
-      } else {
-        dispatch({ type: "SET_NICKNAME", payload: "" });
-        dispatch({ type: "SET_PREVIEW_NICKNAME", payload: "" });
-      }
-    } else if (selectedBody?.pokemon) {
-      // Single body Pokémon
-      if (selectedBody.pokemon.nickname) {
-        dispatch({
-          type: "SET_NICKNAME",
-          payload: selectedBody.pokemon.nickname,
-        });
-        dispatch({
-          type: "SET_PREVIEW_NICKNAME",
-          payload: selectedBody.pokemon.nickname,
-        });
-      } else {
-        dispatch({ type: "SET_NICKNAME", payload: "" });
-        dispatch({ type: "SET_PREVIEW_NICKNAME", payload: "" });
-      }
-    } else {
-      // No Pokémon selected
-      dispatch({ type: "SET_NICKNAME", payload: "" });
-      dispatch({ type: "SET_PREVIEW_NICKNAME", payload: "" });
-    }
+    const selectionNickname = getTeamSelectionNickname(
+      selectedHead?.pokemon,
+      selectedBody?.pokemon,
+    );
+    dispatch({ type: "SET_NICKNAME", payload: selectionNickname });
+    dispatch({ type: "SET_PREVIEW_NICKNAME", payload: selectionNickname });
   }, [selectedHead, selectedBody]);
 
   // Pre-populate selections when editing existing team member
@@ -471,39 +408,20 @@ export function TeamMemberSelectionProvider({
         dispatch({ type: "SET_ACTIVE_SLOT", payload: "body" });
       }
 
-      // Set nickname based on selection priority
-      // For fusions, always prioritize head Pokémon nickname
-      // For single Pokémon, use the selected Pokémon's nickname
       if (slot === "head") {
-        // When selecting head Pokémon, use its nickname
-        if (pokemon.nickname) {
-          dispatch({ type: "SET_NICKNAME", payload: pokemon.nickname });
-          dispatch({ type: "SET_PREVIEW_NICKNAME", payload: pokemon.nickname });
-        } else {
-          dispatch({ type: "SET_NICKNAME", payload: "" });
-          dispatch({ type: "SET_PREVIEW_NICKNAME", payload: "" });
-        }
+        const selectionNickname = getTeamSelectionNickname(
+          pokemon,
+          selectedBody?.pokemon,
+        );
+        dispatch({ type: "SET_NICKNAME", payload: selectionNickname });
+        dispatch({ type: "SET_PREVIEW_NICKNAME", payload: selectionNickname });
       } else if (slot === "body") {
-        // When selecting body Pokémon, check if we have a head Pokémon
-        if (selectedHead?.pokemon?.nickname) {
-          // If head Pokémon has a nickname, use that (fusion priority)
-          dispatch({
-            type: "SET_NICKNAME",
-            payload: selectedHead.pokemon.nickname,
-          });
-          dispatch({
-            type: "SET_PREVIEW_NICKNAME",
-            payload: selectedHead.pokemon.nickname,
-          });
-        } else if (pokemon.nickname) {
-          // If no head nickname, use body Pokémon's nickname
-          dispatch({ type: "SET_NICKNAME", payload: pokemon.nickname });
-          dispatch({ type: "SET_PREVIEW_NICKNAME", payload: pokemon.nickname });
-        } else {
-          // No nickname available
-          dispatch({ type: "SET_NICKNAME", payload: "" });
-          dispatch({ type: "SET_PREVIEW_NICKNAME", payload: "" });
-        }
+        const selectionNickname = getTeamSelectionNickname(
+          selectedHead?.pokemon,
+          pokemon,
+        );
+        dispatch({ type: "SET_NICKNAME", payload: selectionNickname });
+        dispatch({ type: "SET_PREVIEW_NICKNAME", payload: selectionNickname });
       }
     },
     [selectedHead, selectedBody, activeSlot],

--- a/src/components/team/__tests__/teamMemberSelectionDomain.test.ts
+++ b/src/components/team/__tests__/teamMemberSelectionDomain.test.ts
@@ -26,6 +26,12 @@ describe("team member selection domain", () => {
     ).toBe("Flame");
   });
 
+  it("falls back to body nickname when head nickname is blank", () => {
+    expect(
+      getTeamSelectionNickname(pokemon("head", ""), pokemon("body", "Flame")),
+    ).toBe("Flame");
+  });
+
   it("returns empty nickname when no selected pokemon has one", () => {
     expect(getTeamSelectionNickname(pokemon("head"), pokemon("body"))).toBe("");
     expect(getTeamSelectionNickname(null, null)).toBe("");

--- a/src/components/team/__tests__/teamMemberSelectionDomain.test.ts
+++ b/src/components/team/__tests__/teamMemberSelectionDomain.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { PokemonOptionType } from "@/loaders/pokemon";
+import { getTeamSelectionNickname } from "../teamMemberSelectionDomain";
+
+const pokemon = (uid: string, nickname?: string): PokemonOptionType => ({
+  id: 25,
+  name: "Pikachu",
+  nationalDexId: 25,
+  uid,
+  nickname,
+});
+
+describe("team member selection domain", () => {
+  it("prioritizes head nickname for fusion selections", () => {
+    expect(
+      getTeamSelectionNickname(
+        pokemon("head", "Sparky"),
+        pokemon("body", "Flame"),
+      ),
+    ).toBe("Sparky");
+  });
+
+  it("falls back to body nickname when head has none", () => {
+    expect(
+      getTeamSelectionNickname(pokemon("head"), pokemon("body", "Flame")),
+    ).toBe("Flame");
+  });
+
+  it("returns empty nickname when no selected pokemon has one", () => {
+    expect(getTeamSelectionNickname(pokemon("head"), pokemon("body"))).toBe("");
+    expect(getTeamSelectionNickname(null, null)).toBe("");
+  });
+});

--- a/src/components/team/teamMemberSelectionDomain.ts
+++ b/src/components/team/teamMemberSelectionDomain.ts
@@ -1,0 +1,6 @@
+import type { PokemonOptionType } from "@/loaders/pokemon";
+
+export const getTeamSelectionNickname = (
+  headPokemon: PokemonOptionType | null | undefined,
+  bodyPokemon: PokemonOptionType | null | undefined,
+) => headPokemon?.nickname ?? bodyPokemon?.nickname ?? "";

--- a/src/components/team/teamMemberSelectionDomain.ts
+++ b/src/components/team/teamMemberSelectionDomain.ts
@@ -3,4 +3,9 @@ import type { PokemonOptionType } from "@/loaders/pokemon";
 export const getTeamSelectionNickname = (
   headPokemon: PokemonOptionType | null | undefined,
   bodyPokemon: PokemonOptionType | null | undefined,
-) => headPokemon?.nickname ?? bodyPokemon?.nickname ?? "";
+) =>
+  headPokemon?.nickname?.trim()
+    ? headPokemon.nickname
+    : bodyPokemon?.nickname?.trim()
+      ? bodyPokemon.nickname
+      : "";

--- a/src/hooks/playthroughImportExportWorkflow.ts
+++ b/src/hooks/playthroughImportExportWorkflow.ts
@@ -84,22 +84,11 @@ export const getImportErrorMessage = (error: unknown, fallback: string) => {
 };
 
 const resolvePlaythroughForImportAnalytics = async (playthroughId?: string) => {
-  if (
-    playthroughId &&
-    typeof playthroughActions.getAllPlaythroughs === "function"
-  ) {
-    const importedPlaythroughs = await playthroughActions.getAllPlaythroughs();
-    const importedPlaythrough = importedPlaythroughs.find(
-      (playthrough) => playthrough.id === playthroughId,
-    );
-
-    if (importedPlaythrough) {
-      return importedPlaythrough;
-    }
-  }
-
   if (typeof playthroughActions.getActivePlaythrough === "function") {
-    return playthroughActions.getActivePlaythrough();
+    const activePlaythrough = playthroughActions.getActivePlaythrough();
+    if (!playthroughId || activePlaythrough?.id === playthroughId) {
+      return activePlaythrough;
+    }
   }
 
   return null;

--- a/src/hooks/playthroughImportExportWorkflow.ts
+++ b/src/hooks/playthroughImportExportWorkflow.ts
@@ -1,0 +1,286 @@
+import { getSharedEventProperties } from "@/lib/analytics/selectors";
+import {
+  type FileExtensionGroup,
+  type ImportErrorCategory,
+  type ImportFailureStage,
+  type MimeGroup,
+  trackEvent,
+} from "@/lib/analytics/trackEvent";
+import {
+  type ExportedPlaythrough,
+  type GameMode,
+  type Playthrough,
+  playthroughActions,
+} from "@/stores/playthroughs";
+
+const IMPORT_SOURCE = "file_picker" as const;
+
+type ImportFileContext = {
+  hasFile: boolean;
+  fileExtensionGroup: FileExtensionGroup;
+  mimeGroup: MimeGroup;
+};
+
+type ImportPlaythroughFileResult =
+  | { ok: true }
+  | { ok: false; errorMessage: string };
+
+const getFileExtensionGroup = (fileName?: string): FileExtensionGroup => {
+  if (!fileName) {
+    return "other";
+  }
+
+  return fileName.toLowerCase().endsWith(".json") ? "json" : "other";
+};
+
+const getMimeGroup = (mimeType?: string): MimeGroup => {
+  if (!mimeType) {
+    return "empty";
+  }
+
+  if (mimeType === "application/json") {
+    return "application_json";
+  }
+
+  if (mimeType === "text/plain") {
+    return "text_plain";
+  }
+
+  return "other";
+};
+
+const createFileContext = (file?: File): ImportFileContext => {
+  if (!file) {
+    return {
+      hasFile: false,
+      fileExtensionGroup: "other",
+      mimeGroup: "empty",
+    };
+  }
+
+  return {
+    hasFile: true,
+    fileExtensionGroup: getFileExtensionGroup(file.name),
+    mimeGroup: getMimeGroup(file.type),
+  };
+};
+
+const isStorageFailureMessage = (message: string) => {
+  const normalizedMessage = message.toLowerCase();
+
+  return (
+    normalizedMessage.includes("quota") ||
+    normalizedMessage.includes("storage") ||
+    normalizedMessage.includes("indexeddb")
+  );
+};
+
+export const getImportErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+
+  return fallback;
+};
+
+const resolvePlaythroughForImportAnalytics = async (playthroughId?: string) => {
+  if (
+    playthroughId &&
+    typeof playthroughActions.getAllPlaythroughs === "function"
+  ) {
+    const importedPlaythroughs = await playthroughActions.getAllPlaythroughs();
+    const importedPlaythrough = importedPlaythroughs.find(
+      (playthrough) => playthrough.id === playthroughId,
+    );
+
+    if (importedPlaythrough) {
+      return importedPlaythrough;
+    }
+  }
+
+  if (typeof playthroughActions.getActivePlaythrough === "function") {
+    return playthroughActions.getActivePlaythrough();
+  }
+
+  return null;
+};
+
+const trackImportFailure = async ({
+  failureStage,
+  errorCategory,
+  fileContext,
+  playthroughId,
+}: {
+  failureStage: ImportFailureStage;
+  errorCategory: ImportErrorCategory;
+  fileContext: ImportFileContext;
+  playthroughId?: string;
+}) => {
+  const analyticsPlaythrough =
+    await resolvePlaythroughForImportAnalytics(playthroughId);
+  if (!analyticsPlaythrough) {
+    return;
+  }
+
+  trackEvent("playthrough_import_failed", {
+    ...getSharedEventProperties(analyticsPlaythrough),
+    import_source: IMPORT_SOURCE,
+    failure_stage: failureStage,
+    error_category: errorCategory,
+    has_file: fileContext.hasFile,
+    file_extension_group: fileContext.fileExtensionGroup,
+    mime_group: fileContext.mimeGroup,
+  });
+};
+
+const trackImportSuccess = async ({
+  playthroughId,
+  fileContext,
+}: {
+  playthroughId: string;
+  fileContext: ImportFileContext;
+}) => {
+  const analyticsPlaythrough =
+    await resolvePlaythroughForImportAnalytics(playthroughId);
+  if (!analyticsPlaythrough) {
+    return;
+  }
+
+  trackEvent("playthrough_imported", {
+    ...getSharedEventProperties(analyticsPlaythrough),
+    import_source: IMPORT_SOURCE,
+    file_extension_group: fileContext.fileExtensionGroup,
+    mime_group: fileContext.mimeGroup,
+  });
+};
+
+export const exportPlaythrough = (playthrough: Playthrough) => {
+  try {
+    const exportData: ExportedPlaythrough = {
+      version: "1.0.0",
+      exportedAt: new Date().toISOString(),
+      playthrough: {
+        id: playthrough.id,
+        name: playthrough.name,
+        gameMode: playthrough.gameMode as GameMode,
+        createdAt: playthrough.createdAt,
+        updatedAt: playthrough.updatedAt,
+        version: playthrough.version || "1.0.0",
+        customLocations: playthrough.customLocations,
+        encounters: playthrough.encounters,
+        team: playthrough.team,
+      },
+    };
+
+    const jsonString = JSON.stringify(exportData, null, 2);
+    const blob = new Blob([jsonString], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${playthrough.name.replace(/[^a-z0-9]/gi, "_").toLowerCase()}_playthrough.json`;
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+
+    trackEvent("playthrough_exported", getSharedEventProperties(playthrough));
+  } catch (error) {
+    console.error("Failed to export playthrough:", error);
+  }
+};
+
+export const importPlaythroughFile = async (
+  file: File,
+): Promise<ImportPlaythroughFileResult> => {
+  const fileContext = createFileContext(file);
+  let importFailureStage: ImportFailureStage = "unknown";
+  let importErrorCategory: ImportErrorCategory = "unexpected";
+
+  try {
+    if (!file.name.toLowerCase().endsWith(".json")) {
+      await trackImportFailure({
+        failureStage: "file_selection",
+        errorCategory: "unsupported_file_type",
+        fileContext,
+      });
+      return { ok: false, errorMessage: "File must have a .json extension" };
+    }
+
+    if (
+      file.type &&
+      file.type !== "application/json" &&
+      file.type !== "text/plain"
+    ) {
+      await trackImportFailure({
+        failureStage: "file_selection",
+        errorCategory: "unsupported_file_type",
+        fileContext,
+      });
+      return { ok: false, errorMessage: "File is not a valid JSON file" };
+    }
+
+    importFailureStage = "file_read";
+    const text = await file.text();
+
+    importFailureStage = "json_parse";
+    let data: unknown;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      await trackImportFailure({
+        failureStage: importFailureStage,
+        errorCategory: "invalid_json",
+        fileContext,
+      });
+      return { ok: false, errorMessage: "Invalid JSON syntax" };
+    }
+
+    importFailureStage = "store_import";
+    const newId = await playthroughActions.importPlaythrough(data);
+    await trackImportSuccess({
+      playthroughId: newId,
+      fileContext,
+    });
+
+    return { ok: true };
+  } catch (error) {
+    console.error("Failed to import playthrough:", error);
+
+    let errorMessage = "Import failed";
+
+    if (error instanceof Error) {
+      errorMessage = error.message;
+
+      if (importFailureStage === "store_import") {
+        if (error.message.startsWith("Validation failed:")) {
+          importFailureStage = "schema_validation";
+          importErrorCategory = "invalid_schema";
+        } else if (isStorageFailureMessage(error.message)) {
+          importErrorCategory = "storage_failure";
+        }
+      } else if (
+        importFailureStage === "file_read" &&
+        isStorageFailureMessage(error.message)
+      ) {
+        importErrorCategory = "storage_failure";
+      }
+    }
+
+    await trackImportFailure({
+      failureStage: importFailureStage,
+      errorCategory: importErrorCategory,
+      fileContext,
+    });
+
+    return { ok: false, errorMessage };
+  }
+};
+
+export const trackImportPickerFailure = async () => {
+  await trackImportFailure({
+    failureStage: "unknown",
+    errorCategory: "unexpected",
+    fileContext: createFileContext(),
+  });
+};

--- a/src/hooks/usePlaythroughImportExport.ts
+++ b/src/hooks/usePlaythroughImportExport.ts
@@ -1,201 +1,11 @@
 import { useCallback, useState } from "react";
-import { getSharedEventProperties } from "@/lib/analytics/selectors";
+import type { Playthrough } from "@/stores/playthroughs";
 import {
-  type FileExtensionGroup,
-  type ImportErrorCategory,
-  type ImportFailureStage,
-  type MimeGroup,
-  trackEvent,
-} from "@/lib/analytics/trackEvent";
-import {
-  type ExportedPlaythrough,
-  type GameMode,
-  type Playthrough,
-  playthroughActions,
-} from "@/stores/playthroughs";
-
-const IMPORT_SOURCE = "file_picker" as const;
-
-type ImportFileContext = {
-  hasFile: boolean;
-  fileExtensionGroup: FileExtensionGroup;
-  mimeGroup: MimeGroup;
-};
-
-const getFileExtensionGroup = (fileName?: string): FileExtensionGroup => {
-  if (!fileName) {
-    return "other";
-  }
-
-  return fileName.toLowerCase().endsWith(".json") ? "json" : "other";
-};
-
-const getMimeGroup = (mimeType?: string): MimeGroup => {
-  if (!mimeType) {
-    return "empty";
-  }
-
-  if (mimeType === "application/json") {
-    return "application_json";
-  }
-
-  if (mimeType === "text/plain") {
-    return "text_plain";
-  }
-
-  return "other";
-};
-
-const createFileContext = (file?: File): ImportFileContext => {
-  if (!file) {
-    return {
-      hasFile: false,
-      fileExtensionGroup: "other",
-      mimeGroup: "empty",
-    };
-  }
-
-  return {
-    hasFile: true,
-    fileExtensionGroup: getFileExtensionGroup(file.name),
-    mimeGroup: getMimeGroup(file.type),
-  };
-};
-
-const isStorageFailureMessage = (message: string) => {
-  const normalizedMessage = message.toLowerCase();
-
-  return (
-    normalizedMessage.includes("quota") ||
-    normalizedMessage.includes("storage") ||
-    normalizedMessage.includes("indexeddb")
-  );
-};
-
-const getErrorMessage = (error: unknown, fallback: string) => {
-  if (error instanceof Error && error.message.length > 0) {
-    return error.message;
-  }
-
-  return fallback;
-};
-
-const resolvePlaythroughForImportAnalytics = async (playthroughId?: string) => {
-  if (
-    playthroughId &&
-    typeof playthroughActions.getAllPlaythroughs === "function"
-  ) {
-    const importedPlaythroughs = await playthroughActions.getAllPlaythroughs();
-    const importedPlaythrough = importedPlaythroughs.find(
-      (playthrough) => playthrough.id === playthroughId,
-    );
-
-    if (importedPlaythrough) {
-      return importedPlaythrough;
-    }
-  }
-
-  if (typeof playthroughActions.getActivePlaythrough === "function") {
-    return playthroughActions.getActivePlaythrough();
-  }
-
-  return null;
-};
-
-const trackImportFailure = async ({
-  failureStage,
-  errorCategory,
-  fileContext,
-  playthroughId,
-}: {
-  failureStage: ImportFailureStage;
-  errorCategory: ImportErrorCategory;
-  fileContext: ImportFileContext;
-  playthroughId?: string;
-}) => {
-  const analyticsPlaythrough =
-    await resolvePlaythroughForImportAnalytics(playthroughId);
-  if (!analyticsPlaythrough) {
-    return;
-  }
-
-  trackEvent("playthrough_import_failed", {
-    ...getSharedEventProperties(analyticsPlaythrough),
-    import_source: IMPORT_SOURCE,
-    failure_stage: failureStage,
-    error_category: errorCategory,
-    has_file: fileContext.hasFile,
-    file_extension_group: fileContext.fileExtensionGroup,
-    mime_group: fileContext.mimeGroup,
-  });
-};
-
-const trackImportSuccess = async ({
-  playthroughId,
-  fileContext,
-}: {
-  playthroughId: string;
-  fileContext: ImportFileContext;
-}) => {
-  const analyticsPlaythrough =
-    await resolvePlaythroughForImportAnalytics(playthroughId);
-  if (!analyticsPlaythrough) {
-    return;
-  }
-
-  trackEvent("playthrough_imported", {
-    ...getSharedEventProperties(analyticsPlaythrough),
-    import_source: IMPORT_SOURCE,
-    file_extension_group: fileContext.fileExtensionGroup,
-    mime_group: fileContext.mimeGroup,
-  });
-};
-
-// Helper function to export playthrough data as JSON
-const exportPlaythrough = (playthrough: Playthrough) => {
-  try {
-    // Create a clean export object with only the necessary data
-    const exportData: ExportedPlaythrough = {
-      version: "1.0.0",
-      exportedAt: new Date().toISOString(),
-      playthrough: {
-        id: playthrough.id,
-        name: playthrough.name,
-        gameMode: playthrough.gameMode as GameMode,
-        createdAt: playthrough.createdAt,
-        updatedAt: playthrough.updatedAt,
-        version: playthrough.version || "1.0.0",
-        customLocations: playthrough.customLocations,
-        encounters: playthrough.encounters,
-        team: playthrough.team,
-      },
-    };
-
-    // Convert to JSON string with pretty formatting
-    const jsonString = JSON.stringify(exportData, null, 2);
-
-    // Create blob and download
-    const blob = new Blob([jsonString], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-
-    // Create download link
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = `${playthrough.name.replace(/[^a-z0-9]/gi, "_").toLowerCase()}_playthrough.json`;
-
-    // Trigger download
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-
-    // Clean up URL
-    URL.revokeObjectURL(url);
-
-    trackEvent("playthrough_exported", getSharedEventProperties(playthrough));
-  } catch (error) {
-    console.error("Failed to export playthrough:", error);
-  }
-};
+  exportPlaythrough,
+  getImportErrorMessage,
+  importPlaythroughFile,
+  trackImportPickerFailure,
+} from "./playthroughImportExportWorkflow";
 
 export function usePlaythroughImportExport() {
   const [showImportError, setShowImportError] = useState(false);
@@ -229,121 +39,24 @@ export function usePlaythroughImportExport() {
       input.accept = ".json,application/json,text/plain";
 
       input.onchange = async (e) => {
-        let importFailureStage: ImportFailureStage = "unknown";
-        let importErrorCategory: ImportErrorCategory = "unexpected";
-
         try {
           const target = e.target as HTMLInputElement;
           const file = target.files?.[0];
-          const fileContext = createFileContext(file);
 
           if (!file) {
-            input.remove();
             return;
           }
 
-          // Check file extension
-          if (!file.name.toLowerCase().endsWith(".json")) {
-            importFailureStage = "file_selection";
-            importErrorCategory = "unsupported_file_type";
-            await trackImportFailure({
-              failureStage: importFailureStage,
-              errorCategory: importErrorCategory,
-              fileContext,
-            });
-
-            setImportErrorMessage("File must have a .json extension");
+          const result = await importPlaythroughFile(file);
+          if (!result.ok) {
+            setImportErrorMessage(result.errorMessage);
             setShowImportError(true);
-            input.remove();
-            return;
           }
-
-          // Check MIME type if available
-          if (
-            file.type &&
-            file.type !== "application/json" &&
-            file.type !== "text/plain"
-          ) {
-            importFailureStage = "file_selection";
-            importErrorCategory = "unsupported_file_type";
-            await trackImportFailure({
-              failureStage: importFailureStage,
-              errorCategory: importErrorCategory,
-              fileContext,
-            });
-
-            setImportErrorMessage("File is not a valid JSON file");
-            setShowImportError(true);
-            input.remove();
-            return;
-          }
-
-          importFailureStage = "file_read";
-          const text = await file.text();
-
-          // Try to parse as JSON first to catch JSON syntax errors
-          importFailureStage = "json_parse";
-          let data: unknown;
-          try {
-            data = JSON.parse(text);
-          } catch {
-            importErrorCategory = "invalid_json";
-            await trackImportFailure({
-              failureStage: importFailureStage,
-              errorCategory: importErrorCategory,
-              fileContext,
-            });
-
-            setImportErrorMessage("Invalid JSON syntax");
-            setShowImportError(true);
-            input.remove();
-            return;
-          }
-
-          // Import the playthrough
-          importFailureStage = "store_import";
-          const newId = await playthroughActions.importPlaythrough(data);
-          await trackImportSuccess({
-            playthroughId: newId,
-            fileContext,
-          });
-
-          // Clean up
-          input.remove();
         } catch (error) {
           console.error("Failed to import playthrough:", error);
-
-          const file = (e.target as HTMLInputElement).files?.[0];
-          const fileContext = createFileContext(file);
-
-          let errorMessage = "Import failed";
-
-          if (error instanceof Error) {
-            errorMessage = error.message;
-
-            if (importFailureStage === "store_import") {
-              if (error.message.startsWith("Validation failed:")) {
-                importFailureStage = "schema_validation";
-                importErrorCategory = "invalid_schema";
-              } else if (isStorageFailureMessage(error.message)) {
-                importErrorCategory = "storage_failure";
-              }
-            } else if (
-              importFailureStage === "file_read" &&
-              isStorageFailureMessage(error.message)
-            ) {
-              importErrorCategory = "storage_failure";
-            }
-          }
-
-          await trackImportFailure({
-            failureStage: importFailureStage,
-            errorCategory: importErrorCategory,
-            fileContext,
-          });
-
-          setImportErrorMessage(errorMessage);
+          setImportErrorMessage(getImportErrorMessage(error, "Import failed"));
           setShowImportError(true);
+        } finally {
           input.remove();
         }
       };
@@ -351,14 +64,10 @@ export function usePlaythroughImportExport() {
       input.click();
     } catch (error) {
       console.error("Import failed:", error);
-      await trackImportFailure({
-        failureStage: "unknown",
-        errorCategory: "unexpected",
-        fileContext: createFileContext(),
-      });
+      await trackImportPickerFailure();
 
       setImportErrorMessage(
-        getErrorMessage(error, "Import failed. Please try again."),
+        getImportErrorMessage(error, "Import failed. Please try again."),
       );
       setShowImportError(true);
     }

--- a/src/stores/playthroughs/__tests__/drag-drop.test.ts
+++ b/src/stores/playthroughs/__tests__/drag-drop.test.ts
@@ -3,6 +3,7 @@ import {
   getLocationFromComboboxId,
   moveEncounter,
   moveEncounterAtomic,
+  relocateEncounterSlot,
   swapEncounters,
   updateEncounter,
 } from "../encounters";
@@ -27,6 +28,49 @@ describe("Encounter drag/drop operations", () => {
 
     expectTeamMember(activePlaythrough.team.members[0], "pikachu_route1_123");
     expect(activePlaythrough.encounters?.route1).toBeUndefined();
+    expect(activePlaythrough.encounters?.route2?.head?.uid).toBe(
+      "pikachu_route1_123",
+    );
+  });
+
+  it("relocates to an empty destination slot", async () => {
+    const { activePlaythrough } = createTestPlaythrough();
+    const pikachu = testPokemon.pikachu();
+
+    await updateEncounter("route1", pikachu, "head", false);
+
+    await relocateEncounterSlot({
+      sourceLocationId: "route1",
+      sourceField: "head",
+      targetLocationId: "route2",
+      targetField: "head",
+    });
+
+    expect(activePlaythrough.encounters?.route1).toBeUndefined();
+    expect(activePlaythrough.encounters?.route2?.head?.uid).toBe(
+      "pikachu_route1_123",
+    );
+    expectTeamMember(activePlaythrough.team.members[0], "pikachu_route1_123");
+  });
+
+  it("swaps when relocation destination slot is occupied", async () => {
+    const { activePlaythrough } = createTestPlaythrough();
+    const pikachu = testPokemon.pikachu();
+    const charmander = testPokemon.charmander("charmander_route2_456");
+
+    await updateEncounter("route1", pikachu, "head", false);
+    await updateEncounter("route2", charmander, "head", false);
+
+    await relocateEncounterSlot({
+      sourceLocationId: "route1",
+      sourceField: "head",
+      targetLocationId: "route2",
+      targetField: "head",
+    });
+
+    expect(activePlaythrough.encounters?.route1?.head?.uid).toBe(
+      "charmander_route2_456",
+    );
     expect(activePlaythrough.encounters?.route2?.head?.uid).toBe(
       "pikachu_route1_123",
     );

--- a/src/stores/playthroughs/__tests__/import-pipeline.test.ts
+++ b/src/stores/playthroughs/__tests__/import-pipeline.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prepareImportedPlaythrough } from "../importPipeline";
+
+const validImportData = (id = "playthrough_existing") => ({
+  version: "1.0.0",
+  exportedAt: new Date(0).toISOString(),
+  playthrough: {
+    id,
+    name: "Imported Run",
+    gameMode: "classic",
+    version: "1.0.0",
+    createdAt: 1,
+    updatedAt: 2,
+    encounters: {},
+    team: { members: [null, null, null, null, null, null] },
+  },
+});
+
+describe("playthrough import pipeline", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes valid imported data", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1234);
+
+    const playthrough = prepareImportedPlaythrough(validImportData(), []);
+
+    expect(playthrough).toMatchObject({
+      id: "playthrough_existing",
+      name: "Imported Run",
+      gameMode: "classic",
+      updatedAt: 1234,
+      customLocations: [],
+      encounters: {},
+      team: { members: [null, null, null, null, null, null] },
+    });
+  });
+
+  it("generates a new id when the imported id already exists", () => {
+    const playthrough = prepareImportedPlaythrough(validImportData(), [
+      "playthrough_existing",
+    ]);
+
+    expect(playthrough.id).not.toBe("playthrough_existing");
+    expect(playthrough.id).toMatch(/^playthrough_/);
+  });
+
+  it("throws a validation error for invalid import data", () => {
+    const invalidImportData = validImportData();
+    (invalidImportData.playthrough as Record<string, unknown>).customLocations =
+      [{ bad: "location" }];
+
+    expect(() => prepareImportedPlaythrough(invalidImportData, [])).toThrow(
+      "Validation failed:",
+    );
+  });
+});

--- a/src/stores/playthroughs/__tests__/playthrough-export-analytics.test.ts
+++ b/src/stores/playthroughs/__tests__/playthrough-export-analytics.test.ts
@@ -187,10 +187,9 @@ describe("usePlaythroughImportExport lifecycle analytics", () => {
     playthroughActionMocks.importPlaythrough.mockResolvedValue(
       importedPlaythrough.id,
     );
-    playthroughActionMocks.getAllPlaythroughs.mockReturnValue([
-      basePlaythrough,
+    playthroughActionMocks.getActivePlaythrough.mockReturnValue(
       importedPlaythrough,
-    ]);
+    );
 
     const { result } = renderHook(() => usePlaythroughImportExport());
 
@@ -203,6 +202,7 @@ describe("usePlaythroughImportExport lifecycle analytics", () => {
     expect(playthroughActionMocks.importPlaythrough).toHaveBeenCalledWith({
       playthrough: {},
     });
+    expect(playthroughActionMocks.getAllPlaythroughs).not.toHaveBeenCalled();
     expect(analyticsMocks.trackEvent).toHaveBeenCalledWith(
       "playthrough_imported",
       {

--- a/src/stores/playthroughs/encounters/dragDrop.ts
+++ b/src/stores/playthroughs/encounters/dragDrop.ts
@@ -62,6 +62,52 @@ export const clearEncounterFromLocation = async (
   }
 };
 
+export const relocateEncounterSlot = async ({
+  sourceLocationId,
+  sourceField,
+  targetLocationId,
+  targetField,
+}: {
+  sourceLocationId: string;
+  sourceField: "head" | "body";
+  targetLocationId: string;
+  targetField: "head" | "body";
+}) => {
+  if (sourceLocationId === targetLocationId && sourceField === targetField) {
+    return;
+  }
+
+  const activePlaythrough = ensureActivePlaythroughWithEncounters();
+  if (!activePlaythrough) {
+    return;
+  }
+
+  const sourceEncounter = activePlaythrough.encounters[sourceLocationId];
+  const pokemon = sourceEncounter?.[sourceField];
+  if (!pokemon) {
+    return;
+  }
+
+  const targetEncounter = activePlaythrough.encounters[targetLocationId];
+  if (targetEncounter?.[targetField]) {
+    await swapEncounters(
+      sourceLocationId,
+      targetLocationId,
+      sourceField,
+      targetField,
+    );
+    return;
+  }
+
+  await moveEncounterAtomic(
+    sourceLocationId,
+    sourceField,
+    targetLocationId,
+    targetField,
+    pokemon,
+  );
+};
+
 // Move encounter atomically from source to destination (for drag and drop)
 export const moveEncounterAtomic = async (
   sourceLocationId: string,

--- a/src/stores/playthroughs/encounters/index.ts
+++ b/src/stores/playthroughs/encounters/index.ts
@@ -11,6 +11,7 @@ export {
   moveEncounter,
   moveEncounterAtomic,
   moveToOriginalLocation,
+  relocateEncounterSlot,
   swapEncounters,
 } from "./dragDrop";
 export {

--- a/src/stores/playthroughs/importPipeline.ts
+++ b/src/stores/playthroughs/importPipeline.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import { generatePrefixedId } from "@/utils/id";
+import { migrateImportedPlaythroughData } from "./migrations";
+import { ImportedPlaythroughSchema, type Playthrough } from "./types";
+
+export const prepareImportedPlaythrough = (
+  importData: unknown,
+  existingIds: Iterable<string>,
+): Playthrough => {
+  try {
+    const migratedImportData = migrateImportedPlaythroughData(importData);
+    const validationResult =
+      ImportedPlaythroughSchema.safeParse(migratedImportData);
+
+    if (!validationResult.success) {
+      throw validationResult.error;
+    }
+
+    const importedPlaythrough = validationResult.data.playthrough;
+    const idSet = new Set(existingIds);
+    const finalId = idSet.has(importedPlaythrough.id)
+      ? generatePrefixedId("playthrough")
+      : importedPlaythrough.id;
+
+    return {
+      id: finalId,
+      name: importedPlaythrough.name,
+      gameMode: importedPlaythrough.gameMode,
+      version: importedPlaythrough.version || "1.0.0",
+      createdAt: importedPlaythrough.createdAt,
+      updatedAt: Date.now(),
+      customLocations: importedPlaythrough.customLocations || [],
+      encounters: importedPlaythrough.encounters || {},
+      team: importedPlaythrough.team || {
+        members: [null, null, null, null, null, null],
+      },
+    };
+  } catch (error) {
+    console.error("Failed to import playthrough:", error);
+
+    if (error && typeof error === "object" && "issues" in error) {
+      try {
+        const prettyError = z.prettifyError(error as z.ZodError);
+        throw new Error(`Validation failed:\n\n${prettyError}`);
+      } catch {
+        const zodError = error as z.ZodError;
+        if (zodError.issues && zodError.issues.length > 0) {
+          const errorDetails = zodError.issues
+            .map((issue: z.ZodIssue) => {
+              const path =
+                issue.path.length > 0 ? ` at ${issue.path.join(".")}` : "";
+              return `• ${issue.message}${path}`;
+            })
+            .join("\n");
+          throw new Error(`Validation failed:\n\n${errorDetails}`);
+        }
+        throw new Error("Data validation failed");
+      }
+    }
+
+    throw new Error("Invalid playthrough data format");
+  }
+};

--- a/src/stores/playthroughs/importPipeline.ts
+++ b/src/stores/playthroughs/importPipeline.ts
@@ -39,23 +39,31 @@ export const prepareImportedPlaythrough = (
     console.error("Failed to import playthrough:", error);
 
     if (error && typeof error === "object" && "issues" in error) {
+      const zodError = error as z.ZodError;
+      let prettyError: string | null = null;
+
       try {
-        const prettyError = z.prettifyError(error as z.ZodError);
-        throw new Error(`Validation failed:\n\n${prettyError}`);
+        prettyError = z.prettifyError(zodError);
       } catch {
-        const zodError = error as z.ZodError;
-        if (zodError.issues && zodError.issues.length > 0) {
-          const errorDetails = zodError.issues
-            .map((issue: z.ZodIssue) => {
-              const path =
-                issue.path.length > 0 ? ` at ${issue.path.join(".")}` : "";
-              return `• ${issue.message}${path}`;
-            })
-            .join("\n");
-          throw new Error(`Validation failed:\n\n${errorDetails}`);
-        }
-        throw new Error("Data validation failed");
+        // Fall back to manual issue formatting.
       }
+
+      if (prettyError) {
+        throw new Error(`Validation failed:\n\n${prettyError}`);
+      }
+
+      if (zodError.issues.length > 0) {
+        const errorDetails = zodError.issues
+          .map((issue: z.ZodIssue) => {
+            const path =
+              issue.path.length > 0 ? ` at ${issue.path.join(".")}` : "";
+            return `• ${issue.message}${path}`;
+          })
+          .join("\n");
+        throw new Error(`Validation failed:\n\n${errorDetails}`);
+      }
+
+      throw new Error("Data validation failed");
     }
 
     throw new Error("Invalid playthrough data format");

--- a/src/stores/playthroughs/index.ts
+++ b/src/stores/playthroughs/index.ts
@@ -32,6 +32,7 @@ export {
   moveToOriginalLocation,
   prefetchAdjacentVariants,
   preloadArtworkVariants,
+  relocateEncounterSlot,
   resetEncounter,
   restorePokemonToTeam,
   setArtworkVariant,

--- a/src/stores/playthroughs/store.ts
+++ b/src/stores/playthroughs/store.ts
@@ -325,9 +325,13 @@ const getGameMode = (): GameMode => {
 };
 
 const importPlaythrough = async (importData: unknown): Promise<string> => {
+  const persistedIds = (await loadAllPlaythroughs()).map((p) => p.id);
   const newPlaythrough = prepareImportedPlaythrough(
     importData,
-    playthroughsStore.playthroughs.map((p) => p.id),
+    new Set([
+      ...persistedIds,
+      ...playthroughsStore.playthroughs.map((p) => p.id),
+    ]),
   );
 
   playthroughsStore.playthroughs.push(newPlaythrough);

--- a/src/stores/playthroughs/store.ts
+++ b/src/stores/playthroughs/store.ts
@@ -1,6 +1,5 @@
 import { proxy, subscribe } from "valtio";
 import { devtools } from "valtio/utils";
-import { z } from "zod";
 import { getSharedEventProperties } from "@/lib/analytics/selectors";
 import {
   type SourceSurface,
@@ -11,7 +10,7 @@ import type { PokemonOptionType } from "@/loaders/pokemon";
 import { buildPokemonUidIndex } from "@/utils/encounter-utils";
 import { generatePrefixedId } from "@/utils/id";
 import { createDefaultPlaythrough } from "./defaultPlaythrough";
-import { migrateImportedPlaythroughData } from "./migrations";
+import { prepareImportedPlaythrough } from "./importPipeline";
 import {
   createDebouncedSaveAll,
   deletePlaythroughFromIndexedDB,
@@ -326,80 +325,15 @@ const getGameMode = (): GameMode => {
 };
 
 const importPlaythrough = async (importData: unknown): Promise<string> => {
-  try {
-    const { ImportedPlaythroughSchema } = await import("./types");
-    const migratedImportData = migrateImportedPlaythroughData(importData);
-    const validationResult =
-      ImportedPlaythroughSchema.safeParse(migratedImportData);
+  const newPlaythrough = prepareImportedPlaythrough(
+    importData,
+    playthroughsStore.playthroughs.map((p) => p.id),
+  );
 
-    if (!validationResult.success) {
-      throw validationResult.error;
-    }
+  playthroughsStore.playthroughs.push(newPlaythrough);
+  playthroughsStore.activePlaythroughId = newPlaythrough.id;
 
-    const validatedData = validationResult.data;
-
-    // Extract the playthrough data - the transform ensures proper typing
-    const importedPlaythrough = validatedData.playthrough;
-
-    // Check for ID conflicts and generate new ID if needed
-    const existingIds = new Set(
-      playthroughsStore.playthroughs.map((p) => p.id),
-    );
-    let finalId = importedPlaythrough.id;
-
-    if (existingIds.has(finalId)) {
-      // Generate a new unique ID with timestamp and crypto-secure random suffix
-      finalId = generatePrefixedId("playthrough");
-    }
-
-    // Create the new playthrough with migrated data
-    const newPlaythrough: Playthrough = {
-      id: finalId,
-      name: importedPlaythrough.name,
-      gameMode: importedPlaythrough.gameMode,
-      version: importedPlaythrough.version || "1.0.0",
-      createdAt: importedPlaythrough.createdAt,
-      updatedAt: Date.now(), // Update to current time
-      customLocations: importedPlaythrough.customLocations || [],
-      encounters: importedPlaythrough.encounters || {},
-      team: importedPlaythrough.team || {
-        members: [null, null, null, null, null, null],
-      }, // Fixed size 6 with null values
-    };
-
-    // Add to store
-    playthroughsStore.playthroughs.push(newPlaythrough);
-
-    // Set as active playthrough
-    playthroughsStore.activePlaythroughId = finalId;
-
-    return finalId;
-  } catch (error) {
-    console.error("Failed to import playthrough:", error);
-
-    // Handle Zod validation errors specifically
-    if (error && typeof error === "object" && "issues" in error) {
-      try {
-        const prettyError = z.prettifyError(error as z.ZodError);
-        throw new Error(`Validation failed:\n\n${prettyError}`);
-      } catch {
-        const zodError = error as z.ZodError;
-        if (zodError.issues && zodError.issues.length > 0) {
-          const errorDetails = zodError.issues
-            .map((issue: z.ZodIssue) => {
-              const path =
-                issue.path.length > 0 ? ` at ${issue.path.join(".")}` : "";
-              return `• ${issue.message}${path}`;
-            })
-            .join("\n");
-          throw new Error(`Validation failed:\n\n${errorDetails}`);
-        }
-        throw new Error("Data validation failed");
-      }
-    }
-
-    throw new Error("Invalid playthrough data format");
-  }
+  return newPlaythrough.id;
 };
 
 const isRandomizedModeEnabled = (): boolean => {


### PR DESCRIPTION
## Summary
- Add an encounter relocation API so UI callers request move/swap outcomes instead of orchestrating store internals.
- Extract team selection nickname precedence, playthrough import preparation, and import/export workflow mechanics into focused modules.
- Add focused tests for relocation, team selection nickname policy, and import pipeline validation.

## Validation
- pnpm type-check
- pnpm test:run
- pnpm validate

## Notes
- Draft PR for review while remaining deep-module candidates can be considered separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added playthrough import and export functionality, enabling users to save and load playthroughs from files.

* **Refactor**
  * Enhanced Pokémon encounter slot relocation and swapping logic for improved reliability.

* **Tests**
  * Added test coverage for playthrough import/export and encounter relocation operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fbosch/infinite-fusion-nuzlocke/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->