### PR TITLE
ci: update workflows for Node 24 actions

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,6 +1,6 @@
 name: Setup Node.js and pnpm
 description: >
-  Checkout, install Node.js, set up pnpm with cache, and install
+  Checkout, install Node.js, set up pnpm with setup-node caching, and install
   frozen dependencies. Used by all CI jobs to avoid duplicating setup steps.
 
 inputs:

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -15,29 +15,18 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node-version }}
-
-    - name: Get pnpm store directory
-      shell: bash
-      run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-    - name: Setup pnpm cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+        cache: pnpm
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -79,7 +79,7 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-${{ github.sha }}
           path: coverage/
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -105,7 +105,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -145,7 +145,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -45,7 +45,7 @@ jobs:
           find data -name "*.json" -type f -exec du -h {} \;
 
       - name: Upload data artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pokemon-data
           path: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -88,17 +88,18 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
+          package-manager-cache: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Validate Vercel secrets
         run: |

--- a/.github/workflows/vercel-preview-on-demand.yml
+++ b/.github/workflows/vercel-preview-on-demand.yml
@@ -75,17 +75,18 @@ jobs:
           exit 1
 
       - name: Checkout PR head SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Intent

{"summary":"The developer wanted to fix GitHub Actions warnings caused by Node 20-based action versions by bumping affected workflow actions to Node 24-compatible majors while keeping the change minimal. They asked whether native setup-node package-manager caching should replace the repo’s custom pnpm cache setup, and wanted that simplification applied where dependencies are actually installed while keeping caching disabled where no install runs. They then asked to open a new PR for the workflow changes, implying committing, pushing through the repo’s Worktrunk workflow, and creating a concise PR after required validation."}

## What Changed

- Updated CI, data refresh, release, and Vercel preview workflows to use Node 24-compatible GitHub Action versions.
- Simplified the shared setup action to rely on `actions/setup-node` pnpm caching where dependencies are installed.
- Kept pnpm caching disabled for workflows that do not install dependencies.

## Risk Assessment

✅ Low: The diff is limited to GitHub Actions version bumps and native pnpm cache configuration, with no material correctness or security regressions found.

## Testing

The provided baseline install/type-check/test run had already passed, and I added a targeted workflow evidence check covering the changed CI, data-refresh, production deploy, and preview deploy paths; the evidence report passed and the worktree remained clean of transient testing artifacts.

<details>
<summary>Evidence: Workflow Node 24 and pnpm cache evidence</summary>

<code># Workflow Node 24 and pnpm Cache Evidence&#10;&#10;This report exercises the changed GitHub Actions user surface by inspecting the workflow paths a contributor or release operator would trigger.&#10;&#10;| Result | Workflow surface | File | Evidence |&#10;| --- | --- | --- | --- |&#10;| PASS | Composite setup action checks out with actions/checkout@v5 | .github/actions/setup-node-pnpm/action.yml | uses: actions/checkout@v5 |&#10;| PASS | Composite setup action uses pnpm/action-setup v5 | .github/actions/setup-node-pnpm/action.yml | uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5 |&#10;| PASS | Composite setup action uses actions/setup-node@v5 with native pnpm cache | .github/actions/setup-node-pnpm/action.yml | uses: actions/setup-node@v5 + cache: pnpm + pnpm install --frozen-lockfile |&#10;| PASS | CI artifact/cache actions use Node 24-compatible majors | .github/workflows/ci.yml | uses: actions/upload-artifact@v6; uses: actions/cache@v5 |&#10;| PASS | Data refresh upload-artifact uses v6 and dependency install still goes through cached composite setup | .github/workflows/data-refresh.yml | uses: actions/upload-artifact@v6; uses: ./.github/actions/setup-node-pnpm; pnpm run scrape |&#10;| PASS | Production deploy setup-node disables package-manager caching because no dependency install runs | .github/workflows/release-please.yml | uses: actions/setup-node@v5 with package-manager-cache: false; no pnpm install in deploy-production job |&#10;| PASS | On-demand preview installs dependencies after setup-node native pnpm cache is enabled | .github/workflows/vercel-preview-on-demand.yml | uses: actions/setup-node@v5 + cache: pnpm + pnpm install --frozen-lockfile |&#10;| PASS | No remaining old official action majors in changed workflow surface | .github | No actions/checkout@v4, actions/setup-node@v4, actions/upload-artifact@v4, or actions/cache@v4 in changed files |&#10;&#10;Overall result: PASS</code>

```text
# Workflow Node 24 and pnpm Cache Evidence

This report exercises the changed GitHub Actions user surface by inspecting the workflow paths a contributor or release operator would trigger.

| Result | Workflow surface | File | Evidence |
| --- | --- | --- | --- |
| PASS | Composite setup action checks out with actions/checkout@v5 | .github/actions/setup-node-pnpm/action.yml | uses: actions/checkout@v5 |
| PASS | Composite setup action uses pnpm/action-setup v5 | .github/actions/setup-node-pnpm/action.yml | uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5 |
| PASS | Composite setup action uses actions/setup-node@v5 with native pnpm cache | .github/actions/setup-node-pnpm/action.yml | uses: actions/setup-node@v5 + cache: pnpm + pnpm install --frozen-lockfile |
| PASS | CI artifact/cache actions use Node 24-compatible majors | .github/workflows/ci.yml | uses: actions/upload-artifact@v6; uses: actions/cache@v5 |
| PASS | Data refresh upload-artifact uses v6 and dependency install still goes through cached composite setup | .github/workflows/data-refresh.yml | uses: actions/upload-artifact@v6; uses: ./.github/actions/setup-node-pnpm; pnpm run scrape |
| PASS | Production deploy setup-node disables package-manager caching because no dependency install runs | .github/workflows/release-please.yml | uses: actions/setup-node@v5 with package-manager-cache: false; no pnpm install in deploy-production job |
| PASS | On-demand preview installs dependencies after setup-node native pnpm cache is enabled | .github/workflows/vercel-preview-on-demand.yml | uses: actions/setup-node@v5 + cache: pnpm + pnpm install --frozen-lockfile |
| PASS | No remaining old official action majors in changed workflow surface | .github | No actions/checkout@v4, actions/setup-node@v4, actions/upload-artifact@v4, or actions/cache@v4 in changed files |

Overall result: PASS
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm install --frozen-lockfile --prefer-offline && pnpm type-check && pnpm test:run`
- <code>Baseline already ran successfully before this validation: `pnpm install --frozen-lockfile --prefer-offline &amp;&amp; pnpm type-check &amp;&amp; pnpm test:run`</code>
- <code>Inspected target diff with `rtk git diff --stat 792cc65f7635e407f1bcdcfd6907543f6e6c0681..1d35e48e3b52c66d2f50c2ae715f483cb265f1b5` and `rtk git diff --name-only 792cc65f7635e407f1bcdcfd6907543f6e6c0681..1d35e48e3b52c66d2f50c2ae715f483cb265f1b5`</code>
- <code>Read `.github/actions/setup-node-pnpm/action.yml`, `.github/workflows/ci.yml`, `.github/workflows/data-refresh.yml`, `.github/workflows/release-please.yml`, and `.github/workflows/vercel-preview-on-demand.yml`</code>
- <code>Generated workflow evidence with `node - &lt;&lt;&#39;NODE&#39; &gt; /tmp/no-mistakes-evidence/01KVNBXWW0CQM70S2T8NR85YC6/workflow-node24-cache-evidence.md`</code>
- <code>Verified no source-tree test artifacts remained with `rtk git status --short`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
