### PR TITLE
refactor(components): isolate decision models

### DIFF
--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -83,7 +83,7 @@ Purpose: close the residual first-party findings through behavior-preserving ref
 - [x] Remove remaining verified unused files, exports, and types in coherent module batches.
 - [x] Add behavior and accessibility coverage for context-menu, summary-card, PC, team, and location interaction paths.
 - [x] Refactor context-menu action construction and shared behavior before extracting common code.
-- [ ] Refactor summary-card and PC/team decision surfaces without widening component interfaces unnecessarily.
+- [x] Refactor summary-card and PC/team decision surfaces without widening component interfaces unnecessarily.
 - [ ] Resolve UI clone groups only where states and accessibility behavior are identical.
 - [ ] Group scraper and sprite clone findings by data-pipeline step.
 - [ ] Add deterministic input/output tests before consolidating script utilities.

--- a/src/components/LocationTable/LocationCell.tsx
+++ b/src/components/LocationTable/LocationCell.tsx
@@ -56,37 +56,7 @@ export default function LocationCell({
     return pokemon;
   }, [encounters, location.id]);
 
-  // Check if any Pokémon have been moved from their original locations
-  const hasMovedPokemon = useMemo(() => {
-    if (!encounters) return false;
-
-    // Check all encounters to see if any Pokémon are not in their original location
-    for (const [currentLocationId, encounter] of Object.entries(encounters) as [
-      string,
-      EncounterData,
-    ][]) {
-      // Check head Pokémon
-      if (
-        encounter.head?.originalLocation &&
-        encounter.head.originalLocation !== currentLocationId
-      ) {
-        return true;
-      }
-      // Check body Pokémon
-      if (
-        encounter.body?.originalLocation &&
-        encounter.body.originalLocation !== currentLocationId
-      ) {
-        return true;
-      }
-    }
-
-    return false;
-  }, [encounters]);
-
-  // Determine if we should show detailed original encounter information
-  const shouldShowOriginalEncounter =
-    settings.moveEncountersBetweenLocations || hasMovedPokemon;
+  const shouldShowOriginalEncounter = settings.moveEncountersBetweenLocations;
 
   const encounterUids = locationPokemon
     .map((p) => p.uid)
