### PR TITLE
build: add coverage badge automation

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -2,13 +2,7 @@
 pre-start = "pnpm install --frozen-lockfile --prefer-offline && sh ./.config/ensure-vercel-link.sh"
 
 [[pre-merge]]
-typecheck = "pnpm type-check"
-
-[[pre-merge]]
-tests = "pnpm test:run"
-
-[[pre-merge]]
-fallow = "pnpm quality:graph"
+quality = "pnpm quality:pre-push"
 
 [aliases]
 # Publish the current Worktrunk branch through the no-mistakes gate.

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -3,7 +3,3 @@ pre-start = "pnpm install --frozen-lockfile --prefer-offline && sh ./.config/ens
 
 [[pre-merge]]
 quality = "pnpm quality:pre-push"
-
-[aliases]
-# Publish the current Worktrunk branch through the no-mistakes gate.
-push-nomistakes = "git push no-mistakes HEAD:refs/heads/{{ branch }}"

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -13,7 +13,7 @@
     "duplicate-exports": "warn",
     "circular-dependencies": "warn",
     "boundary-violation": "warn",
-    "coverage-gaps": "off",
+    "coverage-gaps": "warn",
     "stale-suppressions": "warn"
   },
   "audit": {

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -19,6 +19,7 @@
   "audit": {
     "gate": "new-only"
   },
+  "ignorePatterns": [".opencode/skills/impeccable/**"],
   "duplicates": {
     "mode": "mild",
     "minTokens": 50,

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-pnpm exec lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,0 @@
-pnpm run typecheck
-pnpm run test:run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,6 @@ Pokemon Infinite Fusion Nuzlocke tracker with strict run-state invariants.
 ## Operational constraints
 
 - Keep repo-wide policy guidance minimal; put directory rules in local `AGENTS.md` files.
-- When pushing work intended for a PR, use `wt push-nomistakes` or `git push no-mistakes` instead of `git push origin`.
 - For targeted testing workflows, run the smallest relevant checks first before broader validation.
 - When work touches game-rule behavior or run-state logic, read relevant domain docs listed in `docs/agents/domain/README.md` and local `AGENTS.md` references.
 - Keep new guidance failure-mode-driven: prefer local `AGENTS.md` for path scope and narrow skills for repeated non-obvious implementation errors.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pnpm dev
 
 Open [http://localhost:4000](http://localhost:4000).
 
-If you use devenv, `devenv shell` provides the pinned Node.js, pnpm, git, GitHub CLI, Worktrunk, and no-mistakes tooling, then runs dependency and git hook setup on entry. Run `devenv tasks run no-mistakes:init` once when setting up the gated push remote.
+If you use devenv, `devenv shell` provides the pinned Node.js, pnpm, git, GitHub CLI, and Worktrunk tooling, then runs dependency and git hook setup on entry.
 
 ## Common Scripts
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Track Pokemon Infinite Fusion Nuzlocke runs with encounter logging, team and box
 [![React](https://img.shields.io/badge/React-19-149eca)](https://react.dev/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Coverage](docs/coverage.svg)](https://app.codecov.io/gh/fbosch/infinite-fusion-nuzlocke)
+[![Fallow health](docs/fallow.svg)](https://github.com/fallow-rs/fallow)
 
 Live app: [fusion.nuzlocke.io](https://fusion.nuzlocke.io)  
 Source: [github.com/fbosch/infinite-fusion-nuzlocke](https://github.com/fbosch/infinite-fusion-nuzlocke)

--- a/devenv.nix
+++ b/devenv.nix
@@ -51,9 +51,9 @@ in
   };
 
   tasks."git-hooks:init" = {
-    exec = "pnpm exec husky";
+    exec = "pnpm exec lefthook install";
     status = ''
-      [ "$(git config --get core.hooksPath 2>/dev/null)" = ".husky/_" ] && [ -f .husky/_/h ] && [ -x .husky/_/pre-commit ] && [ -x .husky/_/pre-push ]
+      [ -z "$(git config --get --local core.hooksPath 2>/dev/null)" ] && [ -x "$(git rev-parse --git-path hooks/pre-commit)" ] && [ -x "$(git rev-parse --git-path hooks/pre-push)" ]
     '';
     after = [ "pnpm:install" ];
     before = [ "devenv:enterShell" ];

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,22 +1,4 @@
 { config, pkgs, ... }:
-
-let
-  no-mistakes = pkgs.buildGoModule rec {
-    pname = "no-mistakes";
-    version = "1.22.3";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "kunchenguid";
-      repo = "no-mistakes";
-      rev = "v${version}";
-      hash = "sha256-+8SPfOaQlG0oxSDsws9XqzqNnhjL/eA/nk+4osSxrck=";
-    };
-
-    vendorHash = "sha256-2pjiHVUwdQpXG9HTLW6wMZD+JpvFEcPMgBsVc6sck6w=";
-
-    subPackages = [ "cmd/no-mistakes" ];
-  };
-in
 {
   languages.javascript = {
     enable = true;
@@ -28,19 +10,7 @@ in
     pkgs.git
     pkgs.gh
     pkgs.worktrunk
-    no-mistakes
   ];
-
-  tasks."no-mistakes:init" = {
-    exec = ''
-      cd "${config.env.DEVENV_ROOT}"
-      env -u GIT_DIR -u GIT_WORK_TREE ${no-mistakes}/bin/no-mistakes init
-    '';
-    status = ''
-      cd "${config.env.DEVENV_ROOT}"
-      env -u GIT_DIR -u GIT_WORK_TREE ${no-mistakes}/bin/no-mistakes status >/dev/null 2>&1 && env -u GIT_DIR -u GIT_WORK_TREE ${pkgs.git}/bin/git remote get-url no-mistakes >/dev/null 2>&1
-    '';
-  };
 
   tasks."pnpm:install" = {
     exec = "pnpm install --frozen-lockfile --prefer-offline";
@@ -60,7 +30,6 @@ in
   };
 
   enterTest = ''
-    no-mistakes --version
     git --version
     gh --version
     wt --version

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -1,0 +1,107 @@
+# Fallow Remediation Plan
+
+## Goal
+
+Resolve every first-party Fallow finding or record a narrow, reasoned exception. Keep vendored agent skills outside the application quality baseline.
+
+The initial full-project audit reported 317 dead-code findings, 365 complexity findings, and 52 duplication groups. The `.opencode/skills/impeccable` vendor subtree accounts for 56 dead-code findings, 211 complexity findings, and 15 duplication groups. The three phases below deliberately separate audit correctness, runtime safety, and broad maintainability work.
+
+## Working Rules
+
+- Trace an export, file, or dependency before removing it.
+- Add outcome-focused coverage before refactoring run-state, API, or interactive UI behavior.
+- Keep dependency direction one-way when breaking cycles; do not replace a cycle with a compatibility barrel.
+- Add a suppression only for an intentionally retained first-party finding and include its reason.
+- Validate each completed slice with the smallest relevant tests, then run the phase checks.
+
+## Phase 1: Trustworthy Audit And Easy Cleanup
+
+Purpose: make Fallow findings actionable and remove low-risk debt before structural refactors.
+
+- [x] Exclude `.opencode/skills/impeccable/**` from first-party Fallow reporting while preserving analysis of product code.
+- [ ] Configure Fallow to resolve the `@data/*` TypeScript alias rather than report it as an unlisted dependency.
+- [ ] Register or otherwise classify dynamic entry points, including the service worker, web worker, browser-test setup, and public runtime assets.
+- [ ] Verify the `pnpm-workspace.yaml` dependency override against the lockfile and either retain it with a narrow Fallow exception or remove it.
+- [ ] Trace `cheerio`, `cli-progress`, `pokedex-promise-v2`, and `tailwindcss`; move each to the dependency class required by its production execution path.
+- [ ] Trace the seven reported unused dependencies across application code, scripts, CI, and release flows; remove only packages with no consumer.
+- [ ] Remove verified unused files, types, props, class members, duplicate exports, and small export batches.
+- [ ] Record remaining first-party findings in a machine-readable baseline grouped by remediation phase.
+
+Acceptance criteria:
+
+- Vendored skill findings no longer affect the first-party baseline.
+- Dynamic entry points and aliases do not produce known false positives.
+- Every remaining Phase 1 finding is either removed or has a documented disposition.
+
+Validation:
+
+```bash
+pnpm type-check
+pnpm test:run
+pnpm validate
+pnpm quality:graph:json
+```
+
+## Phase 2: Structural And Runtime Safety
+
+Purpose: remove dependency-cycle and state-transition risks before broader cleanup.
+
+- [ ] Map the query, loader, service, data, and query-client import cycles to their public consumers and select one break point per underlying cycle.
+- [ ] Break the encounters/locations loader cycle with a one-way dependency boundary.
+- [ ] Break the query/loader/service cycle cluster without adding barrel-mediated cycles.
+- [ ] Add focused integration coverage for each changed query or loader request path.
+- [ ] Reconcile this phase with the existing encounter-transition architecture work to avoid parallel ownership changes.
+- [ ] Add outcome-focused tests for encounter CRUD state changes, including duplicate catches, nickname requirements, team placement, and death handling.
+- [ ] Simplify `updateEncounter`, artwork variants, and migration paths while preserving run-state invariants.
+- [ ] Inventory high-complexity API processors by request validation, decisions, side effects, and response behavior.
+- [ ] Refactor API processors one request path at a time, with success, invalid-input, and downstream-failure coverage.
+
+Acceptance criteria:
+
+- The mapped first-party circular dependencies are removed.
+- State transitions preserve Nuzlocke invariants under focused regression tests.
+- API contracts remain stable and affected complexity findings decrease.
+
+Validation:
+
+```bash
+pnpm type-check
+pnpm test:run
+pnpm validate
+pnpm quality:graph:json
+```
+
+Run browser, API, or migration tests for each affected slice.
+
+## Phase 3: Remaining Maintainability Debt
+
+Purpose: close the residual first-party findings through behavior-preserving refactors and verified cleanup.
+
+- [ ] Trace and reduce the public export surface in `src/stores/playthroughs/` without removing runtime or external consumers.
+- [ ] Remove remaining verified unused files, exports, and types in coherent module batches.
+- [ ] Add behavior and accessibility coverage for context-menu, summary-card, PC, team, and location interaction paths.
+- [ ] Refactor context-menu action construction and shared behavior before extracting common code.
+- [ ] Refactor summary-card and PC/team decision surfaces without widening component interfaces unnecessarily.
+- [ ] Resolve UI clone groups only where states and accessibility behavior are identical.
+- [ ] Group scraper and sprite clone findings by data-pipeline step.
+- [ ] Add deterministic input/output tests before consolidating script utilities.
+- [ ] Resolve remaining complexity findings by workflow or pipeline stage, prioritizing items with matching duplication findings.
+- [ ] Trace every remaining first-party finding and remove it, refactor it, configure it, or add a narrow reasoned suppression.
+- [ ] Save the resulting first-party baseline and keep the changed-code audit gate enabled.
+
+Acceptance criteria:
+
+- No first-party finding remains untriaged.
+- Remaining exceptions are intentional, narrow, and documented.
+- The audit baseline excludes only vendored code and approved exceptions.
+
+Validation:
+
+```bash
+pnpm type-check
+pnpm test:run
+pnpm validate
+pnpm quality:graph:json
+```
+
+Run browser and script checks for every affected workflow before closing the phase.

--- a/docs/coverage.svg
+++ b/docs/coverage.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20" role="img" aria-label="coverage: 39.38%">
+  <title>coverage: 39.38%</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="118" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="66" height="20" fill="#555"/>
+    <rect x="66" width="52" height="20" fill="#e05d44"/>
+    <rect width="118" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
+    <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+    <text x="33" y="14">coverage</text>
+    <text x="92" y="15" fill="#010101" fill-opacity=".3">39.38%</text>
+    <text x="92" y="14">39.38%</text>
+  </g>
+</svg>

--- a/docs/fallow.svg
+++ b/docs/fallow.svg
@@ -1,21 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20" role="img" aria-label="fallow: F (38)">
-<title>fallow: F (38)</title>
-<linearGradient id="s-323b4d39" x2="0" y2="100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="fallow: D (44)">
+<title>fallow: D (44)</title>
+<linearGradient id="s-2ed19f40" x2="0" y2="100%">
 <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 <stop offset="1" stop-opacity=".1"/>
 </linearGradient>
-<clipPath id="r-323b4d39">
-<rect width="88" height="20" rx="3" fill="#fff"/>
+<clipPath id="r-2ed19f40">
+<rect width="90" height="20" rx="3" fill="#fff"/>
 </clipPath>
-<g clip-path="url(#r-323b4d39)">
+<g clip-path="url(#r-2ed19f40)">
 <rect width="43" height="20" fill="#555"/>
-<rect x="43" width="45" height="20" fill="#e05d44"/>
-<rect width="88" height="20" fill="url(#s-323b4d39)"/>
+<rect x="43" width="47" height="20" fill="#fe7d37"/>
+<rect width="90" height="20" fill="url(#s-2ed19f40)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 <text aria-hidden="true" x="220" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">fallow</text>
 <text x="220" y="140" transform="scale(.1)" fill="#fff" textLength="330">fallow</text>
-<text aria-hidden="true" x="640" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="350">F (38)</text>
-<text x="640" y="140" transform="scale(.1)" fill="#fff" textLength="350">F (38)</text>
+<text aria-hidden="true" x="650" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">D (44)</text>
+<text x="650" y="140" transform="scale(.1)" fill="#fff" textLength="370">D (44)</text>
 </g>
 </svg>

--- a/docs/fallow.svg
+++ b/docs/fallow.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20" role="img" aria-label="fallow: F (38)">
+<title>fallow: F (38)</title>
+<linearGradient id="s-323b4d39" x2="0" y2="100%">
+<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+<stop offset="1" stop-opacity=".1"/>
+</linearGradient>
+<clipPath id="r-323b4d39">
+<rect width="88" height="20" rx="3" fill="#fff"/>
+</clipPath>
+<g clip-path="url(#r-323b4d39)">
+<rect width="43" height="20" fill="#555"/>
+<rect x="43" width="45" height="20" fill="#e05d44"/>
+<rect width="88" height="20" fill="url(#s-323b4d39)"/>
+</g>
+<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+<text aria-hidden="true" x="220" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">fallow</text>
+<text x="220" y="140" transform="scale(.1)" fill="#fff" textLength="330">fallow</text>
+<text aria-hidden="true" x="640" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="350">F (38)</text>
+<text x="640" y="140" transform="scale(.1)" fill="#fff" textLength="350">F (38)</text>
+</g>
+</svg>

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+output:
+  - failure
+  - summary
+
+pre-commit:
+  commands:
+    lint-staged:
+      run: pnpm exec lint-staged
+    badges:
+      run: pnpm badges:staged {staged_files}
+
+pre-push:
+  commands:
+    quality:
+      run: pnpm quality:pre-push

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:all": "biome lint src tests scripts data --vcs-use-ignore-file=true --files-ignore-unknown=true",
     "quality:graph": "fallow audit --format compact",
     "quality:graph:json": "fallow audit --format json --quiet --explain",
+    "quality:pre-push": "pnpm type-check && pnpm test:run && pnpm quality:graph",
     "format": "biome format --write src tests scripts data --vcs-use-ignore-file=true --files-ignore-unknown=true",
     "format:check": "biome check src tests scripts data --formatter-enabled=true --linter-enabled=false --assist-enabled=false --vcs-use-ignore-file=true --files-ignore-unknown=true",
     "validate": "pnpm format:check && pnpm lint",
@@ -31,6 +32,8 @@
     "test:coverage:watch": "vitest --coverage",
     "test:coverage:html": "vitest run --coverage --reporter=html",
     "coverage:badge": "node scripts/generate-coverage-badge.js",
+    "fallow:badge": "node scripts/generate-fallow-badge.js",
+    "badges:staged": "node scripts/update-staged-badges.js",
     "react-doctor:badge": "node scripts/generate-react-doctor-badge.js",
     "coverage:full": "pnpm test:coverage && pnpm coverage:badge",
     "analyze": "ANALYZE=true pnpm build",
@@ -47,7 +50,7 @@
     "sprites:download": "jiti scripts/scrape-pokemon-icons.ts",
     "spritesheet": "pnpm run sprites:download && jiti scripts/generate-spritesheet.ts",
     "mcp:test": "npx -y @modelcontextprotocol/inspector npx @upstash/context7-mcp",
-    "prepare": "husky"
+    "prepare": "lefthook install"
   },
   "dependencies": {
     "@floating-ui/react": "^0.27.20",
@@ -109,9 +112,9 @@
     "cli-progress": "^3.12.0",
     "fallow": "^3.6.0",
     "happy-dom": "^20.10.6",
-    "husky": "^9.1.7",
     "jiti": "^2.7.0",
     "jsdom": "^29.1.1",
+    "lefthook": "^2.1.9",
     "lint-staged": "^17.0.8",
     "npm-run-all": "^4.1.5",
     "oxipng": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,15 +199,15 @@ importers:
       happy-dom:
         specifier: ^20.10.6
         version: 20.10.6(bufferutil@4.0.9)
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      lefthook:
+        specifier: ^2.1.9
+        version: 2.1.10
       lint-staged:
         specifier: ^17.0.8
         version: 17.0.8
@@ -3129,11 +3129,6 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
-  husky@9.1.7:
-    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -3395,6 +3390,60 @@ packages:
 
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
+  lefthook-darwin-arm64@2.1.10:
+    resolution: {integrity: sha512-nw+X8wRNDoUUV6WSteyKBbcLySq+fsmZt5WV/s50ZJpysmsDKJOUMln6SllNfP+60dzUahAO7REco/2633BsLg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.10:
+    resolution: {integrity: sha512-KQ/bHmvpkFdHMn4pZnUdTf+GuSC+aBBgBTxZT4GW+6cSf+qbErKZBhK7cH6BmILsvx43+VzEArvHYY7YOfRFOQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.10:
+    resolution: {integrity: sha512-8su6DwydP7+pv7kG0zCtjphqsw4ouOnfexRUErapy5GTxYBoUOhYz3RSHTSWNRsK6W4jva7FPUh2Lp5/PSn30w==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.10:
+    resolution: {integrity: sha512-GeAJEFxko3Lk+AsnS3NleAFrpyMLFUKOlgJvPKuU0xHwVEI/z+ZoCcmuO0BX+4CS0NLbZhC/YQAvBASqDvvVdQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.10:
+    resolution: {integrity: sha512-1sHTCmpTWjVMs+yKPBLRNT1kuuIr1yjietlk7rCB6wFPVOS6Ph3o2zPFH2AvW1UymHlqwyHXzBr9EtDpQ7j1mQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.10:
+    resolution: {integrity: sha512-z/VlRB3bh6mBvW3r1rwnJ5vP8z+Krx5gJzkZ4veDXh+6FlRTx8wtd3g3fllOv/yZMxkgmL3fQoFXv05Esa7vBQ==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.10:
+    resolution: {integrity: sha512-430zL8sSIKw5P0YXGG6PB+eAhHa06n0PXuaERaAQE4Ss3odfqwnl5Mq9hQmkEnOS1EGiQEKkd0UHv/i4PtMNIQ==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.10:
+    resolution: {integrity: sha512-bgkO8PphGZVDhQgCJ524aYYPI5491pVmCiLPGjBIo1AvOSlIyw4N1Y+1C3QfqwEmechzw+Aq16SNc8pqv6UuXg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.10:
+    resolution: {integrity: sha512-5Q6etF0Fla2DDA4ilDySrdNgiR5+W7cJZwnZ69Je3kvWCaWm4wnkuc8FEdjp3kiL2x3ZXipdI00f5vpO8aWmog==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.10:
+    resolution: {integrity: sha512-c/XH8YZtylG4XaxzqFfXluvq2LXq2W/p54Bnzn3+Z7E5X2Fk3JlFJAibulMbIt2+w8T7UI/r97ok5GqE4kGaeA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.10:
+    resolution: {integrity: sha512-K7mM4WoqMwqfXYK11EHy+lSH1uW8XHni3Yn/bSqyerPkUPygGdf3xn18JoV5HyA06xuQL3ofGAOjG01QX9oJ4w==}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -7831,8 +7880,6 @@ snapshots:
 
   human-signals@5.0.0: {}
 
-  husky@9.1.7: {}
-
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -8079,6 +8126,49 @@ snapshots:
   keyv@5.6.0:
     dependencies:
       '@keyv/serialize': 1.1.1
+
+  lefthook-darwin-arm64@2.1.10:
+    optional: true
+
+  lefthook-darwin-x64@2.1.10:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.10:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.10:
+    optional: true
+
+  lefthook-linux-arm64@2.1.10:
+    optional: true
+
+  lefthook-linux-x64@2.1.10:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.10:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.10:
+    optional: true
+
+  lefthook-windows-arm64@2.1.10:
+    optional: true
+
+  lefthook-windows-x64@2.1.10:
+    optional: true
+
+  lefthook@2.1.10:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.10
+      lefthook-darwin-x64: 2.1.10
+      lefthook-freebsd-arm64: 2.1.10
+      lefthook-freebsd-x64: 2.1.10
+      lefthook-linux-arm64: 2.1.10
+      lefthook-linux-x64: 2.1.10
+      lefthook-openbsd-arm64: 2.1.10
+      lefthook-openbsd-x64: 2.1.10
+      lefthook-windows-arm64: 2.1.10
+      lefthook-windows-x64: 2.1.10
 
   lightningcss-android-arm64@1.32.0:
     optional: true

--- a/scripts/generate-coverage-badge.js
+++ b/scripts/generate-coverage-badge.js
@@ -1,152 +1,82 @@
 #!/usr/bin/env node
 
-/**
- * Generate a coverage badge for the README
- * Run with: node scripts/generate-coverage-badge.js
- */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 
-import fs from "node:fs";
-import path from "node:path";
+const coveragePath = "coverage/coverage-summary.json";
+const coverageColors = [
+  [90, "#4c1"],
+  [80, "#97ca00"],
+  [70, "#a4a61d"],
+  [60, "#dfb317"],
+  [50, "#fe7d37"],
+  [0, "#e05d44"],
+];
+const coverage = JSON.parse(await readFile(coveragePath, "utf8"));
+const lineCoverage = coverage.total?.lines?.pct;
 
-function generateCoverageBadge() {
-  try {
-    // Read the coverage summary
-    const coveragePath = path.join(
-      process.cwd(),
-      "coverage",
-      "coverage-final.json",
-    );
-
-    if (!fs.existsSync(coveragePath)) {
-      console.log('Coverage report not found. Run "pnpm test:coverage" first.');
-      return;
-    }
-
-    const coverageData = JSON.parse(fs.readFileSync(coveragePath, "utf8"));
-
-    // Calculate coverage from the coverage-final.json format
-    let totalStatements = 0;
-    let coveredStatements = 0;
-    let totalFunctions = 0;
-    let coveredFunctions = 0;
-    let totalBranches = 0;
-    let coveredBranches = 0;
-    let totalLines = 0;
-    let coveredLines = 0;
-
-    // Process each file's coverage data
-    Object.values(coverageData).forEach((fileData) => {
-      if (fileData.s) {
-        // Statements
-        Object.values(fileData.s).forEach((hit) => {
-          totalStatements++;
-          if (hit > 0) coveredStatements++;
-        });
-      }
-
-      if (fileData.f) {
-        // Functions
-        Object.values(fileData.f).forEach((hit) => {
-          totalFunctions++;
-          if (hit > 0) coveredFunctions++;
-        });
-      }
-
-      if (fileData.b) {
-        // Branches
-        Object.values(fileData.b).forEach((hits) => {
-          if (Array.isArray(hits)) {
-            totalBranches += hits.length;
-            hits.forEach((hit) => {
-              if (hit > 0) coveredBranches++;
-            });
-          }
-        });
-      }
-
-      if (fileData.l) {
-        // Lines (approximate from statements)
-        totalLines += Object.keys(fileData.s || {}).length;
-        coveredLines += Object.values(fileData.s || {}).filter(
-          (hit) => hit > 0,
-        ).length;
-      }
-    });
-
-    // Calculate percentages
-    const statementsPct =
-      totalStatements > 0
-        ? Math.round((coveredStatements / totalStatements) * 100)
-        : 0;
-    const functionsPct =
-      totalFunctions > 0
-        ? Math.round((coveredFunctions / totalFunctions) * 100)
-        : 0;
-    const branchesPct =
-      totalBranches > 0
-        ? Math.round((coveredBranches / totalBranches) * 100)
-        : 0;
-    const linesPct =
-      totalLines > 0 ? Math.round((coveredLines / totalLines) * 100) : 0;
-
-    // Calculate overall coverage percentage
-    const percentage = Math.round(
-      (statementsPct + functionsPct + branchesPct + linesPct) / 4,
-    );
-
-    // Determine badge color
-    let color = "red";
-    if (percentage >= 80) color = "brightgreen";
-    else if (percentage >= 60) color = "yellow";
-    else if (percentage >= 40) color = "orange";
-
-    // Generate badge URL
-    const badgeUrl = `https://img.shields.io/badge/coverage-${percentage}%25-${color}`;
-
-    // Create badge markdown
-    const badgeMarkdown = `![Test Coverage](${badgeUrl})`;
-
-    // Update README.md with the new badge
-    const readmePath = path.join(process.cwd(), "README.md");
-    let readmeContent = fs.readFileSync(readmePath, "utf8");
-
-    // Replace existing badge or add new one after the title
-    const badgeRegex =
-      /!\[Test Coverage\]\(https:\/\/img\.shields\.io\/badge\/coverage-\d+%25-\w+\)/;
-    if (badgeRegex.test(readmeContent)) {
-      // Replace existing badge
-      readmeContent = readmeContent.replace(badgeRegex, badgeMarkdown);
-    } else {
-      // Add badge after the description line
-      const descriptionRegex =
-        /(A Next\.js application for tracking Nuzlocke runs in Pokémon Infinite Fusion, featuring fusion mechanics, encounter tracking, and comprehensive run management\.)/;
-      readmeContent = readmeContent.replace(
-        descriptionRegex,
-        `$1\n\n${badgeMarkdown}`,
-      );
-    }
-
-    fs.writeFileSync(readmePath, readmeContent);
-
-    console.log(`✅ Coverage badge updated in README.md: ${percentage}%`);
-    console.log(`🔗 Badge URL: ${badgeUrl}`);
-
-    // Also log detailed coverage
-    console.log("\n📊 Detailed Coverage:");
-    console.log(`   Lines: ${linesPct}% (${coveredLines}/${totalLines})`);
-    console.log(
-      `   Functions: ${functionsPct}% (${coveredFunctions}/${totalFunctions})`,
-    );
-    console.log(
-      `   Branches: ${branchesPct}% (${coveredBranches}/${totalBranches})`,
-    );
-    console.log(
-      `   Statements: ${statementsPct}% (${coveredStatements}/${totalStatements})`,
-    );
-  } catch (error) {
-    console.error("❌ Error generating coverage badge:", error.message);
-    process.exit(1);
-  }
+if (Number.isFinite(lineCoverage) === false) {
+  throw new Error(
+    `Could not read aggregate line coverage from ${coveragePath}.`,
+  );
 }
 
-generateCoverageBadge();
+await mkdir("docs", { recursive: true });
+await writeFile(
+  "docs/coverage.svg",
+  renderBadge(
+    "coverage",
+    `${lineCoverage.toFixed(2)}%`,
+    coverageColor(lineCoverage),
+  ),
+);
+
+console.log(
+  `Wrote docs/coverage.svg (${lineCoverage.toFixed(2)}% line coverage).`,
+);
+
+function coverageColor(coverage) {
+  return coverageColors.find(([minimum]) => coverage >= minimum)[1];
+}
+
+function renderBadge(label, value, valueColor) {
+  const labelWidth = textWidth(label);
+  const valueWidth = textWidth(value);
+  const width = labelWidth + valueWidth;
+  const labelCenter = labelWidth / 2;
+  const valueCenter = labelWidth + valueWidth / 2;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="20" role="img" aria-label="${escapeXml(label)}: ${escapeXml(value)}">
+  <title>${escapeXml(label)}: ${escapeXml(value)}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="${width}" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${labelWidth}" height="20" fill="#555"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="20" fill="${valueColor}"/>
+    <rect width="${width}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
+    <text x="${labelCenter}" y="15" fill="#010101" fill-opacity=".3">${escapeXml(label)}</text>
+    <text x="${labelCenter}" y="14">${escapeXml(label)}</text>
+    <text x="${valueCenter}" y="15" fill="#010101" fill-opacity=".3">${escapeXml(value)}</text>
+    <text x="${valueCenter}" y="14">${escapeXml(value)}</text>
+  </g>
+</svg>
+`;
+}
+
+function textWidth(text) {
+  return text.length * 7 + 10;
+}
+
+function escapeXml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}

--- a/scripts/generate-fallow-badge.js
+++ b/scripts/generate-fallow-badge.js
@@ -1,0 +1,45 @@
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+
+const proc = spawn(
+  "pnpm",
+  [
+    "exec",
+    "fallow",
+    "health",
+    "--coverage-gaps",
+    "--format",
+    "badge",
+    "--quiet",
+  ],
+  { stdio: ["ignore", "pipe", "pipe"] },
+);
+
+const [stdout, stderr, exitCode] = await Promise.all([
+  readStream(proc.stdout),
+  readStream(proc.stderr),
+  new Promise((resolve) => proc.once("close", resolve)),
+]);
+
+process.stderr.write(stderr);
+
+const svg = stdout.slice(stdout.indexOf("<svg"));
+
+if (exitCode > 1 || svg.startsWith("<svg") === false) {
+  process.stdout.write(stdout);
+  throw new Error("Could not read Fallow badge SVG from output.");
+}
+
+await mkdir("docs", { recursive: true });
+await writeFile("docs/fallow.svg", svg);
+console.log("Wrote docs/fallow.svg.");
+
+function readStream(stream) {
+  return new Promise((resolve, reject) => {
+    let output = "";
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => (output += chunk));
+    stream.on("end", () => resolve(output));
+    stream.on("error", reject);
+  });
+}

--- a/scripts/update-staged-badges.js
+++ b/scripts/update-staged-badges.js
@@ -20,16 +20,32 @@ const shouldUpdateFallowBadge = stagedPaths.some((path) =>
   matchesAny(path, [
     ".fallowrc.jsonc",
     "package.json",
-    "scripts/generate-fallow-badge.js",
+    "pnpm-workspace.yaml",
+    "tsconfig.json",
+    "vitest.config.ts",
     "src/",
+    "scripts/",
     "tests/",
   ]),
 );
 
-if (shouldUpdateCoverageBadge) await run(["pnpm", "coverage:full"]);
-if (shouldUpdateFallowBadge) await run(["pnpm", "fallow:badge"]);
-if (shouldUpdateCoverageBadge || shouldUpdateFallowBadge) {
-  await run(["git", "add", "docs/coverage.svg", "docs/fallow.svg"]);
+const generatedBadges = [];
+const stashedUnstagedChanges = await stashUnstagedChanges();
+
+try {
+  if (shouldUpdateCoverageBadge) {
+    await run(["pnpm", "coverage:full"]);
+    generatedBadges.push("docs/coverage.svg");
+  }
+
+  if (shouldUpdateFallowBadge) {
+    await run(["pnpm", "fallow:badge"]);
+    generatedBadges.push("docs/fallow.svg");
+  }
+
+  if (generatedBadges.length > 0) await run(["git", "add", ...generatedBadges]);
+} finally {
+  if (stashedUnstagedChanges) await run(["git", "stash", "pop"]);
 }
 
 function matchesAny(path, patterns) {
@@ -38,11 +54,49 @@ function matchesAny(path, patterns) {
   );
 }
 
+async function stashUnstagedChanges() {
+  const status = await runOutput(["git", "status", "--porcelain"]);
+  const hasUnstagedChanges = status
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .some((line) => line.startsWith("??") || line[1] !== " ");
+
+  if (hasUnstagedChanges === false) return false;
+
+  // Leave the index checked out so badges describe the staged snapshot.
+  await run([
+    "git",
+    "stash",
+    "push",
+    "--keep-index",
+    "--include-untracked",
+    "--message",
+    "lefthook badge generation",
+  ]);
+  return true;
+}
+
 function run(command) {
   return new Promise((resolve, reject) => {
     const proc = spawn(command[0], command.slice(1), { stdio: "inherit" });
     proc.once("close", (exitCode) => {
       if (exitCode === 0) resolve();
+      else reject(new Error(`${command.join(" ")} exited with ${exitCode}.`));
+    });
+  });
+}
+
+function runOutput(command) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command[0], command.slice(1), {
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+    let output = "";
+
+    proc.stdout.setEncoding("utf8");
+    proc.stdout.on("data", (chunk) => (output += chunk));
+    proc.once("close", (exitCode) => {
+      if (exitCode === 0) resolve(output);
       else reject(new Error(`${command.join(" ")} exited with ${exitCode}.`));
     });
   });

--- a/scripts/update-staged-badges.js
+++ b/scripts/update-staged-badges.js
@@ -1,0 +1,49 @@
+import { spawn } from "node:child_process";
+import { isAbsolute, relative } from "node:path";
+
+const stagedPaths = process.argv
+  .slice(2)
+  .map((path) => (isAbsolute(path) ? relative(process.cwd(), path) : path));
+
+if (stagedPaths.length === 0) process.exit(0);
+
+const shouldUpdateCoverageBadge = stagedPaths.some((path) =>
+  matchesAny(path, [
+    "package.json",
+    "vitest.config.ts",
+    "scripts/generate-coverage-badge.js",
+    "src/",
+    "tests/",
+  ]),
+);
+const shouldUpdateFallowBadge = stagedPaths.some((path) =>
+  matchesAny(path, [
+    ".fallowrc.jsonc",
+    "package.json",
+    "scripts/generate-fallow-badge.js",
+    "src/",
+    "tests/",
+  ]),
+);
+
+if (shouldUpdateCoverageBadge) await run(["pnpm", "coverage:full"]);
+if (shouldUpdateFallowBadge) await run(["pnpm", "fallow:badge"]);
+if (shouldUpdateCoverageBadge || shouldUpdateFallowBadge) {
+  await run(["git", "add", "docs/coverage.svg", "docs/fallow.svg"]);
+}
+
+function matchesAny(path, patterns) {
+  return patterns.some((pattern) =>
+    pattern.endsWith("/") ? path.startsWith(pattern) : path === pattern,
+  );
+}
+
+function run(command) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command[0], command.slice(1), { stdio: "inherit" });
+    proc.once("close", (exitCode) => {
+      if (exitCode === 0) resolve();
+      else reject(new Error(`${command.join(" ")} exited with ${exitCode}.`));
+    });
+  });
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "fallow": {
+      "source": "fallow-rs/fallow-skills",
+      "sourceType": "github",
+      "skillPath": "fallow/skills/fallow/SKILL.md",
+      "computedHash": "e6c1246f756dcc78f08edbe6d9c32439455d0bfb5aa0ed42dbc2a159240d7e52"
+    },
     "impeccable": {
       "source": "pbakaus/impeccable",
       "sourceType": "github",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     globals: true,
     coverage: {
       provider: "v8",
-      reporter: ["text", "json", "html", "lcov", "cobertura"],
+      reporter: ["text", "json", "json-summary", "html", "lcov", "cobertura"],
       include: ["src/**/*.{ts,tsx}"],
       exclude: [
         "**/node_modules/**",


### PR DESCRIPTION
## Summary
Add checked-in coverage and Fallow health badges, and use Lefthook for the local validation and badge-update workflow.

## Changes
- Generate coverage and Fallow SVG badges for the README.
- Enable Fallow coverage-gap reporting.
- Replace Husky with Lefthook and share the pre-push quality command with Worktrunk.
- Remove the no-mistakes tool, remote workflow, and related guidance.

## Testing
- pnpm coverage:full
- pnpm fallow:badge
- pnpm type-check
- pnpm test:run
- pnpm validate
- pnpm quality:graph
- pnpm exec lefthook run pre-commit --force
- pnpm exec lefthook run pre-push --force
- devenv test reached profile and hook builds but exceeded the local two-minute command timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added coverage and code-health badges to the README.
  * Added a phased remediation plan for improving code quality and test coverage.

* **Quality & Tooling**
  * Updated project checks to run type validation, tests, and quality analysis before pushing.
  * Migrated Git hooks from Husky to Lefthook.

* **Reports**
  * Added generated coverage and code-health SVG reports.
  * Added HTML coverage report output.
  * Updated staged-change workflows to refresh relevant badges automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->