### PR TITLE
refactor: remove circular dependencies

### DIFF
--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -46,10 +46,10 @@ pnpm quality:graph:json
 
 Purpose: remove dependency-cycle and state-transition risks before broader cleanup.
 
-- [ ] Map the query, loader, service, data, and query-client import cycles to their public consumers and select one break point per underlying cycle.
-- [ ] Break the encounters/locations loader cycle with a one-way dependency boundary.
-- [ ] Break the query/loader/service cycle cluster without adding barrel-mediated cycles.
-- [ ] Add focused integration coverage for each changed query or loader request path.
+- [x] Map the query, loader, service, data, and query-client import cycles to their public consumers and select one break point per underlying cycle.
+- [x] Break the encounters/locations loader cycle with a one-way dependency boundary.
+- [x] Break the query/loader/service cycle cluster without adding barrel-mediated cycles.
+- [x] Add focused integration coverage for each changed query or loader request path.
 - [ ] Reconcile this phase with the existing encounter-transition architecture work to avoid parallel ownership changes.
 - [ ] Add outcome-focused tests for encounter CRUD state changes, including duplicate catches, nickname requirements, team placement, and death handling.
 - [ ] Simplify `updateEncounter`, artwork variants, and migration paths while preserving run-state invariants.

--- a/docs/coverage.svg
+++ b/docs/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20" role="img" aria-label="coverage: 39.38%">
-  <title>coverage: 39.38%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20" role="img" aria-label="coverage: 39.19%">
+  <title>coverage: 39.19%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="92" y="15" fill="#010101" fill-opacity=".3">39.38%</text>
-    <text x="92" y="14">39.38%</text>
+    <text x="92" y="15" fill="#010101" fill-opacity=".3">39.19%</text>
+    <text x="92" y="14">39.19%</text>
   </g>
 </svg>

