### PR TITLE
fix: skip hooks for data refresh PRs

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Create Pull Request with updated data
         if: steps.data-changes.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        env:
+          HUSKY: '0'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update Pokemon data files'


### PR DESCRIPTION
## Summary
- Disable Husky only for the automated data refresh PR creation step.
- Prevent lint-staged from blocking create-pull-request when refreshed JSON normalizes to an empty commit.

## Validation
- Parsed `.github/workflows/data-refresh.yml` as YAML locally.
- Confirmed Biome ignores the workflow file (`Checked 0 files`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to optimize pull request creation process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fbosch/infinite-fusion-nuzlocke/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->