@@ -120,7 +90,6 @@ export default function LocationCell({
   }, [isTooltipHovered, encounterUids, shouldShowOriginalEncounter]);
 
   const getTooltipContent = useMemo(() => {
-    // Only show detailed original encounter information if setting is enabled or Pokémon have been moved
     if (locationPokemon.length > 0 && shouldShowOriginalEncounter) {
       return (
         <div className="max-w-xs">

--- a/src/components/LocationTable/__tests__/LocationCell.test.tsx
+++ b/src/components/LocationTable/__tests__/LocationCell.test.tsx
@@ -1,0 +1,79 @@
+/** @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { CombinedLocation } from "@/loaders/locations";
+import { PokemonStatus } from "@/loaders/pokemon";
+
+vi.mock("valtio", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("valtio")>()),
+  useSnapshot: () => ({ moveEncountersBetweenLocations: false }),
+}));
+
+vi.mock("@/stores/playthroughs/hooks", () => ({
+  useEncounters: () => ({
+    "route-2": {
+      head: {
+        id: 25,
+        name: "Pikachu",
+        nationalDexId: 25,
+        originalLocation: "route-1",
+        status: PokemonStatus.CAPTURED,
+      },
+      body: null,
+      isFusion: false,
+      updatedAt: 0,
+    },
+  }),
+}));
+
+vi.mock("@/stores/settings", () => ({
+  settingsStore: { moveEncountersBetweenLocations: false },
+}));
+
+vi.mock("@/loaders", () => ({
+  isCustomLocation: () => false,
+}));
+
+vi.mock("@/components/CursorTooltip", () => ({
+  CursorTooltip: ({
+    children,
+    content,
+  }: {
+    children: React.ReactNode;
+    content: React.ReactNode;
+  }) => (
+    <div>
+      {children}
+      <div data-testid="tooltip-content">{content}</div>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/PokemonSprite", () => ({
+  PokemonSprite: () => null,
+}));
+
+vi.mock("@/constants/special-locations", () => ({
+  isStarterLocation: () => false,
+}));
+
+import LocationCell from "../LocationCell";
+
+const location = {
+  id: "route-1",
+  name: "Route 1",
+  description: "A quiet starting route.",
+} as CombinedLocation;
+
+describe("LocationCell", () => {
+  it("hides original encounter details when moving encounters is disabled", () => {
+    render(<LocationCell location={location} locationName="Route 1" />);
+
+    expect(screen.getByTestId("tooltip-content").textContent).toContain(
+      "A quiet starting route.",
+    );
+    expect(screen.queryByText("Original Encounter")).toBeNull();
+  });
+});

--- a/src/components/PokemonSummaryCard/__tests__/summaryCardModel.test.ts
+++ b/src/components/PokemonSummaryCard/__tests__/summaryCardModel.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { type PokemonOptionType, PokemonStatus } from "@/loaders/pokemon";
+import { getSummaryCardDisplay } from "../summaryCardModel";
+
+const pokemon = (
+  id: number,
+  status: PokemonOptionType["status"] = PokemonStatus.CAPTURED,
+): PokemonOptionType => ({
+  id,
+  name: `Pokemon ${id}`,
+  nationalDexId: id,
+  status,
+});
+
+describe("getSummaryCardDisplay", () => {
+  it("uses displayed IDs for a non-fusion Pokédex link", () => {
+    const display = getSummaryCardDisplay({
+      headPokemon: pokemon(25),
+      bodyPokemon: pokemon(1),
+      isFusion: false,
+      isTeamMember: false,
+    });
+
+    expect(display.link).toBe("https://infinitefusiondex.com/details/25");
+  });
+
+  it("keeps requested team fusions visible even when one member is stored", () => {
+    const display = getSummaryCardDisplay({
+      headPokemon: pokemon(25),
+      bodyPokemon: pokemon(1, PokemonStatus.STORED),
+      isFusion: true,
+      isTeamMember: true,
+    });
+
+    expect(display.displayPokemon).toMatchObject({ isFusion: true });
+    expect(display.link).toBe("https://infinitefusiondex.com/details/25.1");
+  });
+
+  it("only marks a fusion deceased when both original members are deceased", () => {
+    const display = getSummaryCardDisplay({
+      headPokemon: pokemon(25, PokemonStatus.DECEASED),
+      bodyPokemon: pokemon(1),
+      isFusion: true,
+      isTeamMember: false,
+    });
+
+    expect(display.isDeceased).toBe(false);
+  });
+});

--- a/src/components/PokemonSummaryCard/index.tsx
+++ b/src/components/PokemonSummaryCard/index.tsx
@@ -5,14 +5,13 @@ import { CursorTooltip } from "@/components/CursorTooltip";
 import { useFusionTypesFromPokemon } from "@/hooks/useFusionTypes";
 import { usePreferredVariantState, useSpriteCredits } from "@/hooks/useSprite";
 import { getSpriteId } from "@/lib/sprites";
-import { isEggId, type PokemonOptionType } from "@/loaders/pokemon";
+import type { PokemonOptionType } from "@/loaders/pokemon";
 import { formatArtistCredits } from "@/utils/formatCredits";
-import { isPokemonDeceased } from "@/utils/pokemonPredicates";
 import { TypePills } from "../TypePills";
 import { ArtworkVariantButton } from "./ArtworkVariantButton";
 import { FusionSprite, type FusionSpriteHandle } from "./FusionSprite";
 import { PokemonContextMenu } from "./PokemonContextMenu";
-import { getDisplayPokemon, getNicknameText } from "./utils";
+import { getSummaryCardDisplay } from "./summaryCardModel";
 
 interface SummaryCardProps {
   headPokemon?: PokemonOptionType | null;
@@ -45,23 +44,14 @@ const SummaryCard = React.forwardRef<FusionSpriteHandle, SummaryCardProps>(
     const effectiveHeadPokemon = headPokemon;
     const effectiveBodyPokemon = bodyPokemon;
     const effectiveIsFusion = isFusion;
-
-    const eitherPokemonIsEgg =
-      isEggId(effectiveHeadPokemon?.id) || isEggId(effectiveBodyPokemon?.id);
-
-    // For team member selection, bypass encounter logic and always show fusion when requested
-    // For encounters, use the full display logic with canFuse restrictions
-    const displayPokemon = isTeamMember
-      ? {
-          head: effectiveHeadPokemon || null,
-          body: effectiveBodyPokemon || null,
-          isFusion: effectiveIsFusion,
-        }
-      : getDisplayPokemon(
-          effectiveHeadPokemon || null,
-          effectiveBodyPokemon || null,
-          effectiveIsFusion,
-        );
+    const { displayPokemon, eitherPokemonIsEgg, isDeceased, link, name } =
+      getSummaryCardDisplay({
+        headPokemon: effectiveHeadPokemon,
+        bodyPokemon: effectiveBodyPokemon,
+        isFusion: effectiveIsFusion,
+        isTeamMember,
+        nickname,
+      });
 
     // Preload credits for the artwork variants when they exist
     useSpriteCredits(
@@ -108,44 +98,8 @@ const SummaryCard = React.forwardRef<FusionSpriteHandle, SummaryCardProps>(
       return null;
     }
 
-    // Use the nickname prop if provided, otherwise use the Pokémon's existing nickname
-    const name =
-      nickname !== undefined
-        ? nickname ||
-          displayPokemon.head?.name ||
-          displayPokemon.body?.name ||
-          ""
-        : getNicknameText(
-            displayPokemon.head,
-            displayPokemon.body,
-            displayPokemon.isFusion,
-          );
-
-    // Only consider deceased if both Pokemon are dead (for fusion) or the single Pokemon is dead
-    // Note: boxed Pokemon are not considered deceased, only actually dead Pokemon
-    const headDead = isPokemonDeceased(effectiveHeadPokemon);
-    const bodyDead = isPokemonDeceased(effectiveBodyPokemon);
-
-    const isDeceased =
-      effectiveIsFusion && effectiveHeadPokemon && effectiveBodyPokemon
-        ? headDead && bodyDead
-        : headDead || bodyDead;
-
     const head = displayPokemon.head;
     const body = displayPokemon.body;
-
-    // Determine which Pokemon IDs to use for the link based on display state
-    // When fusion is off, use the single Pokemon ID; when fusion is on, use both
-    const linkHeadId = displayPokemon.isFusion
-      ? (displayPokemon.head?.id ?? null)
-      : (displayPokemon.head?.id ?? displayPokemon.body?.id ?? null);
-    const linkBodyId = displayPokemon.isFusion
-      ? (displayPokemon.body?.id ?? null)
-      : null;
-
-    const link = eitherPokemonIsEgg
-      ? "#"
-      : `https://infinitefusiondex.com/details/${linkHeadId && linkBodyId ? `${linkHeadId}.${linkBodyId}` : linkHeadId || linkBodyId}`;
 
     const SpriteWrapper = eitherPokemonIsEgg ? "div" : "a";
     const spriteWrapperProps = eitherPokemonIsEgg

--- a/src/components/PokemonSummaryCard/summaryCardModel.ts
+++ b/src/components/PokemonSummaryCard/summaryCardModel.ts
@@ -1,0 +1,107 @@
+import { isEggId, type PokemonOptionType } from "@/loaders/pokemon";
+import { isPokemonDeceased } from "@/utils/pokemonPredicates";
+import {
+  type DisplayPokemon,
+  getDisplayPokemon,
+  getNicknameText,
+} from "./utils";
+
+type SummaryCardDisplayInput = {
+  headPokemon?: PokemonOptionType | null;
+  bodyPokemon?: PokemonOptionType | null;
+  isFusion: boolean;
+  isTeamMember: boolean;
+  nickname?: string;
+};
+
+export type SummaryCardDisplay = {
+  displayPokemon: DisplayPokemon;
+  eitherPokemonIsEgg: boolean;
+  isDeceased: boolean;
+  link: string;
+  name: string;
+};
+
+function getDisplayPokemonForSummary(
+  headPokemon: PokemonOptionType | null | undefined,
+  bodyPokemon: PokemonOptionType | null | undefined,
+  isFusion: boolean,
+  isTeamMember: boolean,
+) {
+  if (isTeamMember) {
+    return { head: headPokemon ?? null, body: bodyPokemon ?? null, isFusion };
+  }
+
+  return getDisplayPokemon(headPokemon ?? null, bodyPokemon ?? null, isFusion);
+}
+
+function getSummaryCardName(
+  displayPokemon: DisplayPokemon,
+  nickname: string | undefined,
+) {
+  if (nickname !== undefined) {
+    return (
+      nickname || displayPokemon.head?.name || displayPokemon.body?.name || ""
+    );
+  }
+
+  return (
+    getNicknameText(
+      displayPokemon.head,
+      displayPokemon.body,
+      displayPokemon.isFusion,
+    ) || ""
+  );
+}
+
+function isSummaryCardDeceased(
+  headPokemon: PokemonOptionType | null | undefined,
+  bodyPokemon: PokemonOptionType | null | undefined,
+  isFusion: boolean,
+) {
+  const headDead = isPokemonDeceased(headPokemon);
+  const bodyDead = isPokemonDeceased(bodyPokemon);
+
+  return isFusion && headPokemon && bodyPokemon
+    ? headDead && bodyDead
+    : headDead || bodyDead;
+}
+
+function getSummaryCardLink(
+  displayPokemon: DisplayPokemon,
+  eitherPokemonIsEgg: boolean,
+) {
+  if (eitherPokemonIsEgg) return "#";
+
+  const headId = displayPokemon.head?.id;
+  const bodyId = displayPokemon.body?.id;
+  const pokemonId = displayPokemon.isFusion
+    ? headId && bodyId
+      ? `${headId}.${bodyId}`
+      : headId || bodyId
+    : headId || bodyId;
+
+  return `https://infinitefusiondex.com/details/${pokemonId}`;
+}
+
+export function getSummaryCardDisplay({
+  headPokemon,
+  bodyPokemon,
+  isFusion,
+  isTeamMember,
+  nickname,
+}: SummaryCardDisplayInput): SummaryCardDisplay {
+  const eitherPokemonIsEgg =
+    isEggId(headPokemon?.id) || isEggId(bodyPokemon?.id);
+  const displayPokemon = getDisplayPokemonForSummary(
+    headPokemon,
+    bodyPokemon,
+    isFusion,
+    isTeamMember,
+  );
+  const name = getSummaryCardName(displayPokemon, nickname);
+  const isDeceased = isSummaryCardDeceased(headPokemon, bodyPokemon, isFusion);
+  const link = getSummaryCardLink(displayPokemon, eitherPokemonIsEgg);
+
+  return { displayPokemon, eitherPokemonIsEgg, isDeceased, link, name };
+}

--- a/src/components/pc/PokemonPCSheet.tsx
+++ b/src/components/pc/PokemonPCSheet.tsx
@@ -14,10 +14,7 @@ import {
 import clsx from "clsx";
 import { Box, Boxes, Skull, Users, X } from "lucide-react";
 import { useCallback, useMemo } from "react";
-import {
-  getLocationById,
-  getLocationsSortedWithCustom,
-} from "@/loaders/locations";
+import { getLocationsSortedWithCustom } from "@/loaders/locations";
 import type { PokemonOptionType } from "@/loaders/pokemon";
 import {
   useActivePlaythrough,
@@ -25,13 +22,18 @@ import {
   useEncounters,
 } from "@/stores/playthroughs/hooks";
 import { buildPokemonUidIndex } from "@/utils/encounter-utils";
-import { isPokemonDeceased, isPokemonStored } from "@/utils/pokemonPredicates";
 import { scrollToLocationById } from "@/utils/scrollToLocation";
 import TeamMemberPickerModal from "../team/TeamMemberPickerModal";
 import { getTeamSlots } from "../team/teamSlots";
 import { useTeamMemberPicker } from "../team/useTeamMemberPicker";
 import { GraveyardGridItem } from "./GraveyardGridItem";
 import PCEntryItem from "./PCEntryItem";
+import {
+  getDeceasedEntries,
+  getPCTab,
+  getPCTabIndex,
+  getStoredEntries,
+} from "./pcSheetDomain";
 import TeamEntryItem from "./TeamEntryItem";
 
 export interface PokemonPCSheetProps {
@@ -122,94 +124,17 @@ export default function PokemonPCSheet({
     [activePlaythrough?.team, encounters, pokemonByUid],
   );
 
-  const deceased: Entry[] = useMemo(() => {
-    const entries: Entry[] = [];
-
-    Object.entries(encounters || {}).forEach(([locationId, data]) => {
-      const headDead = isPokemonDeceased(data?.head);
-      const bodyDead = isPokemonDeceased(data?.body);
-
-      const locationName =
-        idToName.get(locationId) ||
-        getLocationById(locationId)?.name ||
-        "Unknown Location";
-
-      // Create separate entries for each deceased Pokémon
-      if (headDead && data?.head) {
-        entries.push({
-          locationId: `${locationId}-head`,
-          locationName,
-          head: data.head,
-          body: null,
-        });
-      }
-
-      if (bodyDead && data?.body) {
-        entries.push({
-          locationId: `${locationId}-body`,
-          locationName,
-          head: null,
-          body: data.body,
-        });
-      }
-    });
-
-    return entries;
-  }, [encounters, idToName]);
-
-  const stored: Entry[] = useMemo(() => {
-    const entries: Entry[] = [];
-
-    Object.entries(encounters || {}).forEach(([locationId, data]) => {
-      const headStored = isPokemonStored(data?.head);
-      const bodyStored = isPokemonStored(data?.body);
-
-      if (headStored || bodyStored) {
-        entries.push({
-          locationId,
-          locationName:
-            idToName.get(locationId) ||
-            getLocationById(locationId)?.name ||
-            "Unknown Location",
-          head: headStored ? data?.head || null : null,
-          body: bodyStored ? data?.body || null : null,
-        });
-      }
-    });
-
-    return entries;
-  }, [encounters, idToName]);
-
-  const getSelectedIndex = useCallback((tab: "team" | "box" | "graveyard") => {
-    switch (tab) {
-      case "team":
-        return 0;
-      case "box":
-        return 1;
-      case "graveyard":
-        return 2;
-      default:
-        return 0;
-    }
-  }, []);
-
-  const getTabFromIndex = useCallback(
-    (index: number): "team" | "box" | "graveyard" => {
-      switch (index) {
-        case 0:
-          return "team";
-        case 1:
-          return "box";
-        case 2:
-          return "graveyard";
-        default:
-          return "team";
-      }
-    },
-    [],
+  const deceased: Entry[] = useMemo(
+    () => getDeceasedEntries(encounters, idToName),
+    [encounters, idToName],
   );
 
-  const selectedIndex = getSelectedIndex(activeTab);
+  const stored: Entry[] = useMemo(
+    () => getStoredEntries(encounters, idToName),
+    [encounters, idToName],
+  );
+
+  const selectedIndex = getPCTabIndex(activeTab);
 
   // Memoize the onClose handler to prevent unnecessary re-renders
   const handleClose = useCallback(() => {
@@ -219,9 +144,9 @@ export default function PokemonPCSheet({
   // Memoize the onChangeTab handler
   const handleChangeTab = useCallback(
     (index: number) => {
-      onChangeTab(getTabFromIndex(index));
+      onChangeTab(getPCTab(index));
     },
-    [onChangeTab, getTabFromIndex],
+    [onChangeTab],
   );
 
   return (

--- a/src/components/pc/__tests__/pcSheetDomain.test.ts
+++ b/src/components/pc/__tests__/pcSheetDomain.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { type PokemonOptionType, PokemonStatus } from "@/loaders/pokemon";
+import type { EncounterData } from "@/stores/playthroughs/types";
+import {
+  getDeceasedEntries,
+  getPCTab,
+  getPCTabIndex,
+  getStoredEntries,
+} from "../pcSheetDomain";
+
+const pokemon = (
+  id: number,
+  status: PokemonOptionType["status"],
+): PokemonOptionType => ({
+  id,
+  name: `Pokemon ${id}`,
+  nationalDexId: id,
+  status,
+});
+
+const encounters: Record<string, EncounterData> = {
+  "route-1": {
+    head: pokemon(25, PokemonStatus.DECEASED),
+    body: pokemon(1, PokemonStatus.STORED),
+    isFusion: true,
+    updatedAt: 0,
+  },
+};
+
+describe("PC sheet domain", () => {
+  it("splits deceased members and retains stored members at their encounter", () => {
+    const locations = new Map([["route-1", "Route 1"]]);
+
+    expect(getDeceasedEntries(encounters, locations)).toMatchObject([
+      {
+        locationId: "route-1-head",
+        locationName: "Route 1",
+        head: { id: 25 },
+        body: null,
+      },
+    ]);
+    expect(getStoredEntries(encounters, locations)).toMatchObject([
+      {
+        locationId: "route-1",
+        locationName: "Route 1",
+        head: null,
+        body: { id: 1 },
+      },
+    ]);
+  });
+
+  it("maps known tabs and invalid indices predictably", () => {
+    expect(getPCTabIndex("graveyard")).toBe(2);
+    expect(getPCTab(1)).toBe("box");
+    expect(getPCTab(99)).toBe("team");
+  });
+});

--- a/src/components/pc/pcSheetDomain.ts
+++ b/src/components/pc/pcSheetDomain.ts
@@ -1,0 +1,79 @@
+import { getLocationById } from "@/loaders/locations";
+import type { EncounterData } from "@/stores/playthroughs/types";
+import { isPokemonDeceased, isPokemonStored } from "@/utils/pokemonPredicates";
+import type { PCEntry } from "./types";
+
+export type PCTab = "team" | "box" | "graveyard";
+
+function getPCEntryLocationName(
+  locationId: string,
+  idToName: Map<string, string>,
+) {
+  return (
+    idToName.get(locationId) ||
+    getLocationById(locationId)?.name ||
+    "Unknown Location"
+  );
+}
+
+export function getDeceasedEntries(
+  encounters: Record<string, EncounterData> | null | undefined,
+  idToName: Map<string, string>,
+): PCEntry[] {
+  const entries: PCEntry[] = [];
+
+  Object.entries(encounters || {}).forEach(([locationId, data]) => {
+    const locationName = getPCEntryLocationName(locationId, idToName);
+
+    if (isPokemonDeceased(data.head)) {
+      entries.push({
+        locationId: `${locationId}-head`,
+        locationName,
+        head: data.head,
+        body: null,
+      });
+    }
+
+    if (isPokemonDeceased(data.body)) {
+      entries.push({
+        locationId: `${locationId}-body`,
+        locationName,
+        head: null,
+        body: data.body,
+      });
+    }
+  });
+
+  return entries;
+}
+
+export function getStoredEntries(
+  encounters: Record<string, EncounterData> | null | undefined,
+  idToName: Map<string, string>,
+): PCEntry[] {
+  const entries: PCEntry[] = [];
+
+  Object.entries(encounters || {}).forEach(([locationId, data]) => {
+    const headStored = isPokemonStored(data.head);
+    const bodyStored = isPokemonStored(data.body);
+
+    if (headStored || bodyStored) {
+      entries.push({
+        locationId,
+        locationName: getPCEntryLocationName(locationId, idToName),
+        head: headStored ? data.head : null,
+        body: bodyStored ? data.body : null,
+      });
+    }
+  });
+
+  return entries;
+}
+
+export function getPCTabIndex(tab: PCTab) {
+  return ["team", "box", "graveyard"].indexOf(tab);
+}
+
+export function getPCTab(index: number): PCTab {
+  return (["team", "box", "graveyard"][index] as PCTab | undefined) ?? "team";
+}

--- a/src/components/team/TeamMemberSelectionPanel.tsx
+++ b/src/components/team/TeamMemberSelectionPanel.tsx
@@ -9,6 +9,7 @@ import { PokemonGridItem } from "./PokemonGridItem";
 import { PokemonSlotSelector } from "./PokemonSlotSelector";
 import { TeamMemberSearchBar } from "./TeamMemberSearchBar";
 import { useTeamMemberSelection } from "./TeamMemberSelectionContext";
+import { flipTeamPokemonSelection } from "./teamMemberSelectionDomain";
 
 export function TeamMemberSelectionPanel() {
   const { state, actions } = useTeamMemberSelection();
@@ -26,55 +27,13 @@ export function TeamMemberSelectionPanel() {
     handlePokemonSelect,
   } = actions;
 
-  // Handler to flip fusion (swap head and body)
-  const handleFlipFusion = React.useCallback(() => {
-    // Always swap the selections, regardless of whether they're filled or empty
-    const tempHead = selectedHead;
-    const tempBody = selectedBody;
-
-    // Swap the selections directly
-    actions.setSelectedHead(tempBody);
-    actions.setSelectedBody(tempHead);
-
-    // Immediately update nickname to reflect the new head Pokémon
-    if (tempBody?.pokemon && tempHead?.pokemon) {
-      // For fusions, always prioritize head Pokémon's nickname (now tempBody)
-      if (tempBody.pokemon.nickname) {
-        actions.setNickname(tempBody.pokemon.nickname);
-        actions.setPreviewNickname(tempBody.pokemon.nickname);
-      } else if (tempHead.pokemon.nickname) {
-        // Fallback to body Pokémon's nickname if head doesn't have one
-        actions.setNickname(tempHead.pokemon.nickname);
-        actions.setPreviewNickname(tempHead.pokemon.nickname);
-      } else {
-        // No nickname available
-        actions.setNickname("");
-        actions.setPreviewNickname("");
-      }
-    } else if (tempBody?.pokemon) {
-      // Single head Pokémon (now tempBody)
-      if (tempBody.pokemon.nickname) {
-        actions.setNickname(tempBody.pokemon.nickname);
-        actions.setPreviewNickname(tempBody.pokemon.nickname);
-      } else {
-        actions.setNickname("");
-        actions.setPreviewNickname("");
-      }
-    } else if (tempHead?.pokemon) {
-      // Single body Pokémon (now tempHead)
-      if (tempHead.pokemon.nickname) {
-        actions.setNickname(tempHead.pokemon.nickname);
-        actions.setPreviewNickname(tempHead.pokemon.nickname);
-      } else {
-        actions.setNickname("");
-        actions.setPreviewNickname("");
-      }
-    } else {
-      // No Pokémon selected
-      actions.setNickname("");
-      actions.setPreviewNickname("");
-    }
-  }, [selectedHead, selectedBody, actions]);
+  const handleFlipFusion = () => {
+    const next = flipTeamPokemonSelection(selectedHead, selectedBody);
+    actions.setSelectedHead(next.selectedHead);
+    actions.setSelectedBody(next.selectedBody);
+    actions.setNickname(next.nickname);
+    actions.setPreviewNickname(next.previewNickname);
+  };
 
   // Filter Pokémon based on search query locally (no need to update state)
   const filteredPokemon = React.useMemo(() => {

--- a/src/components/team/__tests__/teamMemberSelectionDomain.test.ts
+++ b/src/components/team/__tests__/teamMemberSelectionDomain.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { type PokemonOptionType, PokemonStatus } from "@/loaders/pokemon";
 import {
   filterAvailableTeamPokemon,
+  flipTeamPokemonSelection,
   getTeamNicknameUpdate,
   getTeamSelectionNickname,
   initializeExistingTeamMemberSelection,
@@ -41,6 +42,32 @@ describe("team member selection domain", () => {
   it("returns empty nickname when no selected pokemon has one", () => {
     expect(getTeamSelectionNickname(pokemon("head"), pokemon("body"))).toBe("");
     expect(getTeamSelectionNickname(null, null)).toBe("");
+  });
+
+  it("flips selections and uses the new head nickname", () => {
+    const head = { pokemon: pokemon("head", "Sparky"), locationId: "route-1" };
+    const body = { pokemon: pokemon("body", "Flame"), locationId: "route-2" };
+
+    expect(flipTeamPokemonSelection(head, body)).toEqual({
+      selectedHead: body,
+      selectedBody: head,
+      nickname: "Flame",
+      previewNickname: "Flame",
+    });
+  });
+
+  it("clears the nickname when flipping unnamed or empty selections", () => {
+    expect(
+      flipTeamPokemonSelection(
+        { pokemon: pokemon("head"), locationId: "route-1" },
+        null,
+      ),
+    ).toMatchObject({
+      selectedHead: null,
+      nickname: "",
+      previewNickname: "",
+    });
+    expect(flipTeamPokemonSelection(null, null).nickname).toBe("");
   });
 
   it("updates the head nickname before the body nickname", () => {

--- a/src/components/team/teamMemberSelectionDomain.ts
+++ b/src/components/team/teamMemberSelectionDomain.ts
@@ -28,6 +28,21 @@ export const getTeamSelectionNickname = (
       ? bodyPokemon.nickname
       : "";
 
+export const flipTeamPokemonSelection = (
+  selectedHead: TeamPokemonSelection | null,
+  selectedBody: TeamPokemonSelection | null,
+) => {
+  const nickname =
+    selectedBody?.pokemon.nickname || selectedHead?.pokemon.nickname || "";
+
+  return {
+    selectedHead: selectedBody,
+    selectedBody: selectedHead,
+    nickname,
+    previewNickname: nickname,
+  };
+};
+
 export const getTeamNicknameUpdate = (
   headPokemon: PokemonOptionType | null | undefined,
   bodyPokemon: PokemonOptionType | null | undefined,


### PR DESCRIPTION
## Summary
Extract component decision models for summary cards, PC entries, and team fusion reversal. Gate original-encounter details on the Move encounters setting, even when moved Pokemon data exists.

## Changes
- Extract summary-card display/link/deceased decisions and PC entry/tab derivation into tested helpers.
- Replace fusion reversal branching with a pure team-selection transition.
- Remove the moved-data override for original-encounter tooltip details and highlighting.

## Testing
- `pnpm type-check`
- `pnpm test:run`
- `pnpm validate`
- `pnpm quality:graph:json`