### PR TITLE
fix: follow pokedex subpages when scraping

### DIFF
--- a/data/classic/gifts.json
+++ b/data/classic/gifts.json
@@ -40,6 +40,10 @@
     "pokemonIds": [253]
   },
   {
+    "routeName": "Littleroot Town",
+    "pokemonIds": [276, 279, 282]
+  },
+  {
     "routeName": "Mt. Moon",
     "pokemonIds": [138, 140]
   },

--- a/scripts/scrape-pokedex.ts
+++ b/scripts/scrape-pokedex.ts
@@ -2,6 +2,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import * as cheerio from "cheerio";
 import { ConsoleFormatter } from "./utils/console-utils";
 import { fetchWikiPageHtml } from "./utils/wiki-fetch-utils";
@@ -10,7 +11,67 @@ const POKEDEX_URL = "https://infinitefusion.fandom.com/wiki/Pok%C3%A9dex";
 
 export type DexEntry = { id: number; name: string };
 
-async function scrapeDexEntries(): Promise<{ id: number; name: string }[]> {
+export function parseDexEntriesFromHtml(html: string): DexEntry[] {
+  const $ = cheerio.load(html);
+  const dexEntries: DexEntry[] = [];
+
+  $("table tr").each((_index: number, element: any) => {
+    const cells = $(element).find("td");
+    const dexNumber = Number.parseInt(cells.first().text().trim(), 10);
+    const nameText = cells.eq(2).text().trim();
+
+    if (!Number.isNaN(dexNumber) && dexNumber > 0 && nameText.length > 0) {
+      dexEntries.push({
+        id: dexNumber,
+        name: nameText,
+      });
+    }
+  });
+
+  return dexEntries;
+}
+
+export function extractPokedexSubpageTitles(html: string): string[] {
+  const $ = cheerio.load(html);
+  const titles = new Set<string>();
+
+  $('a[href^="/wiki/Pok%C3%A9dex/"]').each((_index: number, element: any) => {
+    const title = $(element).attr("title")?.trim();
+    if (title?.startsWith("Pokédex/") === true) {
+      titles.add(title);
+    }
+  });
+
+  return [...titles];
+}
+
+function getPokedexPageUrl(title: string): string {
+  const pathSegments = title
+    .split("/")
+    .map((segment) => encodeURIComponent(segment));
+  return `https://infinitefusion.fandom.com/wiki/${pathSegments.join("/")}`;
+}
+
+function mergeDexEntries(entries: DexEntry[]): DexEntry[] {
+  const entriesById = new Map<number, string>();
+
+  for (const entry of entries) {
+    const existingName = entriesById.get(entry.id);
+    if (existingName !== undefined && existingName !== entry.name) {
+      throw new Error(
+        `Conflicting Pokédex entry for ID ${entry.id}: "${existingName}" vs "${entry.name}"`,
+      );
+    }
+
+    entriesById.set(entry.id, entry.name);
+  }
+
+  return [...entriesById.entries()]
+    .map(([id, name]) => ({ id, name }))
+    .sort((a, b) => a.id - b.id);
+}
+
+async function scrapeDexEntries(): Promise<DexEntry[]> {
   ConsoleFormatter.printHeader(
     "Scraping Pokédex",
     "Scraping Pokédex entries from the wiki",
@@ -18,37 +79,30 @@ async function scrapeDexEntries(): Promise<{ id: number; name: string }[]> {
   const startTime = Date.now();
 
   try {
-    // Fetch the webpage
-    const html = await ConsoleFormatter.withSpinner(
+    const landingPageHtml = await ConsoleFormatter.withSpinner(
       "Fetching Pokédex page...",
       () => fetchWikiPageHtml(POKEDEX_URL),
     );
 
-    // Parse HTML with cheerio
-    const $ = cheerio.load(html);
+    const subpageTitles = extractPokedexSubpageTitles(landingPageHtml);
+    ConsoleFormatter.working(
+      subpageTitles.length > 0
+        ? `Fetching ${subpageTitles.length} Pokédex subpages...`
+        : "Extracting Pokédex entries from landing page...",
+    );
 
-    // Extract dex numbers from the table
-    const dexEntries: { id: number; name: string }[] = [];
+    const pageHtml = [landingPageHtml];
+    for (const title of subpageTitles) {
+      pageHtml.push(await fetchWikiPageHtml(getPokedexPageUrl(title)));
+    }
 
-    ConsoleFormatter.working("Extracting Pokédex entries from tables...");
+    const dexEntries = mergeDexEntries(
+      pageHtml.flatMap((html) => parseDexEntriesFromHtml(html)),
+    );
 
-    // Look for table rows with dex numbers
-    // The structure appears to be: first column contains the dex number
-    $("table tr").each((_index: number, element: any) => {
-      const firstCell = $(element).find("td").first();
-      const dexText = firstCell.text().trim();
-      const thirdCell = $(element).find("td").eq(2);
-      const nameText = thirdCell.text().trim();
-
-      // Check if this looks like a dex number (should be a number)
-      const dexNumber = parseInt(dexText, 10);
-      if (!Number.isNaN(dexNumber) && dexNumber > 0) {
-        dexEntries.push({
-          id: dexNumber,
-          name: nameText,
-        });
-      }
-    });
+    if (dexEntries.length === 0) {
+      throw new Error("No Pokédex entries found in wiki tables");
+    }
 
     // Add the special egg entry with ID -1 (required for egg encounters)
     dexEntries.unshift({
@@ -101,5 +155,6 @@ async function scrapeDexEntries(): Promise<{ id: number; name: string }[]> {
   }
 }
 
-// Run the scraper
-scrapeDexEntries();
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  scrapeDexEntries();
+}

--- a/scripts/scrape-special-encounters.ts
+++ b/scripts/scrape-special-encounters.ts
@@ -3,11 +3,13 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as cheerio from "cheerio";
+import { extractPokedexSubpageTitles } from "./scrape-pokedex";
 import { ConsoleFormatter } from "./utils/console-utils";
 import { loadPokemonNameMap } from "./utils/data-loading-utils";
 import {
   findPokemonId,
   isPotentialPokemonName,
+  type PokemonNameMap,
 } from "./utils/pokemon-name-utils";
 import { fetchWikiPageHtml } from "./utils/wiki-fetch-utils";
 
@@ -15,6 +17,26 @@ const CLASSIC_POKEDEX_URL =
   "https://infinitefusion.fandom.com/wiki/Pok%C3%A9dex";
 const REMIX_POKEDEX_URL =
   "https://infinitefusion.fandom.com/wiki/Pok%C3%A9dex/Remix";
+
+function getPokedexPageUrl(title: string): string {
+  const pathSegments = title
+    .split("/")
+    .map((segment) => encodeURIComponent(segment));
+  return `https://infinitefusion.fandom.com/wiki/${pathSegments.join("/")}`;
+}
+
+export function getSpecialEncounterPokedexUrls(
+  html: string,
+  sourceUrl: string,
+  mode: "classic" | "remix",
+): string[] {
+  const modeSubpageSuffix = mode === "classic" ? "/Classic" : "/Remix";
+  const subpageUrls = extractPokedexSubpageTitles(html)
+    .filter((title) => title.endsWith(modeSubpageSuffix))
+    .map((title) => getPokedexPageUrl(title));
+
+  return subpageUrls.length > 0 ? subpageUrls : [sourceUrl];
+}
 
 /**
  * Handles special cases for Pokémon names that might not be found in the standard name map
@@ -118,6 +140,32 @@ interface LocationStatics {
   pokemonIds: number[];
 }
 
+type SpecialEncounterKind = "gift" | "trade" | "quest" | "static";
+
+interface SpecialEncounterItem {
+  pokemonId: number;
+  location: string;
+}
+
+interface SpecialEncounterCollection {
+  items: SpecialEncounterItem[];
+  seen: Set<string>;
+}
+
+interface SpecialEncounterAccumulator {
+  gift: SpecialEncounterCollection;
+  trade: SpecialEncounterCollection;
+  quest: SpecialEncounterCollection;
+  static: SpecialEncounterCollection;
+}
+
+interface SpecialEncounterResult {
+  gifts: LocationGifts[];
+  trades: LocationTrades[];
+  quests: LocationQuests[];
+  statics: LocationStatics[];
+}
+
 const SPECIAL_ENCOUNTER_MARKERS = ["(gift)", "(trade)", "(quest)", "(static)"];
 
 function findLocationCellText(cells: cheerio.Cheerio<any>): string {
@@ -132,6 +180,30 @@ function findLocationCellText(cells: cheerio.Cheerio<any>): string {
   }
 
   return "";
+}
+
+function getSpecialEncounterKind(
+  locationCell: string,
+): SpecialEncounterKind | null {
+  const normalizedLocation = locationCell.toLowerCase();
+
+  if (normalizedLocation.includes("(gift)")) {
+    return "gift";
+  }
+
+  if (normalizedLocation.includes("(trade)")) {
+    return "trade";
+  }
+
+  if (normalizedLocation.includes("(quest)")) {
+    return "quest";
+  }
+
+  if (normalizedLocation.includes("(static)")) {
+    return "static";
+  }
+
+  return null;
 }
 
 /**
@@ -260,204 +332,207 @@ function groupPokemonByLocation<
     .sort((a, b) => a.routeName.localeCompare(b.routeName)); // Sort locations alphabetically
 }
 
+function createSpecialEncounterAccumulator(): SpecialEncounterAccumulator {
+  return {
+    gift: { items: [], seen: new Set<string>() },
+    trade: { items: [], seen: new Set<string>() },
+    quest: { items: [], seen: new Set<string>() },
+    static: { items: [], seen: new Set<string>() },
+  };
+}
+
+function addSpecialEncounterItem(
+  collection: SpecialEncounterCollection,
+  pokemonCell: string,
+  pokemonId: number,
+  location: string,
+): void {
+  const uniqueKey = `${pokemonCell}-${location}`;
+  if (collection.seen.has(uniqueKey)) {
+    return;
+  }
+
+  collection.seen.add(uniqueKey);
+  collection.items.push({ pokemonId, location });
+}
+
+function addLocationEncounter(
+  collection: SpecialEncounterCollection,
+  pokemonCell: string,
+  pokemonId: number,
+  locationCell: string,
+): void {
+  const specificLocation = extractSpecialEncounterLocation(locationCell);
+  if (!specificLocation) {
+    ConsoleFormatter.warn(
+      `Could not extract specific location for ${pokemonCell}`,
+    );
+    return;
+  }
+
+  addSpecialEncounterItem(collection, pokemonCell, pokemonId, specificLocation);
+}
+
+function addStaticEncounters(
+  collection: SpecialEncounterCollection,
+  pokemonCell: string,
+  pokemonId: number,
+  locationCell: string,
+): void {
+  const staticLocations = extractStaticEncounterLocations(locationCell);
+  if (staticLocations.length === 0) {
+    ConsoleFormatter.warn(
+      `Could not extract static locations for ${pokemonCell}`,
+    );
+    return;
+  }
+
+  for (const staticLocation of staticLocations) {
+    addSpecialEncounterItem(collection, pokemonCell, pokemonId, staticLocation);
+  }
+}
+
+function addSpecialEncounterRow(
+  cells: cheerio.Cheerio<any>,
+  pokemonNameMap: PokemonNameMap,
+  accumulator: SpecialEncounterAccumulator,
+): void {
+  if (cells.length < 5) {
+    return;
+  }
+
+  const pokemonCell = cells.eq(2).text().trim();
+  if (
+    !pokemonCell ||
+    !isPotentialPokemonName(pokemonCell) ||
+    pokemonCell.toLowerCase().includes("pokemon")
+  ) {
+    return;
+  }
+
+  const locationCell = findLocationCellText(cells);
+  const encounterKind = getSpecialEncounterKind(locationCell);
+  if (encounterKind === null) {
+    return;
+  }
+
+  const pokemonId = findPokemonIdWithSpecialCases(pokemonCell, pokemonNameMap);
+  if (!pokemonId) {
+    ConsoleFormatter.warn(
+      `Could not find ID for ${encounterKind} Pokémon: ${pokemonCell}`,
+    );
+    return;
+  }
+
+  if (encounterKind === "static") {
+    addStaticEncounters(
+      accumulator.static,
+      pokemonCell,
+      pokemonId,
+      locationCell,
+    );
+    return;
+  }
+
+  addLocationEncounter(
+    accumulator[encounterKind],
+    pokemonCell,
+    pokemonId,
+    locationCell,
+  );
+}
+
+function addSpecialEncountersFromHtml(
+  html: string,
+  pokemonNameMap: PokemonNameMap,
+  accumulator: SpecialEncounterAccumulator,
+): void {
+  const $ = cheerio.load(html);
+
+  $("table tr").each((_rowIndex: number, row: any) => {
+    addSpecialEncounterRow($(row).find("td"), pokemonNameMap, accumulator);
+  });
+}
+
+async function fetchSpecialEncounterPokedexPages(
+  url: string,
+  mode: "classic" | "remix",
+): Promise<string[]> {
+  const sourceHtml = await ConsoleFormatter.withSpinner(
+    `Fetching ${mode} Pokédex page...`,
+    () => fetchWikiPageHtml(url),
+  );
+
+  const pokedexUrls = getSpecialEncounterPokedexUrls(sourceHtml, url, mode);
+  if (pokedexUrls.length === 1 && pokedexUrls[0] === url) {
+    return [sourceHtml];
+  }
+
+  ConsoleFormatter.working(
+    `Fetching ${pokedexUrls.length} ${mode} Pokédex subpages...`,
+  );
+
+  const pageHtml: string[] = [];
+  for (const pokedexUrl of pokedexUrls) {
+    pageHtml.push(await fetchWikiPageHtml(pokedexUrl));
+  }
+
+  return pageHtml;
+}
+
+function assertHasSpecialEncounters(
+  mode: "classic" | "remix",
+  result: SpecialEncounterResult,
+): void {
+  if (
+    result.gifts.length > 0 ||
+    result.trades.length > 0 ||
+    result.quests.length > 0 ||
+    result.statics.length > 0
+  ) {
+    return;
+  }
+
+  throw new Error(`No special encounters found in ${mode} Pokédex pages`);
+}
+
 async function scrapePokedexForSpecialEncounters(
   url: string,
   mode: "classic" | "remix",
-): Promise<{
-  gifts: LocationGifts[];
-  trades: LocationTrades[];
-  quests: LocationQuests[];
-  statics: LocationStatics[];
-}> {
+): Promise<SpecialEncounterResult> {
   ConsoleFormatter.printHeader(
     `Scraping ${mode.toUpperCase()} Special Encounters`,
     `Scraping gift, trade, quest, and static Pokémon data from the ${mode} Pokédex`,
   );
 
   try {
-    // Fetch the webpage
-    const html = await ConsoleFormatter.withSpinner(
-      `Fetching ${mode} Pokédex page...`,
-      () => fetchWikiPageHtml(url),
-    );
-
-    const $ = cheerio.load(html);
+    const pageHtml = await fetchSpecialEncounterPokedexPages(url, mode);
     const pokemonNameMap = await loadPokemonNameMap();
+    const accumulator = createSpecialEncounterAccumulator();
 
-    const gifts: { pokemonId: number; location: string }[] = [];
-    const trades: { pokemonId: number; location: string }[] = [];
-    const quests: { pokemonId: number; location: string }[] = [];
-    const statics: { pokemonId: number; location: string }[] = [];
-    const giftsSeen = new Set<string>();
-    const tradesSeen = new Set<string>();
-    const questsSeen = new Set<string>();
-    const staticsSeen = new Set<string>();
-
-    // Find the main Pokédex table
-    const tables = $("table");
-
-    tables.each((tableIndex: number, table: any) => {
-      const $table = $(table);
-      const rows = $table.find("tr");
-      console.log(`Processing table ${tableIndex} with ${rows.length} rows`);
-
-      rows.each((_rowIndex: number, row: any) => {
-        const $row = $(row);
-        const cells = $row.find("td");
-
-        // Skip header rows and rows with insufficient data
-        if (cells.length < 5) {
-          return;
-        }
-
-        // Extract data from cells
-        const _dexCell = cells.eq(0).text().trim();
-        const pokemonCell = cells.eq(2).text().trim(); // Pokémon name is at index 2
-        const locationCell = findLocationCellText(cells);
-
-        // Skip if no Pokémon name found or if it's a header row
-        if (
-          !pokemonCell ||
-          !isPotentialPokemonName(pokemonCell) ||
-          pokemonCell.toLowerCase().includes("pokemon")
-        ) {
-          return;
-        }
-
-        // Check if this is a gift, trade, quest, or static
-        const isGift = locationCell.toLowerCase().includes("(gift)");
-        const isTrade = locationCell.toLowerCase().includes("(trade)");
-        const isQuest = locationCell.toLowerCase().includes("(quest)");
-        const isStatic = locationCell.toLowerCase().includes("(static)");
-
-        if (!isGift && !isTrade && !isQuest && !isStatic) {
-          return;
-        }
-
-        // Find Pokémon ID
-        const pokemonId = findPokemonIdWithSpecialCases(
-          pokemonCell,
-          pokemonNameMap,
-        );
-        if (!pokemonId) {
-          const type = isGift
-            ? "gift"
-            : isTrade
-              ? "trade"
-              : isQuest
-                ? "quest"
-                : "static";
-          ConsoleFormatter.warn(
-            `Could not find ID for ${type} Pokémon: ${pokemonCell}`,
-          );
-          return;
-        }
-
-        if (isGift) {
-          // Extract the specific location that has the (gift), (trade), or (quest) marker
-          const specificLocation =
-            extractSpecialEncounterLocation(locationCell);
-          if (!specificLocation) {
-            ConsoleFormatter.warn(
-              `Could not extract specific location for ${pokemonCell}`,
-            );
-            return;
-          }
-
-          // Create unique key to avoid duplicates
-          const uniqueKey = `${pokemonCell}-${specificLocation}`;
-          if (giftsSeen.has(uniqueKey)) {
-            return;
-          }
-          giftsSeen.add(uniqueKey);
-
-          gifts.push({
-            pokemonId,
-            location: specificLocation,
-          });
-        } else if (isTrade) {
-          const specificLocation =
-            extractSpecialEncounterLocation(locationCell);
-          if (!specificLocation) {
-            ConsoleFormatter.warn(
-              `Could not extract specific location for ${pokemonCell}`,
-            );
-            return;
-          }
-
-          // Create unique key to avoid duplicates
-          const uniqueKey = `${pokemonCell}-${specificLocation}`;
-          if (tradesSeen.has(uniqueKey)) {
-            return;
-          }
-          tradesSeen.add(uniqueKey);
-
-          trades.push({
-            pokemonId,
-            location: specificLocation,
-          });
-        } else if (isQuest) {
-          const specificLocation =
-            extractSpecialEncounterLocation(locationCell);
-          if (!specificLocation) {
-            ConsoleFormatter.warn(
-              `Could not extract specific location for ${pokemonCell}`,
-            );
-            return;
-          }
-
-          // Create unique key to avoid duplicates
-          const uniqueKey = `${pokemonCell}-${specificLocation}`;
-          if (questsSeen.has(uniqueKey)) {
-            return;
-          }
-          questsSeen.add(uniqueKey);
-
-          quests.push({
-            pokemonId,
-            location: specificLocation,
-          });
-        } else if (isStatic) {
-          const staticLocations = extractStaticEncounterLocations(locationCell);
-          if (staticLocations.length === 0) {
-            ConsoleFormatter.warn(
-              `Could not extract static locations for ${pokemonCell}`,
-            );
-            return;
-          }
-
-          for (const staticLocation of staticLocations) {
-            const uniqueKey = `${pokemonCell}-${staticLocation}`;
-            if (staticsSeen.has(uniqueKey)) {
-              continue;
-            }
-            staticsSeen.add(uniqueKey);
-
-            statics.push({
-              pokemonId,
-              location: staticLocation,
-            });
-          }
-        }
-      });
-    });
+    for (const html of pageHtml) {
+      addSpecialEncountersFromHtml(html, pokemonNameMap, accumulator);
+    }
 
     // Group by location to match encounters.json structure
-    const groupedGifts = groupPokemonByLocation(gifts);
-    const groupedTrades = groupPokemonByLocation(trades);
-    const groupedQuests = groupPokemonByLocation(quests);
-    const groupedStatics = groupPokemonByLocation(statics);
-
-    ConsoleFormatter.success(
-      `Found ${gifts.length} gift Pokémon in ${groupedGifts.length} locations, ${trades.length} trades in ${groupedTrades.length} locations, ${quests.length} quest rewards in ${groupedQuests.length} locations, and ${statics.length} static encounters in ${groupedStatics.length} locations in ${mode} mode`,
-    );
-
-    return {
+    const groupedGifts = groupPokemonByLocation(accumulator.gift.items);
+    const groupedTrades = groupPokemonByLocation(accumulator.trade.items);
+    const groupedQuests = groupPokemonByLocation(accumulator.quest.items);
+    const groupedStatics = groupPokemonByLocation(accumulator.static.items);
+    const result = {
       gifts: groupedGifts,
       trades: groupedTrades,
       quests: groupedQuests,
       statics: groupedStatics,
     };
+
+    assertHasSpecialEncounters(mode, result);
+
+    ConsoleFormatter.success(
+      `Found ${accumulator.gift.items.length} gift Pokémon in ${groupedGifts.length} locations, ${accumulator.trade.items.length} trades in ${groupedTrades.length} locations, ${accumulator.quest.items.length} quest rewards in ${groupedQuests.length} locations, and ${accumulator.static.items.length} static encounters in ${groupedStatics.length} locations in ${mode} mode`,
+    );
+
+    return result;
   } catch (error) {
     ConsoleFormatter.error(
       `Error scraping ${mode} special encounters: ${error instanceof Error ? error.message : "Unknown error"}`,

--- a/tests/scrape-pokedex.test.ts
+++ b/tests/scrape-pokedex.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractPokedexSubpageTitles,
+  parseDexEntriesFromHtml,
+} from "../scripts/scrape-pokedex";
+
+describe("Pokédex scraper", () => {
+  it("extracts current Pokédex subpage links from the landing page", () => {
+    const html = [
+      '<a href="/wiki/Pok%C3%A9dex/Kanto/Classic" title="Pokédex/Kanto/Classic">Kanto Classic</a>',
+      '<a href="/wiki/Pok%C3%A9dex/Kanto/Remix" title="Pokédex/Kanto/Remix">Kanto Remix</a>',
+      '<a href="/wiki/Route_1" title="Route 1">Route 1</a>',
+    ].join("");
+
+    expect(extractPokedexSubpageTitles(html)).toEqual([
+      "Pokédex/Kanto/Classic",
+      "Pokédex/Kanto/Remix",
+    ]);
+  });
+
+  it("parses entry rows from regional Pokédex tables", () => {
+    const html = `
+      <table>
+        <tr>
+          <th>Dex</th>
+          <th colspan="2">Pokémon</th>
+        </tr>
+        <tr>
+          <td>132</td>
+          <td><span class="pokemon-icon"></span></td>
+          <td><a href="https://infinitefusiondex.com/details/132">Ditto</a></td>
+          <td>Normal</td>
+        </tr>
+      </table>
+    `;
+
+    expect(parseDexEntriesFromHtml(html)).toEqual([{ id: 132, name: "Ditto" }]);
+  });
+
+  it("returns no entries for landing page navigation tables", () => {
+    const html = `
+      <table>
+        <tr>
+          <td><a href="/wiki/Pok%C3%A9dex/Kanto/Classic" title="Pokédex/Kanto/Classic">Kanto Classic</a></td>
+          <td><a href="/wiki/Pok%C3%A9dex/Kanto/Remix" title="Pokédex/Kanto/Remix">Kanto Remix</a></td>
+        </tr>
+      </table>
+    `;
+
+    expect(parseDexEntriesFromHtml(html)).toEqual([]);
+  });
+});

--- a/tests/scrape-special-encounters.test.ts
+++ b/tests/scrape-special-encounters.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { extractStaticEncounterLocations } from "../scripts/scrape-special-encounters";
+import {
+  extractStaticEncounterLocations,
+  getSpecialEncounterPokedexUrls,
+} from "../scripts/scrape-special-encounters";
 
 describe("extractStaticEncounterLocations", () => {
   it("expands Trash Cans static locations to all listed locations", () => {
@@ -30,5 +33,36 @@ describe("extractStaticEncounterLocations", () => {
     );
 
     expect(locations).toEqual(["Route 11", "Route 12"]);
+  });
+});
+
+describe("getSpecialEncounterPokedexUrls", () => {
+  it("selects Classic subpages from the Pokédex landing page", () => {
+    const html = [
+      '<a href="/wiki/Pok%C3%A9dex/Kanto/Classic" title="Pokédex/Kanto/Classic">Kanto Classic</a>',
+      '<a href="/wiki/Pok%C3%A9dex/Kanto/Remix" title="Pokédex/Kanto/Remix">Kanto Remix</a>',
+      '<a href="/wiki/Pok%C3%A9dex/Hoenn/Classic" title="Pokédex/Hoenn/Classic">Hoenn Classic</a>',
+    ].join("");
+
+    expect(
+      getSpecialEncounterPokedexUrls(
+        html,
+        "https://infinitefusion.fandom.com/wiki/Pok%C3%A9dex",
+        "classic",
+      ),
+    ).toEqual([
+      "https://infinitefusion.fandom.com/wiki/Pok%C3%A9dex/Kanto/Classic",
+      "https://infinitefusion.fandom.com/wiki/Pok%C3%A9dex/Hoenn/Classic",
+    ]);
+  });
+
+  it("uses the source page when no matching subpage links exist", () => {
+    expect(
+      getSpecialEncounterPokedexUrls(
+        "<table><tr><td>1</td></tr></table>",
+        "https://infinitefusion.fandom.com/wiki/Pok%C3%A9dex/Remix",
+        "remix",
+      ),
+    ).toEqual(["https://infinitefusion.fandom.com/wiki/Pok%C3%A9dex/Remix"]);
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Littleroot Town as a new gift location to the database

* **Tests**
  * New test suites added for Pokédex scraping functionality to ensure data accuracy
  * New test suites added for special encounter detection and parsing logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->