### PR TITLE
chore(config): realize worktree shell

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,5 +1,5 @@
-# Ensure each new worktree is ready to run
-pre-start = "pnpm install --frozen-lockfile --prefer-offline && sh ./.config/ensure-vercel-link.sh"
+# Ensure each new worktree is ready to run and its directory-specific shell is realized.
+pre-start = "pnpm install --frozen-lockfile --prefer-offline && sh ./.config/ensure-vercel-link.sh && devenv shell -- true"
 
 [[pre-merge]]
 quality = "pnpm quality:pre-push"

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,5 +1,5 @@
-# Ensure each new worktree is ready to run and its directory-specific shell is realized.
-pre-start = "pnpm install --frozen-lockfile --prefer-offline && sh ./.config/ensure-vercel-link.sh && devenv shell -- true"
+# Ensure each new worktree is ready to run and warm its directory-specific shell when available.
+pre-start = "pnpm install --frozen-lockfile --prefer-offline && sh ./.config/ensure-vercel-link.sh && if command -v devenv >/dev/null 2>&1; then devenv shell -- true; fi"
 
 [[pre-merge]]
 quality = "pnpm quality:pre-push"


### PR DESCRIPTION
## Summary

Realize each worktree's directory-specific devenv shell during Worktrunk setup, moving the first shell evaluation from Neovim mprocs startup to worktree creation.

## Testing

- `wt hook pre-start --dry-run`
- `devenv shell -- true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved project startup setup by automatically initializing the development environment when the required tooling is available.
  * Existing dependency installation and project linking steps continue to run as part of startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->