### PR TITLE
fix: follow Pokédex subpages when scraping

### DIFF
--- a/scripts/scrape-pokedex.ts
+++ b/scripts/scrape-pokedex.ts
@@ -2,6 +2,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import * as cheerio from "cheerio";
 import { ConsoleFormatter } from "./utils/console-utils";
 import { fetchWikiPageHtml } from "./utils/wiki-fetch-utils";
@@ -10,7 +11,67 @@ const POKEDEX_URL = "https://infinitefusion.fandom.com/wiki/Pok%C3%A9dex";
 
 export type DexEntry = { id: number; name: string };
 
-async function scrapeDexEntries(): Promise<{ id: number; name: string }[]> {
+export function parseDexEntriesFromHtml(html: string): DexEntry[] {
+  const $ = cheerio.load(html);
+  const dexEntries: DexEntry[] = [];
+
+  $("table tr").each((_index: number, element: any) => {
+    const cells = $(element).find("td");
+    const dexNumber = Number.parseInt(cells.first().text().trim(), 10);
+    const nameText = cells.eq(2).text().trim();
+
+    if (!Number.isNaN(dexNumber) && dexNumber > 0 && nameText.length > 0) {
+      dexEntries.push({
+        id: dexNumber,
+        name: nameText,
+      });
+    }
+  });
+
+  return dexEntries;
+}
+
+export function extractPokedexSubpageTitles(html: string): string[] {
+  const $ = cheerio.load(html);
+  const titles = new Set<string>();
+
+  $('a[href^="/wiki/Pok%C3%A9dex/"]').each((_index: number, element: any) => {
+    const title = $(element).attr("title")?.trim();
+    if (title?.startsWith("Pokédex/") === true) {
+      titles.add(title);
+    }
+  });
+
+  return [...titles];
+}
+
+function getPokedexPageUrl(title: string): string {
+  const pathSegments = title
+    .split("/")
+    .map((segment) => encodeURIComponent(segment));
+  return `https://infinitefusion.fandom.com/wiki/${pathSegments.join("/")}`;
+}
+
+function mergeDexEntries(entries: DexEntry[]): DexEntry[] {
+  const entriesById = new Map<number, string>();
+
+  for (const entry of entries) {
+    const existingName = entriesById.get(entry.id);
+    if (existingName !== undefined && existingName !== entry.name) {
+      throw new Error(
+        `Conflicting Pokédex entry for ID ${entry.id}: "${existingName}" vs "${entry.name}"`,
+      );
+    }
+
+    entriesById.set(entry.id, entry.name);
+  }
+
+  return [...entriesById.entries()]
+    .map(([id, name]) => ({ id, name }))
+    .sort((a, b) => a.id - b.id);
+}
+
+async function scrapeDexEntries(): Promise<DexEntry[]> {
   ConsoleFormatter.printHeader(
     "Scraping Pokédex",
     "Scraping Pokédex entries from the wiki",
@@ -18,37 +79,30 @@ async function scrapeDexEntries(): Promise<{ id: number; name: string }[]> {
   const startTime = Date.now();
 
   try {
-    // Fetch the webpage
-    const html = await ConsoleFormatter.withSpinner(
+    const landingPageHtml = await ConsoleFormatter.withSpinner(
       "Fetching Pokédex page...",
       () => fetchWikiPageHtml(POKEDEX_URL),
     );
 
-    // Parse HTML with cheerio
-    const $ = cheerio.load(html);
+    const subpageTitles = extractPokedexSubpageTitles(landingPageHtml);
+    ConsoleFormatter.working(
+      subpageTitles.length > 0
+        ? `Fetching ${subpageTitles.length} Pokédex subpages...`
+        : "Extracting Pokédex entries from landing page...",
+    );
 
-    // Extract dex numbers from the table
-    const dexEntries: { id: number; name: string }[] = [];
+    const pageHtml = [landingPageHtml];
+    for (const title of subpageTitles) {
+      pageHtml.push(await fetchWikiPageHtml(getPokedexPageUrl(title)));
+    }
 
-    ConsoleFormatter.working("Extracting Pokédex entries from tables...");
+    const dexEntries = mergeDexEntries(
+      pageHtml.flatMap((html) => parseDexEntriesFromHtml(html)),
+    );
 
-    // Look for table rows with dex numbers
-    // The structure appears to be: first column contains the dex number
-    $("table tr").each((_index: number, element: any) => {
-      const firstCell = $(element).find("td").first();
-      const dexText = firstCell.text().trim();
-      const thirdCell = $(element).find("td").eq(2);
-      const nameText = thirdCell.text().trim();
-
-      // Check if this looks like a dex number (should be a number)
-      const dexNumber = parseInt(dexText, 10);
-      if (!Number.isNaN(dexNumber) && dexNumber > 0) {
-        dexEntries.push({
-          id: dexNumber,
-          name: nameText,
-        });
-      }
-    });
+    if (dexEntries.length === 0) {
+      throw new Error("No Pokédex entries found in wiki tables");
+    }
 
     // Add the special egg entry with ID -1 (required for egg encounters)
     dexEntries.unshift({
@@ -101,5 +155,6 @@ async function scrapeDexEntries(): Promise<{ id: number; name: string }[]> {
   }
 }
 
-// Run the scraper
-scrapeDexEntries();
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  scrapeDexEntries();
+}

--- a/tests/scrape-pokedex.test.ts
+++ b/tests/scrape-pokedex.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractPokedexSubpageTitles,
+  parseDexEntriesFromHtml,
+} from "../scripts/scrape-pokedex";
+
+describe("Pokédex scraper", () => {
+  it("extracts current Pokédex subpage links from the landing page", () => {
+    const html = [
+      '<a href="/wiki/Pok%C3%A9dex/Kanto/Classic" title="Pokédex/Kanto/Classic">Kanto Classic</a>',
+      '<a href="/wiki/Pok%C3%A9dex/Kanto/Remix" title="Pokédex/Kanto/Remix">Kanto Remix</a>',
+      '<a href="/wiki/Route_1" title="Route 1">Route 1</a>',
+    ].join("");
+
+    expect(extractPokedexSubpageTitles(html)).toEqual([
+      "Pokédex/Kanto/Classic",
+      "Pokédex/Kanto/Remix",
+    ]);
+  });
+
+  it("parses entry rows from regional Pokédex tables", () => {
+    const html = `
+      <table>
+        <tr>
+          <th>Dex</th>
+          <th colspan="2">Pokémon</th>
+        </tr>
+        <tr>
+          <td>132</td>
+          <td><span class="pokemon-icon"></span></td>
+          <td><a href="https://infinitefusiondex.com/details/132">Ditto</a></td>
+          <td>Normal</td>
+        </tr>
+      </table>
+    `;
+
+    expect(parseDexEntriesFromHtml(html)).toEqual([{ id: 132, name: "Ditto" }]);
+  });
+
+  it("returns no entries for landing page navigation tables", () => {
+    const html = `
+      <table>
+        <tr>
+          <td><a href="/wiki/Pok%C3%A9dex/Kanto/Classic" title="Pokédex/Kanto/Classic">Kanto Classic</a></td>
+          <td><a href="/wiki/Pok%C3%A9dex/Kanto/Remix" title="Pokédex/Kanto/Remix">Kanto Remix</a></td>
+        </tr>
+      </table>
+    `;
+
+    expect(parseDexEntriesFromHtml(html)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the Pokédex scraper after the wiki moved real Pokédex entries off the landing page and into regional subpages. The broken path wrote only the synthetic Egg entry, which caused the next data-refresh step to produce an empty Pokemon roster and made the wild encounter scraper fail resolving Ditto.

## Changes
- extract Pokédex subpage links from the landing page
- parse and merge unique entries from the linked Pokédex subpages
- fail loudly if no real Pokédex entries are found
- add regression coverage for the current landing-page and regional-table shapes

## Testing
- pnpm exec jiti scripts/scrape-pokedex.ts
- pnpm vitest run tests/scrape-pokedex.test.ts tests/scrape-wild-encounters-wikitext.test.ts
- pnpm type-check
- pnpm exec fallow audit --format json --quiet --explain
- git push origin hook: pnpm typecheck, pnpm test:run

Note: local validation reported the existing Node engine warning because this environment uses node 24 while the repo targets node 22.x.