--- a/docs/fallow-phase-1-baseline.json
+++ b/docs/fallow-phase-1-baseline.json
@@ -23,7 +23,7 @@
     }
   },
   "phase2": {
-    "circularDependencies": 15
+    "circularDependencies": 0
   },
   "phase3": {
     "unusedExports": 190,

--- a/docs/fallow.svg
+++ b/docs/fallow.svg
@@ -1,21 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="fallow: D (44)">
-<title>fallow: D (44)</title>
-<linearGradient id="s-2ed19f40" x2="0" y2="100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20" role="img" aria-label="fallow: B (82)">
+<title>fallow: B (82)</title>
+<linearGradient id="s-2b67fcc8" x2="0" y2="100%">
 <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 <stop offset="1" stop-opacity=".1"/>
 </linearGradient>
-<clipPath id="r-2ed19f40">
-<rect width="90" height="20" rx="3" fill="#fff"/>
+<clipPath id="r-2b67fcc8">
+<rect width="88" height="20" rx="3" fill="#fff"/>
 </clipPath>
-<g clip-path="url(#r-2ed19f40)">
+<g clip-path="url(#r-2b67fcc8)">
 <rect width="43" height="20" fill="#555"/>
-<rect x="43" width="47" height="20" fill="#fe7d37"/>
-<rect width="90" height="20" fill="url(#s-2ed19f40)"/>
+<rect x="43" width="45" height="20" fill="#97ca00"/>
+<rect width="88" height="20" fill="url(#s-2b67fcc8)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 <text aria-hidden="true" x="220" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">fallow</text>
 <text x="220" y="140" transform="scale(.1)" fill="#fff" textLength="330">fallow</text>
-<text aria-hidden="true" x="650" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">D (44)</text>
-<text x="650" y="140" transform="scale(.1)" fill="#fff" textLength="370">D (44)</text>
+<text aria-hidden="true" x="640" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="350">B (82)</text>
+<text x="640" y="140" transform="scale(.1)" fill="#fff" textLength="350">B (82)</text>
 </g>
 </svg>

--- a/src/app/api/__tests__/api-encounters.test.ts
+++ b/src/app/api/__tests__/api-encounters.test.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { describe, expect, it } from "vitest";
 import { GET } from "@/app/api/encounters/route";
-import { RouteEncountersArraySchema } from "@/loaders/encounters";
+import { RouteEncountersArraySchema } from "@/types/encounters";
 
 describe("Encounters API", () => {
   it("should include egg locations with -1 ID", async () => {

--- a/src/app/api/encounters/encounters-processor.ts
+++ b/src/app/api/encounters/encounters-processor.ts
@@ -16,9 +16,10 @@ import legendaryEncounters from "@data/shared/legendary-encounters.json";
 import { z } from "zod";
 import {
   EncounterSource,
+  type EncounterType,
+  EncounterTypeSchema,
   RouteEncountersArraySchema,
-} from "@/loaders/encounters";
-import { type EncounterType, EncounterTypeSchema } from "@/types/encounters";
+} from "@/types/encounters";
 
 // Schema for the new enhanced data format with encounter types
 const NewPokemonEncounterSchema = z.object({

--- a/src/app/api/pokemon/route.ts
+++ b/src/app/api/pokemon/route.ts
@@ -1,7 +1,7 @@
 import pokemonData from "@data/shared/pokemon-data.json";
 import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { PokemonSchema } from "@/loaders/pokemon";
+import { PokemonSchema } from "@/types/pokemon";
 
 // Query parameter schema for filtering
 const QuerySchema = z.object({

--- a/src/components/LocationTable/EncounterCell.tsx
+++ b/src/components/LocationTable/EncounterCell.tsx
@@ -8,10 +8,7 @@ import ConfirmationDialog from "@/components/ConfirmationDialog";
 import { CursorTooltip } from "@/components/CursorTooltip";
 import { PokemonCombobox } from "@/components/PokemonCombobox/PokemonCombobox";
 import { DNA_REVERSER_ICON } from "@/constants/items";
-import {
-  EncounterSource,
-  useEncountersForLocation,
-} from "@/loaders/encounters";
+import { useEncountersForLocation } from "@/loaders/encounters";
 import { getLocationById } from "@/loaders/locations";
 import type { PokemonOptionType, PokemonStatusType } from "@/loaders/pokemon";
 import { PokemonStatus } from "@/loaders/pokemon";
@@ -21,6 +18,7 @@ import {
   useEncounter,
   useGameMode,
 } from "@/stores/playthroughs";
+import { EncounterSource } from "@/types/encounters";
 import { FusionToggleButton } from "./FusionToggleButton";
 
 interface EncounterCellProps {

--- a/src/components/PokemonCombobox/PokemonCombobox.tsx
+++ b/src/components/PokemonCombobox/PokemonCombobox.tsx
@@ -20,10 +20,7 @@ import {
   useRef,
   useState,
 } from "react";
-import type {
-  EncounterSource,
-  RouteEncounterPokemon,
-} from "@/loaders/encounters";
+import type { RouteEncounterPokemon } from "@/loaders/encounters";
 import {
   isEgg,
   isPokemonEvolution,
@@ -34,6 +31,7 @@ import {
   usePokemonSearch,
 } from "@/loaders/pokemon";
 import { useEncounters, useGameMode } from "@/stores/playthroughs";
+import type { EncounterSource } from "@/types/encounters";
 import { buildCapturedSpeciesIdSet } from "@/utils/encounter-utils";
 import { DraggableComboboxSprite } from "./DraggableComboboxSprite";
 import {

--- a/src/components/PokemonCombobox/PokemonOptions.tsx
+++ b/src/components/PokemonCombobox/PokemonOptions.tsx
@@ -4,12 +4,12 @@ import { ComboboxOption } from "@headlessui/react";
 import clsx from "clsx";
 import { Check, Loader2, Search } from "lucide-react";
 import type React from "react";
-import type { EncounterSource } from "@/loaders/encounters";
 import {
   getEncounterDisplayName,
   isEgg,
   type PokemonOptionType,
 } from "@/loaders/pokemon";
+import type { EncounterSource } from "@/types/encounters";
 import { PokemonSprite } from "../PokemonSprite";
 import { SourceTag } from "./SourceTag";
 

--- a/src/components/PokemonCombobox/SourceTag.tsx
+++ b/src/components/PokemonCombobox/SourceTag.tsx
@@ -19,7 +19,7 @@ import NestIcon from "@/assets/images/nest.svg";
 import PokeballIcon from "@/assets/images/pokeball.svg";
 import WildIcon from "@/assets/images/tall-grass.svg";
 import { isStarterLocation } from "@/constants/special-locations";
-import { EncounterSource } from "@/loaders/encounters";
+import { EncounterSource } from "@/types/encounters";
 
 interface SourceTagProps {
   sources: EncounterSource[];

--- a/src/components/PokemonCombobox/__tests__/encounterSelection.test.ts
+++ b/src/components/PokemonCombobox/__tests__/encounterSelection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { EncounterSource } from "@/loaders/encounters";
 import { type PokemonOptionType, PokemonStatus } from "@/loaders/pokemon";
+import { EncounterSource } from "@/types/encounters";
 import {
   applyEncounterDefaultStatus,
   getPokemonSources,

--- a/src/components/PokemonCombobox/encounterSelection.ts
+++ b/src/components/PokemonCombobox/encounterSelection.ts
@@ -1,8 +1,6 @@
-import {
-  EncounterSource,
-  type RouteEncounterPokemon,
-} from "@/loaders/encounters";
+import type { RouteEncounterPokemon } from "@/loaders/encounters";
 import { type PokemonOptionType, PokemonStatus } from "@/loaders/pokemon";
+import { EncounterSource } from "@/types/encounters";
 
 export const getPokemonSources = (
   routeEncounterData: RouteEncounterPokemon[],

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -15,12 +15,8 @@ export const pokemonData = {
 };
 
 export const encountersData = {
-  getEncountersByGameMode: (gameMode: "classic" | "remix") =>
-    queryClient.fetchQuery(encountersQueries.all(gameMode)),
   getAllEncounters: (gameMode: "classic" | "remix") =>
-    queryClient
-      .fetchQuery(encountersQueries.all(gameMode))
-      .then((response) => response.data),
+    queryClient.fetchQuery(encountersQueries.all(gameMode)),
 };
 
 export const spriteData = {

--- a/src/lib/queries/encounters.test.ts
+++ b/src/lib/queries/encounters.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import encountersApiService from "@/services/encountersApiService";
+import { EncounterSource } from "@/types/encounters";
+import { encountersQueries } from "./encounters";
+
+vi.mock("@/services/encountersApiService", () => ({
+  default: {
+    getEncounters: vi.fn(),
+  },
+}));
+
+describe("encountersQueries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the validated encounter collection without a transport wrapper", async () => {
+    const encounters = [
+      {
+        routeName: "Route 1",
+        pokemon: [{ id: 1, source: EncounterSource.WILD }],
+      },
+    ];
+    vi.mocked(encountersApiService.getEncounters).mockResolvedValue(encounters);
+
+    const result = await encountersQueries.all("classic").queryFn!({} as never);
+
+    expect(result).toEqual(encounters);
+    expect(encountersApiService.getEncounters).toHaveBeenCalledWith("classic");
+  });
+});

--- a/src/lib/queries/encounters.ts
+++ b/src/lib/queries/encounters.ts
@@ -7,7 +7,7 @@ export const encountersQueries = {
   all: (gameMode: "classic" | "remix") =>
     queryOptions({
       queryKey: ["encounters", "all", gameMode],
-      queryFn: () => encountersApiService.getEncountersByGameMode(gameMode),
+      queryFn: () => encountersApiService.getEncounters(gameMode),
       enabled: !!gameMode,
       staleTime: process.env.NODE_ENV === "development" ? 0 : ms("1h"),
       gcTime: process.env.NODE_ENV === "development" ? 0 : ms("2h"),

--- a/src/loaders/__tests__/default-status.test.tsx
+++ b/src/loaders/__tests__/default-status.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { EncounterSource } from "@/loaders/encounters";
 import { type PokemonOptionType, PokemonStatus } from "@/loaders/pokemon";
+import { EncounterSource } from "@/types/encounters";
 
 // Helper function to simulate the default status logic from PokemonCombobox
 function applyDefaultStatus(

--- a/src/loaders/__tests__/locations.test.ts
+++ b/src/loaders/__tests__/locations.test.ts
@@ -57,9 +57,6 @@ vi.mock("@/lib/queryClient", () => {
   return {
     encountersData: {
       getAllEncounters: vi.fn().mockResolvedValue(mockEncountersData),
-      getEncountersByGameMode: vi.fn().mockResolvedValue({
-        data: mockEncountersData,
-      }),
     },
     encountersQueries: {
       all: vi.fn(() => ({

--- a/src/loaders/encounters.ts
+++ b/src/loaders/encounters.ts
@@ -1,6 +1,13 @@
 import { useCallback, useMemo } from "react";
-import { z } from "zod";
 import { encountersData } from "@/lib/queryClient";
+import {
+  EncounterSource,
+  type PokemonEncounter,
+  PokemonEncounterSchema,
+  type RouteEncounter,
+  RouteEncounterSchema,
+  RouteEncountersArraySchema,
+} from "@/types/encounters";
 import { useLocationEncountersById } from "./locations";
 import type { Pokemon, PokemonOptionType } from "./pokemon";
 import { useAllPokemon, usePokemonNameMap } from "./pokemon";
@@ -15,67 +22,6 @@ interface EncounterData {
   body: PokemonOptionType | null;
   isFusion: boolean;
 }
-
-export enum EncounterSource {
-  WILD = "wild", // Generic wild (for backward compatibility)
-  GRASS = "grass", // Wild grass encounters
-  SURF = "surf", // Surfing encounters
-  FISHING = "fishing", // Fishing encounters
-  CAVE = "cave", // Cave encounters
-  ROCK_SMASH = "rock_smash", // Rock Smash encounters
-  POKERADAR = "pokeradar", // Pokéradar encounters
-  GIFT = "gift",
-  TRADE = "trade",
-  QUEST = "quest",
-  NEST = "nest",
-  EGG = "egg",
-  STATIC = "static",
-  LEGENDARY = "legendary", // Legendary Pokémon encounters
-}
-
-// Zod schema for individual Pokemon encounters
-export const PokemonEncounterSchema = z.object({
-  id: z
-    .number()
-    .int()
-    .refine((val) => val > 0 || val === -1, {
-      error: "Pokemon ID must be positive or -1 for egg locations",
-    }),
-  source: z.enum(
-    [
-      EncounterSource.WILD,
-      EncounterSource.GRASS,
-      EncounterSource.SURF,
-      EncounterSource.FISHING,
-      EncounterSource.CAVE,
-      EncounterSource.ROCK_SMASH,
-      EncounterSource.POKERADAR,
-      EncounterSource.GIFT,
-      EncounterSource.TRADE,
-      EncounterSource.QUEST,
-      EncounterSource.NEST,
-      EncounterSource.EGG,
-      EncounterSource.STATIC,
-      EncounterSource.LEGENDARY,
-    ],
-    {
-      error:
-        "Source must be wild, grass, surf, fishing, cave, rock_smash, pokeradar, gift, trade, quest, static, nest, egg, or legendary",
-    },
-  ),
-});
-
-export type PokemonEncounter = z.infer<typeof PokemonEncounterSchema>;
-
-// Zod schema for route encounter data
-export const RouteEncounterSchema = z.object({
-  routeName: z.string().min(1, { error: "Route name is required" }),
-  pokemon: z.array(PokemonEncounterSchema),
-});
-
-export type RouteEncounter = z.infer<typeof RouteEncounterSchema>;
-
-export const RouteEncountersArraySchema = z.array(RouteEncounterSchema);
 
 // Data loaders for encounters using TanStack Query
 export async function getClassicEncounters(): Promise<RouteEncounter[]> {

--- a/src/loaders/locations.ts
+++ b/src/loaders/locations.ts
@@ -225,9 +225,7 @@ export function useLocationEncountersById(
     };
   }
 
-  const encounter = (
-    encounters && "data" in encounters ? encounters.data : encounters
-  )?.find((e) => e.routeName === location?.name);
+  const encounter = encounters.find((e) => e.routeName === location?.name);
 
   return {
     pokemonEncounters: encounter?.pokemon || [],

--- a/src/loaders/locations.ts
+++ b/src/loaders/locations.ts
@@ -4,9 +4,9 @@ import { z } from "zod";
 import { isStarterLocation } from "@/constants/special-locations";
 import { encountersData, encountersQueries } from "@/lib/queryClient";
 import { getStarterPokemonByGameMode } from "@/loaders/starters";
+import { EncounterSource, type PokemonEncounter } from "@/types/encounters";
 import { generatePrefixedId } from "@/utils/id";
 import type { GameMode } from "../stores/playthroughs";
-import { EncounterSource, type PokemonEncounter } from "./encounters";
 
 // Location schema
 export const LocationSchema = z.object({

--- a/src/loaders/pokemon.ts
+++ b/src/loaders/pokemon.ts
@@ -10,6 +10,14 @@ import { z } from "zod";
 import { pokemonData, pokemonQueries } from "@/lib/queryClient";
 import { SearchCore } from "@/lib/searchCore";
 import searchService from "@/services/searchService";
+import {
+  type Pokemon,
+  PokemonArraySchema,
+  PokemonSchema,
+} from "@/types/pokemon";
+
+export type { Pokemon } from "@/types/pokemon";
+export { PokemonArraySchema, PokemonSchema } from "@/types/pokemon";
 
 // Utility function to generate unique identifiers
 export function generatePokemonUID(): string {
@@ -92,60 +100,6 @@ export const PokemonOptionSchema = z.object({
 
 // Pokemon option type for search results (inferred from schema)
 export type PokemonOptionType = z.infer<typeof PokemonOptionSchema>;
-
-// Zod schema for Pokemon type
-export const PokemonTypeSchema = z.object({
-  name: z.string().min(1, { error: "Type name is required" }),
-});
-
-// Zod schema for Pokemon species
-export const PokemonSpeciesSchema = z.object({
-  is_legendary: z.boolean(),
-  is_mythical: z.boolean(),
-  generation: z.string().nullable(),
-  evolution_chain: z
-    .object({
-      url: z.string().url({ error: "Invalid evolution chain URL" }),
-    })
-    .nullable(),
-});
-
-// Zod schema for evolution detail
-export const EvolutionDetailSchema = z.object({
-  id: z.number().int().positive({ error: "Evolution ID must be positive" }),
-  name: z.string().min(1, { error: "Evolution name is required" }),
-  min_level: z.number().int().positive().optional(),
-  trigger: z.string().optional(),
-  item: z.string().optional(),
-  location: z.string().optional(),
-  condition: z.string().optional(),
-});
-
-// Zod schema for evolution data
-export const EvolutionDataSchema = z.object({
-  evolves_to: z.array(EvolutionDetailSchema),
-  evolves_from: EvolutionDetailSchema.optional(),
-});
-
-// Zod schema for Pokemon data
-export const PokemonSchema = z.object({
-  id: z.number().int({ error: "Pokemon ID must be an integer" }),
-  nationalDexId: z
-    .number()
-    .int({ error: "National Dex ID must be an integer" }),
-  name: z.string().min(1, { error: "Pokemon name is required" }),
-  types: z.array(PokemonTypeSchema),
-  species: PokemonSpeciesSchema,
-  evolution: EvolutionDataSchema.optional(),
-});
-
-export type Pokemon = z.infer<typeof PokemonSchema>;
-type PokemonType = z.infer<typeof PokemonTypeSchema>;
-type PokemonSpecies = z.infer<typeof PokemonSpeciesSchema>;
-type EvolutionDetail = z.infer<typeof EvolutionDetailSchema>;
-type EvolutionData = z.infer<typeof EvolutionDataSchema>;
-
-export const PokemonArraySchema = z.array(PokemonSchema);
 
 // Evolution helper functions using centralized query client
 export async function getPokemonEvolutionIds(

--- a/src/services/__tests__/encountersApiService.test.ts
+++ b/src/services/__tests__/encountersApiService.test.ts
@@ -14,15 +14,15 @@ vi.mock("@/lib/persistence", () => ({
   getCacheBuster: () => 12345,
 }));
 
-// Mock the encounters loader
-vi.mock("@/loaders/encounters", () => ({
+// Mock the response schema at the service boundary.
+vi.mock("@/types/encounters", () => ({
   RouteEncountersArraySchema: {
     safeParse: vi.fn().mockReturnValue({ success: true, data: [] }),
   },
 }));
 
 // Import the mocked module to access the mock function
-import { RouteEncountersArraySchema } from "@/loaders/encounters";
+import { RouteEncountersArraySchema } from "@/types/encounters";
 
 const encountersApiServicePrivate = encountersApiService as unknown as {
   makeRequest: (params: EncountersApiParams) => Promise<EncountersApiResponse>;

--- a/src/services/__tests__/encountersApiService.test.ts
+++ b/src/services/__tests__/encountersApiService.test.ts
@@ -1,8 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  EncountersApiParams,
-  EncountersApiResponse,
-} from "../encountersApiService";
 import encountersApiService from "../encountersApiService";
 
 // Mock fetch globally
@@ -25,7 +21,7 @@ vi.mock("@/types/encounters", () => ({
 import { RouteEncountersArraySchema } from "@/types/encounters";
 
 const encountersApiServicePrivate = encountersApiService as unknown as {
-  makeRequest: (params: EncountersApiParams) => Promise<EncountersApiResponse>;
+  makeRequest: (gameMode: "classic" | "remix") => Promise<unknown>;
 };
 
 // Mock data - using any to avoid type issues in tests
@@ -86,7 +82,7 @@ describe("EncountersApiService", () => {
         json: async () => [mockRouteEncounter, mockRouteEncounter2],
       });
 
-      await encountersApiServicePrivate.makeRequest({ gameMode: "classic" });
+      await encountersApiServicePrivate.makeRequest("classic");
 
       expect(mockFetch).toHaveBeenCalledWith(
         "http://localhost:3000/api/encounters?gameMode=classic&v=12345",
@@ -109,7 +105,7 @@ describe("EncountersApiService", () => {
       });
 
       await expect(
-        encountersApiServicePrivate.makeRequest({ gameMode: "classic" }),
+        encountersApiServicePrivate.makeRequest("classic"),
       ).rejects.toThrow("Invalid API response format");
     });
 
@@ -117,7 +113,7 @@ describe("EncountersApiService", () => {
       mockFetch.mockRejectedValueOnce(new Error("Network error"));
 
       await expect(
-        encountersApiServicePrivate.makeRequest({ gameMode: "classic" }),
+        encountersApiServicePrivate.makeRequest("classic"),
       ).rejects.toThrow("Network error");
     });
   });
@@ -189,67 +185,6 @@ describe("EncountersApiService", () => {
       await expect(
         encountersApiService.getEncounters("classic"),
       ).rejects.toThrow("Encounters API error: 403 Forbidden");
-    });
-  });
-
-  describe("getEncountersByGameMode", () => {
-    it("should return full response for classic game mode", async () => {
-      vi.mocked(RouteEncountersArraySchema.safeParse).mockReturnValueOnce({
-        success: true,
-        data: [mockRouteEncounter, mockRouteEncounter2],
-      });
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [mockRouteEncounter, mockRouteEncounter2],
-      });
-
-      const result =
-        await encountersApiService.getEncountersByGameMode("classic");
-
-      expect(result).toEqual({
-        data: [mockRouteEncounter, mockRouteEncounter2],
-        count: 2,
-        gameMode: "classic",
-      });
-    });
-
-    it("should return full response for remix game mode", async () => {
-      vi.mocked(RouteEncountersArraySchema.safeParse).mockReturnValueOnce({
-        success: true,
-        data: [mockRouteEncounter],
-      });
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [mockRouteEncounter],
-      });
-
-      const result =
-        await encountersApiService.getEncountersByGameMode("remix");
-
-      expect(result).toEqual({
-        data: [mockRouteEncounter],
-        count: 1,
-        gameMode: "remix",
-      });
-    });
-
-    it("should calculate correct count from response data", async () => {
-      vi.mocked(RouteEncountersArraySchema.safeParse).mockReturnValueOnce({
-        success: true,
-        data: [mockRouteEncounter, mockRouteEncounter2],
-      });
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [mockRouteEncounter, mockRouteEncounter2],
-      });
-
-      const result =
-        await encountersApiService.getEncountersByGameMode("classic");
-
-      expect(result.count).toBe(2);
     });
   });
 

--- a/src/services/encountersApiService.ts
+++ b/src/services/encountersApiService.ts
@@ -3,7 +3,7 @@ import { getCacheBuster } from "@/lib/persistence";
 import {
   type RouteEncounterSchema,
   RouteEncountersArraySchema,
-} from "@/loaders/encounters";
+} from "@/types/encounters";
 
 export type RouteEncounter = z.infer<typeof RouteEncounterSchema>;
 

--- a/src/services/encountersApiService.ts
+++ b/src/services/encountersApiService.ts
@@ -1,21 +1,8 @@
-import type { z } from "zod";
 import { getCacheBuster } from "@/lib/persistence";
 import {
-  type RouteEncounterSchema,
+  type RouteEncounter,
   RouteEncountersArraySchema,
 } from "@/types/encounters";
-
-export type RouteEncounter = z.infer<typeof RouteEncounterSchema>;
-
-export interface EncountersApiResponse {
-  data: RouteEncounter[];
-  count: number;
-  gameMode: "classic" | "remix";
-}
-
-export interface EncountersApiParams {
-  gameMode: "classic" | "remix";
-}
 
 class EncountersApiService {
   private baseUrl: string;
@@ -29,10 +16,10 @@ class EncountersApiService {
   }
 
   private async makeRequest(
-    params: EncountersApiParams,
-  ): Promise<EncountersApiResponse> {
+    gameMode: "classic" | "remix",
+  ): Promise<RouteEncounter[]> {
     const searchParams = new URLSearchParams();
-    searchParams.append("gameMode", params.gameMode);
+    searchParams.append("gameMode", gameMode);
 
     // Add cache busting version parameter
     searchParams.append("v", getCacheBuster().toString());
@@ -62,26 +49,13 @@ class EncountersApiService {
       throw new Error("Invalid API response format");
     }
 
-    const encountersResponse: EncountersApiResponse = {
-      data: validatedData.data,
-      count: validatedData.data.length,
-      gameMode: params.gameMode,
-    };
-
-    return encountersResponse;
+    return validatedData.data;
   }
 
   async getEncounters(
     gameMode: "classic" | "remix",
   ): Promise<RouteEncounter[]> {
-    const response = await this.makeRequest({ gameMode });
-    return response.data;
-  }
-
-  async getEncountersByGameMode(
-    gameMode: "classic" | "remix",
-  ): Promise<EncountersApiResponse> {
-    return await this.makeRequest({ gameMode });
+    return await this.makeRequest(gameMode);
   }
 
   async getEncounterByRouteName(
@@ -95,8 +69,7 @@ class EncountersApiService {
   }
 
   async getEncountersCount(gameMode: "classic" | "remix"): Promise<number> {
-    const response = await this.makeRequest({ gameMode });
-    return response.count;
+    return (await this.makeRequest(gameMode)).length;
   }
 }
 

--- a/src/services/pokemonApiService.ts
+++ b/src/services/pokemonApiService.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { getCacheBuster } from "@/lib/persistence";
-import { PokemonSchema } from "@/loaders/pokemon";
+import { PokemonSchema } from "@/types/pokemon";
 
 export type Pokemon = z.infer<typeof PokemonSchema>;
 

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -1,7 +1,7 @@
 import * as Comlink from "comlink";
 import { pokemonData } from "@/lib/data";
 import { SearchCore } from "@/lib/searchCore";
-import type { Pokemon } from "@/loaders/pokemon";
+import type { Pokemon } from "@/types/pokemon";
 
 let mainThreadInstance: SearchCore | null = null;
 let mainThreadInitPromise: Promise<SearchCore> | null = null;

--- a/src/stores/__tests__/settings.browser.test.ts
+++ b/src/stores/__tests__/settings.browser.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getActivePlaythrough } from "../playthroughs";
+import { getActivePlaythrough, playthroughsStore } from "../playthroughs/store";
 import { SettingsSchema, settingsActions, settingsStore } from "../settings";
 
 // Mock the playthroughs store
-vi.mock("../playthroughs", () => ({
-  getActivePlaythrough: vi.fn(),
-}));
+vi.mock("../playthroughs/store", async () => {
+  const { proxy } = await import("valtio");
+  return {
+    getActivePlaythrough: vi.fn(),
+    playthroughsStore: proxy({ isLoading: false }),
+  };
+});
 
 const mockGetActivePlaythrough = vi.mocked(getActivePlaythrough);
 
@@ -19,6 +23,7 @@ describe("Settings Store", () => {
     // Clear all mocks and localStorage
     vi.clearAllMocks();
     clearLocalStorage();
+    playthroughsStore.isLoading = false;
     mockGetActivePlaythrough.mockReturnValue(null);
   });
 
@@ -91,6 +96,37 @@ describe("Settings Store", () => {
       freshActions.refreshDefaults();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
+    });
+
+    it("re-evaluates defaults when the playthrough store finishes loading", async () => {
+      const oldPlaythrough = {
+        id: "old-playthrough",
+        name: "Old Run",
+        gameMode: "classic",
+        encounters: {},
+        team: [],
+        pc: [],
+        customLocations: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      } as any;
+
+      playthroughsStore.isLoading = true;
+      mockGetActivePlaythrough
+        .mockReturnValueOnce(null)
+        .mockReturnValue(oldPlaythrough);
+
+      const { settingsStore: freshStore } = await import(
+        `../settings?t=${Date.now()}`
+      );
+
+      expect(freshStore.moveEncountersBetweenLocations).toBe(false);
+
+      playthroughsStore.isLoading = false;
+
+      await vi.waitFor(() => {
+        expect(freshStore.moveEncountersBetweenLocations).toBe(true);
+      });
     });
 
     it("enables move encounters for old playthroughs (no version)", async () => {

--- a/src/stores/playthroughs/store.ts
+++ b/src/stores/playthroughs/store.ts
@@ -65,30 +65,16 @@ if (typeof window !== "undefined") {
   // Client-side: Initialize with default state first, then load from IndexedDB
   playthroughsStore = proxy<PlaythroughsState>(defaultState);
 
-  const refreshSettingsDefaultsAfterPlaythroughLoad = async () => {
-    try {
-      const { settingsActions } = await import("@/stores/settings");
-      settingsActions.refreshDefaults();
-    } catch (error) {
-      console.warn(
-        "Failed to refresh settings defaults after playthrough load:",
-        error,
-      );
-    }
-  };
-
   // Add devtools integration for debugging
   if (process.env.NODE_ENV === "development") {
     devtools(playthroughsStore, { name: "Playthroughs Store" });
   }
 
   // Load data from IndexedDB asynchronously
-  loadFromIndexedDB(playthroughsStore)
-    .then(refreshSettingsDefaultsAfterPlaythroughLoad)
-    .finally(() => {
-      // Keep this explicit for callers that rely on the store-level flag.
-      playthroughsStore.isLoading = false;
-    });
+  loadFromIndexedDB(playthroughsStore).finally(() => {
+    // Keep this explicit for callers that rely on the store-level flag.
+    playthroughsStore.isLoading = false;
+  });
 
   // Create debounced save function with store dependencies
   const debouncedSaveAll = createDebouncedSaveAll(playthroughsStore, () =>

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,6 +1,9 @@
 import { proxy, subscribe } from "valtio";
 import { z } from "zod";
-import { getActivePlaythrough } from "@/stores/playthroughs";
+import {
+  getActivePlaythrough,
+  playthroughsStore,
+} from "@/stores/playthroughs/store";
 
 // Zod schema for settings validation
 export const SettingsSchema = z.object({
@@ -151,3 +154,16 @@ export const settingsActions = {
     }
   },
 };
+
+if (typeof window !== "undefined") {
+  let wasLoading = playthroughsStore.isLoading;
+
+  subscribe(playthroughsStore, () => {
+    const hasFinishedLoading = wasLoading && !playthroughsStore.isLoading;
+    wasLoading = playthroughsStore.isLoading;
+
+    if (hasFinishedLoading) {
+      settingsActions.refreshDefaults();
+    }
+  });
+}

--- a/src/types/encounters.ts
+++ b/src/types/encounters.ts
@@ -1,5 +1,58 @@
 import { z } from "zod";
 
+export enum EncounterSource {
+  WILD = "wild",
+  GRASS = "grass",
+  SURF = "surf",
+  FISHING = "fishing",
+  CAVE = "cave",
+  ROCK_SMASH = "rock_smash",
+  POKERADAR = "pokeradar",
+  GIFT = "gift",
+  TRADE = "trade",
+  QUEST = "quest",
+  NEST = "nest",
+  EGG = "egg",
+  STATIC = "static",
+  LEGENDARY = "legendary",
+}
+
+export const PokemonEncounterSchema = z.object({
+  id: z
+    .number()
+    .int()
+    .refine((value) => value > 0 || value === -1, {
+      error: "Pokemon ID must be positive or -1 for egg locations",
+    }),
+  source: z.enum([
+    EncounterSource.WILD,
+    EncounterSource.GRASS,
+    EncounterSource.SURF,
+    EncounterSource.FISHING,
+    EncounterSource.CAVE,
+    EncounterSource.ROCK_SMASH,
+    EncounterSource.POKERADAR,
+    EncounterSource.GIFT,
+    EncounterSource.TRADE,
+    EncounterSource.QUEST,
+    EncounterSource.NEST,
+    EncounterSource.EGG,
+    EncounterSource.STATIC,
+    EncounterSource.LEGENDARY,
+  ]),
+});
+
+export type PokemonEncounter = z.infer<typeof PokemonEncounterSchema>;
+
+export const RouteEncounterSchema = z.object({
+  routeName: z.string().min(1, { error: "Route name is required" }),
+  pokemon: z.array(PokemonEncounterSchema),
+});
+
+export type RouteEncounter = z.infer<typeof RouteEncounterSchema>;
+
+export const RouteEncountersArraySchema = z.array(RouteEncounterSchema);
+
 /**
  * Shared encounter type definition for consistency across the codebase.
  * This type defines all valid encounter types that can be used in the application.

--- a/src/types/pokemon.ts
+++ b/src/types/pokemon.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+const PokemonTypeSchema = z.object({
+  name: z.string().min(1, { error: "Type name is required" }),
+});
+
+const PokemonSpeciesSchema = z.object({
+  is_legendary: z.boolean(),
+  is_mythical: z.boolean(),
+  generation: z.string().nullable(),
+  evolution_chain: z
+    .object({
+      url: z.string().url({ error: "Invalid evolution chain URL" }),
+    })
+    .nullable(),
+});
+
+const EvolutionDetailSchema = z.object({
+  id: z.number().int().positive({ error: "Evolution ID must be positive" }),
+  name: z.string().min(1, { error: "Evolution name is required" }),
+  min_level: z.number().int().positive().optional(),
+  trigger: z.string().optional(),
+  item: z.string().optional(),
+  location: z.string().optional(),
+  condition: z.string().optional(),
+});
+
+const EvolutionDataSchema = z.object({
+  evolves_to: z.array(EvolutionDetailSchema),
+  evolves_from: EvolutionDetailSchema.optional(),
+});
+
+export const PokemonSchema = z.object({
+  id: z.number().int({ error: "Pokemon ID must be an integer" }),
+  nationalDexId: z
+    .number()
+    .int({ error: "National Dex ID must be an integer" }),
+  name: z.string().min(1, { error: "Pokemon name is required" }),
+  types: z.array(PokemonTypeSchema),
+  species: PokemonSpeciesSchema,
+  evolution: EvolutionDataSchema.optional(),
+});
+
+export type Pokemon = z.infer<typeof PokemonSchema>;
+
+export const PokemonArraySchema = z.array(PokemonSchema);


### PR DESCRIPTION
## Summary
Remove first-party circular dependencies and standardize encounter retrieval on one validated collection shape.

## Changes
- Move encounter and Pokemon contracts to neutral type modules.
- Remove query, loader, service, and settings import cycles.
- Return encounter collections directly through query, data, and loader paths.
- Add retrieval and settings regression coverage.

## Risk
Encounter loading and settings compatibility defaults are affected. Transport validation remains at the fetch seam, and the public route response is unchanged.

## Testing
- `pnpm type-check`
- `pnpm test:run`
- `pnpm validate`
- `pnpm quality:graph:json`
- `pnpm exec fallow audit --format json --quiet --explain`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized validation for Pokémon and encounter data.
  * Encounter requests now return validated encounter lists directly.
  * Settings defaults refresh automatically after playthrough data finishes loading.

* **Bug Fixes**
  * Improved encounter loading and location matching behavior.
  * Reduced dependency-related issues across encounter and Pokémon data flows.

* **Tests**
  * Added coverage for encounter query behavior and updated API, loader, and settings tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->