### PR TITLE
refactor: consolidate script pipeline helpers

### DIFF
--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -123,10 +123,10 @@ Completed icon batch work: shared generation-batch processing preserves download
 
 - [x] Complete encounter-scraper terminal reporting. Shared failure formatting, process exit handling, and direct-execution detection removed its clone groups while preserving source-specific summaries, reducing full duplication from 12 to 9 groups.
 - [x] Refactor wild-wikitext parsing and route-state normalization in `scripts/scrape-wild-encounters.ts`. Nested argument boundaries, encounter-type cancellation, route isolation, and resolution failures remain covered; the health report drops from 113 to 110 findings.
-- [ ] Refactor legendary DOM traversal and route aggregation after adding a deterministic HTML fixture seam.
-- [ ] Refactor spritesheet packing and overlap repair as separate policies, retaining the existing geometry utility boundaries.
-- [ ] Add deterministic fixtures before refactoring data-refresh PR-body normalization in `scripts/generate-data-pr-body.ts`.
-- [ ] Complete the independent script-maintenance utilities: license generation, route-article validation, and parsed wiki fetching.
+- [x] Refactor legendary DOM traversal and route aggregation. Fixture coverage preserves form expansion, sibling bounds, heading barriers, and route normalization; the health report drops from 110 to 109 findings.
+- [x] Refactor spritesheet packing and overlap repair as separate policies, retaining the existing geometry utility boundaries. Direct policy coverage preserves packing and repair behavior; the health report drops from 109 to 99 findings.
+- [x] Add deterministic fixtures before refactoring data-refresh PR-body normalization in `scripts/generate-data-pr-body.ts`. Shape precedence and duplicate ordering are covered; the health report drops from 99 to 94 findings.
+- [x] Complete the independent script-maintenance utilities. Wiki transport is decomposed, reducing the health report from 94 to 93 findings. License generation and route-article validation retain narrow documented complexity suppressions for environment-bound CLI orchestration.
 
 ### UI And Store Queue
 

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -84,7 +84,7 @@ Purpose: close the residual first-party findings through behavior-preserving ref
 - [x] Add behavior and accessibility coverage for context-menu, summary-card, PC, team, and location interaction paths.
 - [x] Refactor context-menu action construction and shared behavior before extracting common code.
 - [x] Refactor summary-card and PC/team decision surfaces without widening component interfaces unnecessarily.
-- [ ] Resolve UI clone groups only where states and accessibility behavior are identical.
+- [x] Resolve UI clone groups only where states and accessibility behavior are identical.
 - [ ] Group scraper and sprite clone findings by data-pipeline step.
 - [ ] Add deterministic input/output tests before consolidating script utilities.
 - [ ] Resolve remaining complexity findings by workflow or pipeline stage, prioritizing items with matching duplication findings.

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -87,7 +87,8 @@ Purpose: close the residual first-party findings through behavior-preserving ref
 - [x] Resolve UI clone groups only where states and accessibility behavior are identical.
 - [x] Group scraper and sprite clone findings by data-pipeline step.
 - [x] Add deterministic input/output tests before consolidating script utilities.
-- [ ] Resolve remaining complexity findings by workflow or pipeline stage, prioritizing items with matching duplication findings.
+- [ ] Resolve remaining script and pipeline findings by the bounded stages below, prioritizing items with matching duplication findings.
+- [ ] After the script stages, address the separately tracked UI and store complexity queue below.
 - [ ] Trace every remaining first-party finding and remove it, refactor it, configure it, or add a narrow reasoned suppression.
 - [ ] Save the resulting first-party baseline and keep the changed-code audit gate enabled.
 
@@ -115,6 +116,26 @@ Completed encounter output work: shared classic/remix directory setup removed tw
 Completed runtime sprite helper work: shared suffix and CDN URL generation removed one clone group, reducing full duplication groups from 13 to 12. Server and browser existence checks remain intentionally separate.
 
 Completed egg-location classification work: deterministic egg, location, and nest-link predicates preserve the existing keyword rules and parent-context requirements under direct coverage, removing two scraper callback complexity findings and reducing the health report from 119 to 115 findings.
+
+Completed icon batch work: shared generation-batch processing preserves download order, cumulative progress, retry behavior, and stats under direct coverage, removing the duplicated Gen 7/Gen 8 loop and reducing the health report from 115 to 113 findings. The scraper now runs only under its direct-execution guard, keeping imports side-effect free; the guard has a narrow Fallow duplicate-line suppression because it must remain adjacent to the script entrypoint.
+
+### Remaining Script Stages
+
+- [x] Complete encounter-scraper terminal reporting. Shared failure formatting, process exit handling, and direct-execution detection removed its clone groups while preserving source-specific summaries, reducing full duplication from 12 to 9 groups.
+- [ ] Refactor wild-wikitext parsing and route-state normalization in `scripts/scrape-wild-encounters.ts` with existing parser fixtures.
+- [ ] Refactor legendary DOM traversal and route aggregation after adding a deterministic HTML fixture seam.
+- [ ] Refactor spritesheet packing and overlap repair as separate policies, retaining the existing geometry utility boundaries.
+- [ ] Add deterministic fixtures before refactoring data-refresh PR-body normalization in `scripts/generate-data-pr-body.ts`.
+- [ ] Complete the independent script-maintenance utilities: license generation, route-article validation, and parsed wiki fetching.
+
+### UI And Store Queue
+
+Start this queue only after the script stages are complete or intentionally suppressed.
+
+- [ ] Location-table encounter rendering and actions: consolidate identical `EncounterCell` states while preserving accessibility behavior.
+- [ ] Combobox selection and drag/drop: separate selection rules from drag/drop state transitions before extracting clone groups.
+- [ ] Encounter store transitions: refactor CRUD and drag/drop operations behind existing state-transition tests.
+- [ ] UI decision surfaces: address context menus, summary cards, PC, and team components as independent behavior slices rather than a shared cleanup batch.
 
 Acceptance criteria:
 

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -98,7 +98,7 @@ Fallow's duplication report groups these findings by pipeline responsibility. Re
 | Pipeline step | Clone groups | Files | Consolidation boundary |
 | --- | --- | --- | --- |
 | Pokemon source enrichment | 1-2 | `scripts/fetch-pokemon-data.ts` | Share evolution-chain loading and processed-record construction between batch and fallback retrieval. |
-| Encounter extraction and normalization | 10, 12-14 | `scripts/scrape-legendary-encounters.ts`, `scripts/scrape-safari-encounters.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-wild-encounters.ts` | Extract only parsers with matching source markup and output schemas; retain source-specific validation and error messages. |
+| Encounter extraction and normalization | 10, 12-14 | `scripts/scrape-legendary-encounters.ts`, `scripts/scrape-safari-encounters.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-wild-encounters.ts` | Shared output-directory setup and Safari classification are completed. Extract only parsers with matching source markup and output schemas; retain source-specific validation and error messages. |
 | Scraper orchestration and terminal reporting | 8-9 | `scripts/scrape-egg-locations.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-pokemon-icons.ts` | Keep final summaries and process-exit handling local unless a shared runner can preserve each script's result shape and direct-execution guard. |
 | Sprite source setup and acquisition | 3-4, 11 | `scripts/generate-spritesheet.ts`, `scripts/scrape-pokemon-icons.ts` | Setup clone consolidation and download retry refactor completed through shared path derivation, JSON loading, and focused retry helpers. The duplicated batch loop remains separate acquisition work. |
 | Sprite packing and validation | 5-7 | `scripts/generate-spritesheet.ts` | Clone consolidation completed: shared geometry primitives now cover overlap detection, pair traversal, and packed bounds; packing and repair policies remain distinct and retain their outstanding complexity work. |
@@ -109,6 +109,8 @@ Completed source-enrichment work: shared evolution-chain loading and processed-r
 Completed sprite-packing clone work: targeted geometry tests cover edge contact, overlap detection, pair traversal, and packed bounds. Shared geometry primitives removed clone groups 5-7 and one validation complexity finding, reducing the health report from 124 to 123 complexity findings.
 
 Completed sprite-source work: shared path derivation and JSON loading removed the two cross-script setup clone groups, reducing full duplication groups from 18 to 16. Focused retry helpers have coverage for existing files, eggs, and base-form fallback; the duplicated batch download loop is now consolidated.
+
+Completed encounter output work: shared classic/remix directory setup removed two clone groups across the Safari, wild, and special scrapers. Ordered Safari encounter rules retain classification precedence under focused coverage and reduced the health report from 122 to 119 complexity findings.
 
 Acceptance criteria:
 

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -122,7 +122,7 @@ Completed icon batch work: shared generation-batch processing preserves download
 ### Remaining Script Stages
 
 - [x] Complete encounter-scraper terminal reporting. Shared failure formatting, process exit handling, and direct-execution detection removed its clone groups while preserving source-specific summaries, reducing full duplication from 12 to 9 groups.
-- [ ] Refactor wild-wikitext parsing and route-state normalization in `scripts/scrape-wild-encounters.ts` with existing parser fixtures.
+- [x] Refactor wild-wikitext parsing and route-state normalization in `scripts/scrape-wild-encounters.ts`. Nested argument boundaries, encounter-type cancellation, route isolation, and resolution failures remain covered; the health report drops from 113 to 110 findings.
 - [ ] Refactor legendary DOM traversal and route aggregation after adding a deterministic HTML fixture seam.
 - [ ] Refactor spritesheet packing and overlap repair as separate policies, retaining the existing geometry utility boundaries.
 - [ ] Add deterministic fixtures before refactoring data-refresh PR-body normalization in `scripts/generate-data-pr-body.ts`.

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -102,7 +102,7 @@ Fallow's duplication report groups these findings by pipeline responsibility. Re
 | Scraper orchestration and terminal reporting | 8-9 | `scripts/scrape-egg-locations.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-pokemon-icons.ts` | Keep final summaries and process-exit handling local unless a shared runner can preserve each script's result shape and direct-execution guard. |
 | Sprite source setup and acquisition | 3-4, 11 | `scripts/generate-spritesheet.ts`, `scripts/scrape-pokemon-icons.ts` | Setup clone consolidation and download retry refactor completed through shared path derivation, JSON loading, and focused retry helpers. The duplicated batch loop remains separate acquisition work. |
 | Sprite packing and validation | 5-7 | `scripts/generate-spritesheet.ts` | Clone consolidation completed: shared geometry primitives now cover overlap detection, pair traversal, and packed bounds; packing and repair policies remain distinct and retain their outstanding complexity work. |
-| Runtime sprite delivery | 15-16 | `src/app/api/sprite/variants/route.ts`, `src/lib/sprites.ts` | Track separately from script pipelines because these are request-time behavior and need API coverage. |
+| Runtime sprite delivery | 15-16 | `src/app/api/sprite/variants/route.ts`, `src/lib/sprites.ts` | Shared suffix and URL generation is completed under direct coverage. Keep server/browser existence checks separate because their transport behavior differs. |
 
 Completed source-enrichment work: shared evolution-chain loading and processed-record construction now serve both batch and fallback retrieval in `scripts/fetch-pokemon-data.ts`. This removed clone groups 1-2 and reduced the health report from 126 to 124 complexity findings; the remaining stages stay tracked by the unchecked complexity item.
 
@@ -111,6 +111,10 @@ Completed sprite-packing clone work: targeted geometry tests cover edge contact,
 Completed sprite-source work: shared path derivation and JSON loading removed the two cross-script setup clone groups, reducing full duplication groups from 18 to 16. Focused retry helpers have coverage for existing files, eggs, and base-form fallback; the duplicated batch download loop is now consolidated.
 
 Completed encounter output work: shared classic/remix directory setup removed two clone groups across the Safari, wild, and special scrapers. Ordered Safari encounter rules retain classification precedence under focused coverage and reduced the health report from 122 to 119 complexity findings.
+
+Completed runtime sprite helper work: shared suffix and CDN URL generation removed one clone group, reducing full duplication groups from 13 to 12. Server and browser existence checks remain intentionally separate.
+
+Completed egg gift-row classification work: deterministic egg and location predicates preserve the existing keyword rules under direct coverage, removing the scraper callback complexity finding and reducing the health report from 119 to 116 findings.
 
 Acceptance criteria:
 

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -86,7 +86,7 @@ Purpose: close the residual first-party findings through behavior-preserving ref
 - [x] Refactor summary-card and PC/team decision surfaces without widening component interfaces unnecessarily.
 - [x] Resolve UI clone groups only where states and accessibility behavior are identical.
 - [ ] Group scraper and sprite clone findings by data-pipeline step.
-- [ ] Add deterministic input/output tests before consolidating script utilities.
+- [x] Add deterministic input/output tests before consolidating script utilities.
 - [ ] Resolve remaining complexity findings by workflow or pipeline stage, prioritizing items with matching duplication findings.
 - [ ] Trace every remaining first-party finding and remove it, refactor it, configure it, or add a narrow reasoned suppression.
 - [ ] Save the resulting first-party baseline and keep the changed-code audit gate enabled.

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -100,13 +100,15 @@ Fallow's duplication report groups these findings by pipeline responsibility. Re
 | Pokemon source enrichment | 1-2 | `scripts/fetch-pokemon-data.ts` | Share evolution-chain loading and processed-record construction between batch and fallback retrieval. |
 | Encounter extraction and normalization | 10, 12-14 | `scripts/scrape-legendary-encounters.ts`, `scripts/scrape-safari-encounters.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-wild-encounters.ts` | Extract only parsers with matching source markup and output schemas; retain source-specific validation and error messages. |
 | Scraper orchestration and terminal reporting | 8-9 | `scripts/scrape-egg-locations.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-pokemon-icons.ts` | Keep final summaries and process-exit handling local unless a shared runner can preserve each script's result shape and direct-execution guard. |
-| Sprite source setup and acquisition | 3-4, 11 | `scripts/generate-spritesheet.ts`, `scripts/scrape-pokemon-icons.ts` | Share sprite-specific path/configuration and generation download iteration; do not mix with encounter scrapers. |
+| Sprite source setup and acquisition | 3-4, 11 | `scripts/generate-spritesheet.ts`, `scripts/scrape-pokemon-icons.ts` | Setup clone consolidation completed through shared path derivation and JSON loading. Keep download retry policy local to the icon scraper. |
 | Sprite packing and validation | 5-7 | `scripts/generate-spritesheet.ts` | Clone consolidation completed: shared geometry primitives now cover overlap detection, pair traversal, and packed bounds; packing and repair policies remain distinct and retain their outstanding complexity work. |
 | Runtime sprite delivery | 15-16 | `src/app/api/sprite/variants/route.ts`, `src/lib/sprites.ts` | Track separately from script pipelines because these are request-time behavior and need API coverage. |
 
 Completed source-enrichment work: shared evolution-chain loading and processed-record construction now serve both batch and fallback retrieval in `scripts/fetch-pokemon-data.ts`. This removed clone groups 1-2 and reduced the health report from 126 to 124 complexity findings; the remaining stages stay tracked by the unchecked complexity item.
 
 Completed sprite-packing clone work: targeted geometry tests cover edge contact, overlap detection, pair traversal, and packed bounds. Shared geometry primitives removed clone groups 5-7 and one validation complexity finding, reducing the health report from 124 to 123 complexity findings.
+
+Completed sprite-source setup work: shared path derivation and JSON loading removed the two cross-script setup clone groups, reducing full duplication groups from 18 to 16. The icon download retry workflow remains the next complexity target in this stage.
 
 Acceptance criteria:
 

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -114,7 +114,7 @@ Completed encounter output work: shared classic/remix directory setup removed tw
 
 Completed runtime sprite helper work: shared suffix and CDN URL generation removed one clone group, reducing full duplication groups from 13 to 12. Server and browser existence checks remain intentionally separate.
 
-Completed egg gift-row classification work: deterministic egg and location predicates preserve the existing keyword rules under direct coverage, removing the scraper callback complexity finding and reducing the health report from 119 to 116 findings.
+Completed egg-location classification work: deterministic egg, location, and nest-link predicates preserve the existing keyword rules and parent-context requirements under direct coverage, removing two scraper callback complexity findings and reducing the health report from 119 to 115 findings.
 
 Acceptance criteria:
 

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -101,10 +101,12 @@ Fallow's duplication report groups these findings by pipeline responsibility. Re
 | Encounter extraction and normalization | 10, 12-14 | `scripts/scrape-legendary-encounters.ts`, `scripts/scrape-safari-encounters.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-wild-encounters.ts` | Extract only parsers with matching source markup and output schemas; retain source-specific validation and error messages. |
 | Scraper orchestration and terminal reporting | 8-9 | `scripts/scrape-egg-locations.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-pokemon-icons.ts` | Keep final summaries and process-exit handling local unless a shared runner can preserve each script's result shape and direct-execution guard. |
 | Sprite source setup and acquisition | 3-4, 11 | `scripts/generate-spritesheet.ts`, `scripts/scrape-pokemon-icons.ts` | Share sprite-specific path/configuration and generation download iteration; do not mix with encounter scrapers. |
-| Sprite packing and validation | 5-7 | `scripts/generate-spritesheet.ts` | Extract a rectangle-overlap predicate only after packing and repair behavior has targeted coverage; keep packing and repair policies distinct. |
+| Sprite packing and validation | 5-7 | `scripts/generate-spritesheet.ts` | Clone consolidation completed: shared geometry primitives now cover overlap detection, pair traversal, and packed bounds; packing and repair policies remain distinct and retain their outstanding complexity work. |
 | Runtime sprite delivery | 15-16 | `src/app/api/sprite/variants/route.ts`, `src/lib/sprites.ts` | Track separately from script pipelines because these are request-time behavior and need API coverage. |
 
 Completed source-enrichment work: shared evolution-chain loading and processed-record construction now serve both batch and fallback retrieval in `scripts/fetch-pokemon-data.ts`. This removed clone groups 1-2 and reduced the health report from 126 to 124 complexity findings; the remaining stages stay tracked by the unchecked complexity item.
+
+Completed sprite-packing clone work: targeted geometry tests cover edge contact, overlap detection, pair traversal, and packed bounds. Shared geometry primitives removed clone groups 5-7 and one validation complexity finding, reducing the health report from 124 to 123 complexity findings.
 
 Acceptance criteria:
 

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -85,11 +85,26 @@ Purpose: close the residual first-party findings through behavior-preserving ref
 - [x] Refactor context-menu action construction and shared behavior before extracting common code.
 - [x] Refactor summary-card and PC/team decision surfaces without widening component interfaces unnecessarily.
 - [x] Resolve UI clone groups only where states and accessibility behavior are identical.
-- [ ] Group scraper and sprite clone findings by data-pipeline step.
+- [x] Group scraper and sprite clone findings by data-pipeline step.
 - [x] Add deterministic input/output tests before consolidating script utilities.
 - [ ] Resolve remaining complexity findings by workflow or pipeline stage, prioritizing items with matching duplication findings.
 - [ ] Trace every remaining first-party finding and remove it, refactor it, configure it, or add a narrow reasoned suppression.
 - [ ] Save the resulting first-party baseline and keep the changed-code audit gate enabled.
+
+### Scraper And Sprite Clone Triage
+
+Fallow's duplication report groups these findings by pipeline responsibility. Refactor only within a stage so that source-specific parsing, failure handling, and output contracts remain explicit.
+
+| Pipeline step | Clone groups | Files | Consolidation boundary |
+| --- | --- | --- | --- |
+| Pokemon source enrichment | 1-2 | `scripts/fetch-pokemon-data.ts` | Share evolution-chain loading and processed-record construction between batch and fallback retrieval. |
+| Encounter extraction and normalization | 10, 12-14 | `scripts/scrape-legendary-encounters.ts`, `scripts/scrape-safari-encounters.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-wild-encounters.ts` | Extract only parsers with matching source markup and output schemas; retain source-specific validation and error messages. |
+| Scraper orchestration and terminal reporting | 8-9 | `scripts/scrape-egg-locations.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-pokemon-icons.ts` | Keep final summaries and process-exit handling local unless a shared runner can preserve each script's result shape and direct-execution guard. |
+| Sprite source setup and acquisition | 3-4, 11 | `scripts/generate-spritesheet.ts`, `scripts/scrape-pokemon-icons.ts` | Share sprite-specific path/configuration and generation download iteration; do not mix with encounter scrapers. |
+| Sprite packing and validation | 5-7 | `scripts/generate-spritesheet.ts` | Extract a rectangle-overlap predicate only after packing and repair behavior has targeted coverage; keep packing and repair policies distinct. |
+| Runtime sprite delivery | 15-16 | `src/app/api/sprite/variants/route.ts`, `src/lib/sprites.ts` | Track separately from script pipelines because these are request-time behavior and need API coverage. |
+
+Completed source-enrichment work: shared evolution-chain loading and processed-record construction now serve both batch and fallback retrieval in `scripts/fetch-pokemon-data.ts`. This removed clone groups 1-2 and reduced the health report from 126 to 124 complexity findings; the remaining stages stay tracked by the unchecked complexity item.
 
 Acceptance criteria:
 

--- a/docs/FALLOW_REMEDIATION_PLAN.md
+++ b/docs/FALLOW_REMEDIATION_PLAN.md
@@ -100,7 +100,7 @@ Fallow's duplication report groups these findings by pipeline responsibility. Re
 | Pokemon source enrichment | 1-2 | `scripts/fetch-pokemon-data.ts` | Share evolution-chain loading and processed-record construction between batch and fallback retrieval. |
 | Encounter extraction and normalization | 10, 12-14 | `scripts/scrape-legendary-encounters.ts`, `scripts/scrape-safari-encounters.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-wild-encounters.ts` | Extract only parsers with matching source markup and output schemas; retain source-specific validation and error messages. |
 | Scraper orchestration and terminal reporting | 8-9 | `scripts/scrape-egg-locations.ts`, `scripts/scrape-special-encounters.ts`, `scripts/scrape-pokemon-icons.ts` | Keep final summaries and process-exit handling local unless a shared runner can preserve each script's result shape and direct-execution guard. |
-| Sprite source setup and acquisition | 3-4, 11 | `scripts/generate-spritesheet.ts`, `scripts/scrape-pokemon-icons.ts` | Setup clone consolidation completed through shared path derivation and JSON loading. Keep download retry policy local to the icon scraper. |
+| Sprite source setup and acquisition | 3-4, 11 | `scripts/generate-spritesheet.ts`, `scripts/scrape-pokemon-icons.ts` | Setup clone consolidation and download retry refactor completed through shared path derivation, JSON loading, and focused retry helpers. The duplicated batch loop remains separate acquisition work. |
 | Sprite packing and validation | 5-7 | `scripts/generate-spritesheet.ts` | Clone consolidation completed: shared geometry primitives now cover overlap detection, pair traversal, and packed bounds; packing and repair policies remain distinct and retain their outstanding complexity work. |
 | Runtime sprite delivery | 15-16 | `src/app/api/sprite/variants/route.ts`, `src/lib/sprites.ts` | Track separately from script pipelines because these are request-time behavior and need API coverage. |
 
@@ -108,7 +108,7 @@ Completed source-enrichment work: shared evolution-chain loading and processed-r
 
 Completed sprite-packing clone work: targeted geometry tests cover edge contact, overlap detection, pair traversal, and packed bounds. Shared geometry primitives removed clone groups 5-7 and one validation complexity finding, reducing the health report from 124 to 123 complexity findings.
 
-Completed sprite-source setup work: shared path derivation and JSON loading removed the two cross-script setup clone groups, reducing full duplication groups from 18 to 16. The icon download retry workflow remains the next complexity target in this stage.
+Completed sprite-source work: shared path derivation and JSON loading removed the two cross-script setup clone groups, reducing full duplication groups from 18 to 16. Focused retry helpers have coverage for existing files, eggs, and base-form fallback; the duplicated batch download loop is now consolidated.
 
 Acceptance criteria:
 

--- a/docs/coverage.svg
+++ b/docs/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20" role="img" aria-label="coverage: 45.75%">
-  <title>coverage: 45.75%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20" role="img" aria-label="coverage: 52.32%">
+  <title>coverage: 52.32%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -9,13 +9,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="66" height="20" fill="#555"/>
-    <rect x="66" width="52" height="20" fill="#e05d44"/>
+    <rect x="66" width="52" height="20" fill="#fe7d37"/>
     <rect width="118" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="92" y="15" fill="#010101" fill-opacity=".3">45.75%</text>
-    <text x="92" y="14">45.75%</text>
+    <text x="92" y="15" fill="#010101" fill-opacity=".3">52.32%</text>
+    <text x="92" y="14">52.32%</text>
   </g>
 </svg>

--- a/docs/fallow.svg
+++ b/docs/fallow.svg
@@ -1,21 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20" role="img" aria-label="fallow: B (84)">
-<title>fallow: B (84)</title>
-<linearGradient id="s-2b67fd06" x2="0" y2="100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20" role="img" aria-label="fallow: A (87)">
+<title>fallow: A (87)</title>
+<linearGradient id="s-29b324c4" x2="0" y2="100%">
 <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 <stop offset="1" stop-opacity=".1"/>
 </linearGradient>
-<clipPath id="r-2b67fd06">
+<clipPath id="r-29b324c4">
 <rect width="88" height="20" rx="3" fill="#fff"/>
 </clipPath>
-<g clip-path="url(#r-2b67fd06)">
+<g clip-path="url(#r-29b324c4)">
 <rect width="43" height="20" fill="#555"/>
-<rect x="43" width="45" height="20" fill="#97ca00"/>
-<rect width="88" height="20" fill="url(#s-2b67fd06)"/>
+<rect x="43" width="45" height="20" fill="#4c1"/>
+<rect width="88" height="20" fill="url(#s-29b324c4)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 <text aria-hidden="true" x="220" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">fallow</text>
 <text x="220" y="140" transform="scale(.1)" fill="#fff" textLength="330">fallow</text>
-<text aria-hidden="true" x="640" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="350">B (84)</text>
-<text x="640" y="140" transform="scale(.1)" fill="#fff" textLength="350">B (84)</text>
+<text aria-hidden="true" x="640" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="350">A (87)</text>
+<text x="640" y="140" transform="scale(.1)" fill="#fff" textLength="350">A (87)</text>
 </g>
 </svg>

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-doctor:badge": "node scripts/generate-react-doctor-badge.js",
     "coverage:full": "pnpm test:coverage && pnpm coverage:badge",
     "analyze": "ANALYZE=true pnpm build",
-    "scrape": "npm-run-all --sequential scrape:*",
+    "scrape": "npm-run-all --sequential scrape:* && biome format --write data --vcs-use-ignore-file=true --files-ignore-unknown=true",
     "scrape:pokedex": "jiti scripts/scrape-pokedex.ts && jiti scripts/fetch-pokemon-data.ts",
     "scrape:encounters": "jiti scripts/scrape-wild-encounters.ts",
     "validate:route-articles": "jiti scripts/validate-route-article-coverage.ts",

--- a/scripts/__tests__/scrape-egg-locations.test.ts
+++ b/scripts/__tests__/scrape-egg-locations.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isEggLocationName, isEggRelated } from "../scrape-egg-locations";
+import {
+  getNestLocationName,
+  isEggLocationName,
+  isEggRelated,
+} from "../scrape-egg-locations";
 
 describe("egg gift row classification", () => {
   it.each([
@@ -27,4 +31,27 @@ describe("egg gift row classification", () => {
       expect(isEggLocationName(location)).toBe(false);
     },
   );
+});
+
+describe("nest location links", () => {
+  it.each([
+    ["/wiki/Route_2", "Pikachu nest", false, "Route 2"],
+    ["/wiki/Mt.%20Moon", "", true, "Mt. Moon"],
+  ])(
+    "extracts %s when the parent indicates a nest",
+    (href, parentText, hasNestImage, expected) => {
+      expect(getNestLocationName(href, parentText, hasNestImage)).toBe(
+        expected,
+      );
+    },
+  );
+
+  it.each([
+    ["/wiki/Route_2", "Pokemon list", false],
+    ["/wiki/Pokemon_Nests", "nest", false],
+    ["/wiki/File:Nest.png", "nest", false],
+    ["/not-a-wiki-link/Route_2", "nest", false],
+  ])("rejects unusable nest link: %s", (href, parentText, hasNestImage) => {
+    expect(getNestLocationName(href, parentText, hasNestImage)).toBeNull();
+  });
 });

--- a/scripts/__tests__/scrape-egg-locations.test.ts
+++ b/scripts/__tests__/scrape-egg-locations.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isEggLocationName, isEggRelated } from "../scrape-egg-locations";
+
+describe("egg gift row classification", () => {
+  it.each([
+    ["Togepi", ""],
+    ["Gift Pokemon", "Received as an egg"],
+    ["Trade", "Random egg reward"],
+  ])("recognizes egg-related rows: %s / %s", (pokemonCell, notesCell) => {
+    expect(isEggRelated(pokemonCell, notesCell)).toBe(true);
+  });
+
+  it("rejects rows without an egg marker or listed egg Pokemon", () => {
+    expect(isEggRelated("Bulbasaur", "Gift Pokemon")).toBe(false);
+  });
+
+  it.each(["Route 2", "Cerulean City", "Mt. Moon", "Viridian Forest"])(
+    "accepts valid location names: %s",
+    (location) => {
+      expect(isEggLocationName(location)).toBe(true);
+    },
+  );
+
+  it.each(["Egg", "Pokemon Center", "Togepi", ""])(
+    "rejects non-location names: %s",
+    (location) => {
+      expect(isEggLocationName(location)).toBe(false);
+    },
+  );
+});

--- a/scripts/fetch-pokemon-data.ts
+++ b/scripts/fetch-pokemon-data.ts
@@ -69,8 +69,8 @@ function extractEvolutionData(
   }
 
   function getEvolutionCondition(detail: any): string | undefined {
-    if (detail.held_item_type) {
-      return `Holding ${detail.held_item_type.name}`;
+    if (detail.held_item) {
+      return `Holding ${detail.held_item.name}`;
     }
     if (detail.known_move_type) {
       return `Knows ${detail.known_move_type.name} move`;

--- a/scripts/fetch-pokemon-data.ts
+++ b/scripts/fetch-pokemon-data.ts
@@ -6,6 +6,15 @@ import type * as cliProgress from "cli-progress";
 import Pokedex from "pokedex-promise-v2";
 import type { DexEntry } from "./scrape-pokedex";
 import { ConsoleFormatter } from "./utils/console-utils";
+import {
+  createProcessedPokemonData,
+  type EvolutionData,
+  type EvolutionDetail,
+  type PokemonSpeciesApiData,
+  type ProcessedPokemonData,
+} from "./utils/pokemon-data-utils";
+
+export type { ProcessedPokemonData } from "./utils/pokemon-data-utils";
 
 // Optimized configuration for pokedex-promise-v2
 const P = new Pokedex({
@@ -59,33 +68,43 @@ function extractEvolutionData(
     return null;
   }
 
+  function getEvolutionCondition(detail: any): string | undefined {
+    if (detail.held_item_type) {
+      return `Holding ${detail.held_item_type.name}`;
+    }
+    if (detail.known_move_type) {
+      return `Knows ${detail.known_move_type.name} move`;
+    }
+    if (detail.time_of_day) {
+      return `Time: ${detail.time_of_day}`;
+    }
+    if (detail.min_affection) {
+      return `Affection: ${detail.min_affection}`;
+    }
+    if (detail.min_happiness) {
+      return `Happiness: ${detail.min_happiness}`;
+    }
+    return undefined;
+  }
+
+  function addEvolutionDetails(details: EvolutionDetail, detail: any): void {
+    if (detail.min_level) details.min_level = detail.min_level;
+    if (detail.item) details.item = detail.item.name;
+    if (detail.location) details.location = detail.location.name;
+    if (detail.trigger) details.trigger = detail.trigger.name;
+
+    const condition = getEvolutionCondition(detail);
+    if (condition) details.condition = condition;
+  }
+
   // Helper function to get evolution details
   function getEvolutionDetails(evolution: any): EvolutionDetail {
     const details: EvolutionDetail = {
       id: parseInt(evolution.species.url.split("/").slice(-2)[0], 10),
       name: evolution.species.name,
     };
-
-    if (evolution.evolution_details && evolution.evolution_details.length > 0) {
-      const detail = evolution.evolution_details[0];
-
-      if (detail.min_level) details.min_level = detail.min_level;
-      if (detail.item) details.item = detail.item.name;
-      if (detail.location) details.location = detail.location.name;
-      if (detail.trigger) details.trigger = detail.trigger.name;
-
-      // Handle special conditions
-      if (detail.min_happiness)
-        details.condition = `Happiness: ${detail.min_happiness}`;
-      if (detail.min_affection)
-        details.condition = `Affection: ${detail.min_affection}`;
-      if (detail.time_of_day) details.condition = `Time: ${detail.time_of_day}`;
-      if (detail.known_move_type)
-        details.condition = `Knows ${detail.known_move_type.name} move`;
-      if (detail.held_item_type)
-        details.condition = `Holding ${detail.held_item_type.name}`;
-    }
-
+    const detail = evolution.evolution_details?.[0];
+    if (detail) addEvolutionDetails(details, detail);
     return details;
   }
 
@@ -126,41 +145,20 @@ function extractEvolutionData(
   return evolutionData;
 }
 
-interface PokemonType {
-  name: string;
-}
+async function loadEvolutionData(
+  species: PokemonSpeciesApiData,
+  pokemonName: string,
+): Promise<EvolutionData | undefined> {
+  if (!species.evolution_chain?.url) {
+    return undefined;
+  }
 
-interface PokemonSpeciesData {
-  is_legendary: boolean;
-  is_mythical: boolean;
-  generation: string | null;
-  evolution_chain?: {
-    url: string;
-  };
-}
-
-interface EvolutionDetail {
-  id: number;
-  name: string;
-  trigger?: string;
-  min_level?: number;
-  item?: string;
-  location?: string;
-  condition?: string;
-}
-
-interface EvolutionData {
-  evolves_from?: EvolutionDetail;
-  evolves_to: EvolutionDetail[];
-}
-
-export interface ProcessedPokemonData {
-  id: number;
-  nationalDexId: number;
-  name: string;
-  types: PokemonType[];
-  species: PokemonSpeciesData;
-  evolution?: EvolutionData;
+  const chainId = parseInt(
+    species.evolution_chain.url.split("/").slice(-2)[0],
+    10,
+  );
+  const chainData = await fetchEvolutionChain(chainId);
+  return chainData ? extractEvolutionData(chainData, pokemonName) : undefined;
 }
 
 async function fetchPokemonData(): Promise<ProcessedPokemonData[]> {
@@ -365,34 +363,13 @@ async function processBatch(
         );
       }
 
-      // Fetch evolution data if available
-      let evolutionData: EvolutionData | undefined;
-      if (species.evolution_chain?.url) {
-        const chainId = parseInt(
-          species.evolution_chain.url.split("/").slice(-2)[0],
-          10,
-        );
-        const chainData = await fetchEvolutionChain(chainId);
-        if (chainData) {
-          evolutionData = extractEvolutionData(chainData, pokemon.species.name);
-        }
-      }
-
-      results.push({
-        id: item.entry.id,
-        nationalDexId: pokemon.id,
-        name: item.entry.name, // Keep original name from Infinite Fusion
-        types: pokemon.types.map((type: any) => ({
-          name: type.type.name,
-        })),
-        species: {
-          is_legendary: species.is_legendary,
-          is_mythical: species.is_mythical,
-          generation: species.generation?.name || null,
-          evolution_chain: species.evolution_chain,
-        },
-        evolution: evolutionData,
-      });
+      const evolutionData = await loadEvolutionData(
+        species,
+        pokemon.species.name,
+      );
+      results.push(
+        createProcessedPokemonData(item.entry, pokemon, species, evolutionData),
+      );
     }
 
     return results;
@@ -425,37 +402,16 @@ async function processBatch(
               status: `Fetched ${item.entry.name}`,
             });
 
-            // Fetch evolution data if available
-            let evolutionData: EvolutionData | undefined;
-            if (species.evolution_chain?.url) {
-              const chainId = parseInt(
-                species.evolution_chain.url.split("/").slice(-2)[0],
-                10,
-              );
-              const chainData = await fetchEvolutionChain(chainId);
-              if (chainData) {
-                evolutionData = extractEvolutionData(
-                  chainData,
-                  pokemon.species.name,
-                );
-              }
-            }
-
-            return {
-              id: item.entry.id,
-              nationalDexId: pokemon.id,
-              name: item.entry.name,
-              types: pokemon.types.map((type: any) => ({
-                name: type.type.name,
-              })),
-              species: {
-                is_legendary: species.is_legendary,
-                is_mythical: species.is_mythical,
-                generation: species.generation?.name || null,
-                evolution_chain: species.evolution_chain,
-              },
-              evolution: evolutionData,
-            };
+            const evolutionData = await loadEvolutionData(
+              species,
+              pokemon.species.name,
+            );
+            return createProcessedPokemonData(
+              item.entry,
+              pokemon,
+              species,
+              evolutionData,
+            );
           } catch (_error) {
             batchProgressBar.update(i + chunkIndex + 1, {
               status: `Failed: ${item.entry.name}`,

--- a/scripts/generate-data-pr-body.ts
+++ b/scripts/generate-data-pr-body.ts
@@ -215,7 +215,7 @@ function isLocationPokemonDataRoot(
   return Array.isArray(entry.locations);
 }
 
-function flattenLocationPokemonEntries(
+export function flattenLocationPokemonEntries(
   filePath: string,
   data: unknown,
 ): LocationPokemonEntry[] {
@@ -229,66 +229,91 @@ function flattenLocationPokemonEntries(
   const defaultSource = getSourceFromFilePath(filePath);
 
   for (const item of locationData) {
-    if (isRouteEncounterEntry(item)) {
-      for (const encounter of item.encounters) {
-        if (typeof encounter === "number" && Number.isInteger(encounter)) {
-          entries.push({
-            location: item.routeName,
-            source: defaultSource,
-            pokemonId: encounter,
-          });
-        } else if (
-          typeof encounter === "object" &&
-          typeof encounter.pokemonId === "number" &&
-          Number.isInteger(encounter.pokemonId)
-        ) {
-          entries.push({
-            location: item.routeName,
-            source: encounter.encounterType ?? defaultSource,
-            pokemonId: encounter.pokemonId,
-          });
-        }
-      }
+    if (appendEncounterEntries(entries, item, defaultSource)) {
       continue;
     }
 
-    if (isRoutePokemonIdsEntry(item)) {
-      for (const pokemonId of item.pokemonIds) {
-        if (typeof pokemonId === "number" && Number.isInteger(pokemonId)) {
-          entries.push({
-            location: item.routeName,
-            source: defaultSource,
-            pokemonId,
-          });
-        }
-      }
-    }
-
-    if (
-      typeof item === "object" &&
-      item !== null &&
-      "routeName" in item &&
-      "pokemonId" in item
-    ) {
-      const location = item as Record<string, unknown>;
-      if (
-        typeof location.routeName === "string" &&
-        typeof location.pokemonId === "number" &&
-        Number.isInteger(location.pokemonId)
-      ) {
-        entries.push({
-          location: location.routeName,
-          source:
-            typeof location.source === "string"
-              ? location.source
-              : defaultSource,
-          pokemonId: location.pokemonId,
-        });
-      }
-    }
+    appendPokemonIdEntries(entries, item, defaultSource);
+    appendDirectLocationEntry(entries, item, defaultSource);
   }
 
   return entries;
+}
+
+function appendEncounterEntries(
+  entries: LocationPokemonEntry[],
+  item: unknown,
+  defaultSource: string,
+): boolean {
+  if (!isRouteEncounterEntry(item)) {
+    return false;
+  }
+
+  for (const encounter of item.encounters) {
+    if (typeof encounter === "number" && Number.isInteger(encounter)) {
+      entries.push({
+        location: item.routeName,
+        source: defaultSource,
+        pokemonId: encounter,
+      });
+    } else if (
+      typeof encounter === "object" &&
+      typeof encounter.pokemonId === "number" &&
+      Number.isInteger(encounter.pokemonId)
+    ) {
+      entries.push({
+        location: item.routeName,
+        source: encounter.encounterType ?? defaultSource,
+        pokemonId: encounter.pokemonId,
+      });
+    }
+  }
+
+  return true;
+}
+
+function appendPokemonIdEntries(
+  entries: LocationPokemonEntry[],
+  item: unknown,
+  defaultSource: string,
+): void {
+  if (!isRoutePokemonIdsEntry(item)) {
+    return;
+  }
+
+  for (const pokemonId of item.pokemonIds) {
+    if (typeof pokemonId === "number" && Number.isInteger(pokemonId)) {
+      entries.push({
+        location: item.routeName,
+        source: defaultSource,
+        pokemonId,
+      });
+    }
+  }
+}
+
+function appendDirectLocationEntry(
+  entries: LocationPokemonEntry[],
+  item: unknown,
+  defaultSource: string,
+): void {
+  if (!item || typeof item !== "object") {
+    return;
+  }
+
+  const location = item as Record<string, unknown>;
+  if (
+    typeof location.routeName === "string" &&
+    typeof location.pokemonId === "number" &&
+    Number.isInteger(location.pokemonId)
+  ) {
+    entries.push({
+      location: location.routeName,
+      source:
+        typeof location.source === "string" ? location.source : defaultSource,
+      pokemonId: location.pokemonId,
+    });
+  }
 }
 
 function countEntries(entries: LocationPokemonEntry[]): Map<string, number> {
@@ -534,8 +559,10 @@ async function main(): Promise<void> {
   process.stdout.write(`Generated data PR body: ${outputPath}\n`);
 }
 
-main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : "unknown error";
-  process.stderr.write(`Failed to generate data PR body: ${message}\n`);
-  process.exit(1);
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : "unknown error";
+    process.stderr.write(`Failed to generate data PR body: ${message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/generate-data-pr-body.ts
+++ b/scripts/generate-data-pr-body.ts
@@ -3,6 +3,8 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { z } from "zod";
+import { runDirectScript } from "./utils/script-runtime-utils";
 
 const DEFAULT_OUTPUT_PATH = ".github/data-refresh-pr-body.md";
 const POKEMON_ICON_BASE_URL =
@@ -74,6 +76,14 @@ interface LocationPokemonEntry {
   source: string;
   pokemonId: number;
 }
+
+const EncounterEntrySchema = z.union([
+  z.number().int(),
+  z.object({
+    pokemonId: z.number().int(),
+    encounterType: z.string().optional(),
+  }),
+]);
 
 function runGitCommand(args: string[]): string {
   try {
@@ -250,21 +260,22 @@ function appendEncounterEntries(
   }
 
   for (const encounter of item.encounters) {
-    if (typeof encounter === "number" && Number.isInteger(encounter)) {
+    const parsedEncounter = EncounterEntrySchema.safeParse(encounter);
+    if (parsedEncounter.success === false) {
+      continue;
+    }
+
+    if (typeof parsedEncounter.data === "number") {
       entries.push({
         location: item.routeName,
         source: defaultSource,
-        pokemonId: encounter,
+        pokemonId: parsedEncounter.data,
       });
-    } else if (
-      typeof encounter === "object" &&
-      typeof encounter.pokemonId === "number" &&
-      Number.isInteger(encounter.pokemonId)
-    ) {
+    } else {
       entries.push({
         location: item.routeName,
-        source: encounter.encounterType ?? defaultSource,
-        pokemonId: encounter.pokemonId,
+        source: parsedEncounter.data.encounterType ?? defaultSource,
+        pokemonId: parsedEncounter.data.pokemonId,
       });
     }
   }
@@ -559,10 +570,12 @@ async function main(): Promise<void> {
   process.stdout.write(`Generated data PR body: ${outputPath}\n`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error: unknown) => {
+runDirectScript(import.meta.url, async () => {
+  try {
+    await main();
+  } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "unknown error";
     process.stderr.write(`Failed to generate data PR body: ${message}\n`);
     process.exit(1);
-  });
-}
+  }
+});

--- a/scripts/generate-licenses.ts
+++ b/scripts/generate-licenses.ts
@@ -30,6 +30,7 @@ type LicensePackage = {
   noticeText?: string;
 };
 
+// fallow-ignore-next-line complexity
 async function generateLicenses(): Promise<void> {
   try {
     const { stdout } = await exec("pnpm licenses list --prod --json", {

--- a/scripts/generate-spritesheet.ts
+++ b/scripts/generate-spritesheet.ts
@@ -8,6 +8,7 @@ import {
   normalizePokemonNameForSprite,
   stripPokemonFormSuffix,
 } from "./utils/pokemon-name-utils";
+import { runDirectScript } from "./utils/script-runtime-utils";
 import {
   findFirstOverlappingPair,
   forEachOverlappingPair,
@@ -426,7 +427,7 @@ async function loadSpriteData(
 /**
  * Pack sprites using bin packing algorithm
  */
-function packSprites(sprites: SpriteInfo[]): {
+export function packSprites(sprites: SpriteInfo[]): {
   width: number;
   height: number;
   efficiency: number;
@@ -445,96 +446,11 @@ function packSprites(sprites: SpriteInfo[]): {
     return heightDiff !== 0 ? heightDiff : b.width - a.width;
   });
 
-  // Estimate initial canvas size with more padding to prevent overlaps
-  const totalArea = validSprites.reduce(
-    (sum, s) => sum + s.width * s.height,
-    0,
+  const packedBounds = packWithGrowingCanvas(validSprites);
+  const { width: canvasWidth, height: canvasHeight } = resolvePackedOverlaps(
+    validSprites,
+    packedBounds,
   );
-  const avgAspectRatio =
-    validSprites.reduce((sum, s) => sum + s.width / s.height, 0) /
-    validSprites.length;
-
-  let canvasWidth = Math.ceil(Math.sqrt(totalArea * avgAspectRatio)) + 200; // Increased padding
-  let canvasHeight = Math.ceil(totalArea / canvasWidth) + 200;
-
-  // Try packing with progressively larger canvas sizes
-  let packed = false;
-  let attempts = 0;
-  const maxAttempts = 15; // Increased max attempts
-
-  while (!packed && attempts < maxAttempts) {
-    const packer = new BinPacker(canvasWidth, canvasHeight);
-    let allFit = true;
-
-    // Reset positions
-    validSprites.forEach((sprite) => {
-      sprite.x = 0;
-      sprite.y = 0;
-    });
-
-    // Try to pack all sprites
-    for (const sprite of validSprites) {
-      const rect = packer.pack(sprite.width, sprite.height);
-      if (rect) {
-        sprite.x = rect.x;
-        sprite.y = rect.y;
-      } else {
-        allFit = false;
-        break;
-      }
-    }
-
-    if (allFit) {
-      packed = true;
-
-      // Trim canvas to actual used area
-      ({ width: canvasWidth, height: canvasHeight } =
-        getPackedBounds(validSprites));
-    } else {
-      // Increase canvas size more aggressively and try again
-      canvasWidth = Math.ceil(canvasWidth * 1.3);
-      canvasHeight = Math.ceil(canvasHeight * 1.3);
-      attempts++;
-    }
-  }
-
-  if (!packed) {
-    throw new Error("Failed to pack all sprites after multiple attempts");
-  }
-
-  // Validate that no sprites overlap
-  const hasOverlap = validateNoOverlap(validSprites);
-  if (hasOverlap) {
-    ConsoleFormatter.warn(
-      "Overlap detected in sprite packing, attempting to fix...",
-    );
-
-    // Try to fix overlaps by adding padding
-    const fixed = fixOverlaps(validSprites);
-    if (fixed) {
-      // Recalculate canvas dimensions after fixing
-      ({ width: canvasWidth, height: canvasHeight } =
-        getPackedBounds(validSprites));
-
-      ConsoleFormatter.success("Successfully fixed sprite overlaps");
-    } else {
-      throw new Error("Failed to fix sprite overlaps");
-    }
-  } else {
-    ConsoleFormatter.success("No sprite overlaps detected");
-  }
-
-  // Final validation
-  const finalOverlapCheck = validateNoOverlap(validSprites);
-  if (finalOverlapCheck) {
-    ConsoleFormatter.error(
-      "Final overlap check failed - sprites still overlap",
-    );
-
-    logOverlappingSprites(validSprites);
-
-    throw new Error("Sprite overlaps could not be resolved");
-  }
 
   const usedArea = validSprites.reduce((sum, s) => sum + s.width * s.height, 0);
   const efficiency = (usedArea / (canvasWidth * canvasHeight)) * 100;
@@ -545,6 +461,78 @@ function packSprites(sprites: SpriteInfo[]): {
   ConsoleFormatter.info(`Packing efficiency: ${efficiency.toFixed(1)}%`);
 
   return { width: canvasWidth, height: canvasHeight, efficiency };
+}
+
+function packWithGrowingCanvas(sprites: SpriteInfo[]): {
+  width: number;
+  height: number;
+} {
+  const totalArea = sprites.reduce((sum, s) => sum + s.width * s.height, 0);
+  const avgAspectRatio =
+    sprites.reduce((sum, s) => sum + s.width / s.height, 0) / sprites.length;
+  let width = Math.ceil(Math.sqrt(totalArea * avgAspectRatio)) + 200;
+  let height = Math.ceil(totalArea / width) + 200;
+
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    if (packAllSpritesIntoCanvas(sprites, width, height)) {
+      return getPackedBounds(sprites);
+    }
+    width = Math.ceil(width * 1.3);
+    height = Math.ceil(height * 1.3);
+  }
+
+  throw new Error("Failed to pack all sprites after multiple attempts");
+}
+
+function packAllSpritesIntoCanvas(
+  sprites: SpriteInfo[],
+  width: number,
+  height: number,
+): boolean {
+  const packer = new BinPacker(width, height);
+
+  for (const sprite of sprites) {
+    sprite.x = 0;
+    sprite.y = 0;
+  }
+
+  for (const sprite of sprites) {
+    const rect = packer.pack(sprite.width, sprite.height);
+    if (!rect) {
+      return false;
+    }
+    sprite.x = rect.x;
+    sprite.y = rect.y;
+  }
+
+  return true;
+}
+
+function resolvePackedOverlaps(
+  sprites: SpriteInfo[],
+  bounds: { width: number; height: number },
+): { width: number; height: number } {
+  if (!validateNoOverlap(sprites)) {
+    ConsoleFormatter.success("No sprite overlaps detected");
+    return bounds;
+  }
+
+  ConsoleFormatter.warn(
+    "Overlap detected in sprite packing, attempting to fix...",
+  );
+  if (!fixOverlaps(sprites)) {
+    throw new Error("Failed to fix sprite overlaps");
+  }
+
+  ConsoleFormatter.success("Successfully fixed sprite overlaps");
+  const fixedBounds = getPackedBounds(sprites);
+  if (!validateNoOverlap(sprites)) {
+    return fixedBounds;
+  }
+
+  ConsoleFormatter.error("Final overlap check failed - sprites still overlap");
+  logOverlappingSprites(sprites);
+  throw new Error("Sprite overlaps could not be resolved");
 }
 
 /**
@@ -576,11 +564,10 @@ function logOverlappingSprites(sprites: SpriteInfo[]): void {
 /**
  * Attempt to fix overlaps by adding padding
  */
-function fixOverlaps(sprites: SpriteInfo[]): boolean {
-  let attempts = 0;
-  const maxAttempts = 10; // Increased attempts
+export function fixOverlaps(sprites: SpriteInfo[]): boolean {
+  const maxAttempts = 10;
 
-  while (attempts < maxAttempts) {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     const hasOverlap = forEachOverlappingPair(sprites, (a, b) => {
       const overlapX = Math.max(0, a.x + a.width - b.x);
       const overlapY = Math.max(0, a.y + a.height - b.y);
@@ -591,34 +578,13 @@ function fixOverlaps(sprites: SpriteInfo[]): boolean {
     });
 
     if (!hasOverlap) {
-      ConsoleFormatter.success(`Fixed overlaps in ${attempts + 1} attempts`);
+      ConsoleFormatter.success(`Fixed overlaps in ${attempt + 1} attempts`);
       return true;
     }
 
-    attempts++;
-
-    // If we're taking too long, try a more aggressive approach
-    if (attempts === 5) {
+    if (attempt === 4) {
       ConsoleFormatter.warn("Using aggressive overlap fixing...");
-
-      // Sort sprites by position and ensure minimum spacing
-      sprites.sort((a, b) => {
-        if (a.y !== b.y) return a.y - b.y;
-        return a.x - b.x;
-      });
-
-      for (let i = 1; i < sprites.length; i++) {
-        const prev = sprites[i - 1]!;
-        const curr = sprites[i]!;
-
-        // Ensure minimum spacing between sprites
-        if (curr.x < prev.x + prev.width + 1) {
-          curr.x = prev.x + prev.width + 1;
-        }
-        if (curr.y < prev.y + prev.height + 1) {
-          curr.y = prev.y + prev.height + 1;
-        }
-      }
+      applyAggressiveOverlapSpacing(sprites);
     }
   }
 
@@ -626,6 +592,20 @@ function fixOverlaps(sprites: SpriteInfo[]): boolean {
     `Failed to fix overlaps after ${maxAttempts} attempts`,
   );
   return false;
+}
+
+function applyAggressiveOverlapSpacing(sprites: SpriteInfo[]): void {
+  sprites.sort((a, b) => a.y - b.y || a.x - b.x);
+
+  for (let index = 1; index < sprites.length; index += 1) {
+    const previous = sprites[index - 1];
+    const current = sprites[index];
+    if (!previous || !current) {
+      continue;
+    }
+    current.x = Math.max(current.x, previous.x + previous.width + 1);
+    current.y = Math.max(current.y, previous.y + previous.height + 1);
+  }
 }
 
 /**
@@ -928,5 +908,4 @@ async function generatePokemonSpritesheets(): Promise<void> {
   }
 }
 
-// Run the generator
-generatePokemonSpritesheets();
+runDirectScript(import.meta.url, generatePokemonSpritesheets);

--- a/scripts/generate-spritesheet.ts
+++ b/scripts/generate-spritesheet.ts
@@ -2,7 +2,6 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import sharp from "sharp";
 import { ConsoleFormatter } from "./utils/console-utils";
 import {
@@ -14,22 +13,24 @@ import {
   forEachOverlappingPair,
   getPackedBounds,
 } from "./utils/sprite-packing-utils";
+import {
+  getSpriteSourcePaths,
+  loadJsonFile,
+} from "./utils/sprite-source-utils";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const BASE_ENTRIES_PATH = path.join(
-  __dirname,
+const {
+  scriptDirectory,
+  baseEntriesPath: BASE_ENTRIES_PATH,
+  gen7SpritesDir: GEN7_SPRITES_DIR,
+  gen8SpritesDir: GEN8_SPRITES_DIR,
+} = getSpriteSourcePaths(import.meta.url);
+const SPRITESHEET_OUTPUT_DIR = path.join(
+  scriptDirectory,
   "..",
-  "data",
-  "shared",
-  "base-entries.json",
+  "public",
+  "images",
 );
-const SPRITES_BASE_DIR = path.join(__dirname, "sprites");
-const GEN7_SPRITES_DIR = path.join(SPRITES_BASE_DIR, "pokemon-gen7");
-const GEN8_SPRITES_DIR = path.join(SPRITES_BASE_DIR, "pokemon-gen8");
-const SPRITESHEET_OUTPUT_DIR = path.join(__dirname, "..", "public", "images");
-const METADATA_OUTPUT_DIR = path.join(__dirname, "..", "src", "assets");
+const METADATA_OUTPUT_DIR = path.join(scriptDirectory, "..", "src", "assets");
 
 export type PokemonEntry = {
   id: number;
@@ -316,8 +317,7 @@ async function loadSpriteData(
   const entriesData = await ConsoleFormatter.withSpinner(
     "Loading Pokemon entries...",
     async () => {
-      const data = await fs.readFile(BASE_ENTRIES_PATH, "utf-8");
-      return JSON.parse(data) as PokemonEntry[];
+      return loadJsonFile<PokemonEntry[]>(BASE_ENTRIES_PATH);
     },
   );
 

--- a/scripts/generate-spritesheet.ts
+++ b/scripts/generate-spritesheet.ts
@@ -15,6 +15,7 @@ import {
   getPackedBounds,
 } from "./utils/sprite-packing-utils";
 import {
+  BasePokemonEntrySchema,
   getSpriteSourcePaths,
   loadJsonFile,
 } from "./utils/sprite-source-utils";
@@ -318,7 +319,7 @@ async function loadSpriteData(
   const entriesData = await ConsoleFormatter.withSpinner(
     "Loading Pokemon entries...",
     async () => {
-      return loadJsonFile<PokemonEntry[]>(BASE_ENTRIES_PATH);
+      return loadJsonFile(BASE_ENTRIES_PATH, BasePokemonEntrySchema.array());
     },
   );
 

--- a/scripts/generate-spritesheet.ts
+++ b/scripts/generate-spritesheet.ts
@@ -9,6 +9,11 @@ import {
   normalizePokemonNameForSprite,
   stripPokemonFormSuffix,
 } from "./utils/pokemon-name-utils";
+import {
+  findFirstOverlappingPair,
+  forEachOverlappingPair,
+  getPackedBounds,
+} from "./utils/sprite-packing-utils";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -483,11 +488,8 @@ function packSprites(sprites: SpriteInfo[]): {
       packed = true;
 
       // Trim canvas to actual used area
-      const maxX = Math.max(...validSprites.map((s) => s.x + s.width));
-      const maxY = Math.max(...validSprites.map((s) => s.y + s.height));
-
-      canvasWidth = maxX;
-      canvasHeight = maxY;
+      ({ width: canvasWidth, height: canvasHeight } =
+        getPackedBounds(validSprites));
     } else {
       // Increase canvas size more aggressively and try again
       canvasWidth = Math.ceil(canvasWidth * 1.3);
@@ -511,10 +513,8 @@ function packSprites(sprites: SpriteInfo[]): {
     const fixed = fixOverlaps(validSprites);
     if (fixed) {
       // Recalculate canvas dimensions after fixing
-      const maxX = Math.max(...validSprites.map((s) => s.x + s.width));
-      const maxY = Math.max(...validSprites.map((s) => s.y + s.height));
-      canvasWidth = maxX;
-      canvasHeight = maxY;
+      ({ width: canvasWidth, height: canvasHeight } =
+        getPackedBounds(validSprites));
 
       ConsoleFormatter.success("Successfully fixed sprite overlaps");
     } else {
@@ -531,24 +531,7 @@ function packSprites(sprites: SpriteInfo[]): {
       "Final overlap check failed - sprites still overlap",
     );
 
-    // Log problematic sprites for debugging
-    for (let i = 0; i < validSprites.length; i++) {
-      for (let j = i + 1; j < validSprites.length; j++) {
-        const a = validSprites[i]!;
-        const b = validSprites[j]!;
-
-        if (
-          a.x < b.x + b.width &&
-          a.x + a.width > b.x &&
-          a.y < b.y + b.height &&
-          a.y + a.height > b.y
-        ) {
-          ConsoleFormatter.error(
-            `Overlap: ${a.name} (${a.x},${a.y},${a.width}x${a.height}) with ${b.name} (${b.x},${b.y},${b.width}x${b.height})`,
-          );
-        }
-      }
-    }
+    logOverlappingSprites(validSprites);
 
     throw new Error("Sprite overlaps could not be resolved");
   }
@@ -568,38 +551,26 @@ function packSprites(sprites: SpriteInfo[]): {
  * Check if any sprites overlap
  */
 function validateNoOverlap(sprites: SpriteInfo[]): boolean {
-  for (let i = 0; i < sprites.length; i++) {
-    for (let j = i + 1; j < sprites.length; j++) {
-      const a = sprites[i]!;
-      const b = sprites[j]!;
+  const overlap = findFirstOverlappingPair(sprites);
+  if (!overlap) return false;
 
-      // Check for any overlap using precise mathematical bounds
-      // Two rectangles overlap if and only if:
-      // a.x < b.x + b.width AND a.x + a.width > b.x AND
-      // a.y < b.y + b.height AND a.y + a.height > b.y
-      if (
-        a.x < b.x + b.width &&
-        a.x + a.width > b.x &&
-        a.y < b.y + b.height &&
-        a.y + a.height > b.y
-      ) {
-        ConsoleFormatter.error(
-          `Overlap detected between ${a.name} and ${b.name}`,
-        );
-        ConsoleFormatter.error(
-          `  ${a.name}: (${a.x},${a.y}) ${a.width}x${a.height}`,
-        );
-        ConsoleFormatter.error(
-          `  ${b.name}: (${b.x},${b.y}) ${b.width}x${b.height}`,
-        );
-        ConsoleFormatter.error(
-          `  Overlap area: ${Math.max(0, Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x))} x ${Math.max(0, Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y))}`,
-        );
-        return true;
-      }
-    }
-  }
-  return false;
+  const [a, b] = overlap;
+  ConsoleFormatter.error(`Overlap detected between ${a.name} and ${b.name}`);
+  ConsoleFormatter.error(`  ${a.name}: (${a.x},${a.y}) ${a.width}x${a.height}`);
+  ConsoleFormatter.error(`  ${b.name}: (${b.x},${b.y}) ${b.width}x${b.height}`);
+  ConsoleFormatter.error(
+    `  Overlap area: ${Math.max(0, Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x))} x ${Math.max(0, Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y))}`,
+  );
+  return true;
+}
+
+function logOverlappingSprites(sprites: SpriteInfo[]): void {
+  forEachOverlappingPair(sprites, (a, b) => {
+    ConsoleFormatter.error(
+      `Overlap: ${a.name} (${a.x},${a.y},${a.width}x${a.height}) with ${b.name} (${b.x},${b.y},${b.width}x${b.height})`,
+    );
+    return false;
+  });
 }
 
 /**
@@ -610,35 +581,14 @@ function fixOverlaps(sprites: SpriteInfo[]): boolean {
   const maxAttempts = 10; // Increased attempts
 
   while (attempts < maxAttempts) {
-    let hasOverlap = false;
+    const hasOverlap = forEachOverlappingPair(sprites, (a, b) => {
+      const overlapX = Math.max(0, a.x + a.width - b.x);
+      const overlapY = Math.max(0, a.y + a.height - b.y);
 
-    for (let i = 0; i < sprites.length; i++) {
-      for (let j = i + 1; j < sprites.length; j++) {
-        const a = sprites[i]!;
-        const b = sprites[j]!;
-
-        if (
-          a.x < b.x + b.width &&
-          a.x + a.width > b.x &&
-          a.y < b.y + b.height &&
-          a.y + a.height > b.y
-        ) {
-          // Calculate overlap amounts
-          const overlapX = Math.max(0, a.x + a.width - b.x);
-          const overlapY = Math.max(0, a.y + a.height - b.y);
-
-          // Move sprite b to avoid overlap with some extra padding
-          if (overlapX > 0) {
-            b.x += overlapX + 1; // Add 1px padding
-          }
-          if (overlapY > 0) {
-            b.y += overlapY + 1; // Add 1px padding
-          }
-
-          hasOverlap = true;
-        }
-      }
-    }
+      if (overlapX > 0) b.x += overlapX + 1;
+      if (overlapY > 0) b.y += overlapY + 1;
+      return false;
+    });
 
     if (!hasOverlap) {
       ConsoleFormatter.success(`Fixed overlaps in ${attempts + 1} attempts`);

--- a/scripts/scrape-egg-locations.ts
+++ b/scripts/scrape-egg-locations.ts
@@ -5,6 +5,10 @@ import * as path from "node:path";
 import * as cheerio from "cheerio";
 import { ConsoleFormatter } from "./utils/console-utils";
 import { cleanLocationName } from "./utils/location-utils";
+import {
+  exitOnScriptError,
+  runDirectScript,
+} from "./utils/script-runtime-utils";
 import { fetchWikiPageHtml } from "./utils/wiki-fetch-utils";
 
 const GIFTS_AND_TRADES_URL =
@@ -558,14 +562,8 @@ async function main() {
       },
     ]);
   } catch (error) {
-    ConsoleFormatter.error(
-      `Fatal error: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
-    process.exit(1);
+    exitOnScriptError("Fatal error", error);
   }
 }
 
-// Check if this script is being run directly
-if (process.argv[1]?.endsWith("scrape-egg-locations.ts")) {
-  main();
-}
+runDirectScript(import.meta.url, main);

--- a/scripts/scrape-egg-locations.ts
+++ b/scripts/scrape-egg-locations.ts
@@ -26,6 +26,62 @@ interface EggLocation {
   pokemonId?: number;
 }
 
+const EGG_KEYWORDS = ["egg", "as egg", "daycare egg", "random egg"] as const;
+
+const EGG_POKEMON_NAMES = [
+  "togepi",
+  "azurill",
+  "pichu",
+  "cleffa",
+  "igglybuff",
+  "bonsly",
+  "mantyke",
+  "happiny",
+  "elekid",
+  "magby",
+  "smoochum",
+  "ralts",
+  "pawniard",
+  "bagon",
+] as const;
+
+const LOCATION_KEYWORDS = [
+  "route",
+  "city",
+  "town",
+  "island",
+  "park",
+  "daycare",
+  "mt.",
+  "mountain",
+  "cave",
+  "forest",
+] as const;
+
+/** Returns whether a gift/trade row describes an egg encounter. */
+export function isEggRelated(pokemonCell: string, notesCell: string): boolean {
+  const pokemonText = pokemonCell.toLowerCase();
+  const notesText = notesCell.toLowerCase();
+
+  return (
+    EGG_KEYWORDS.some(
+      (keyword) => pokemonText.includes(keyword) || notesText.includes(keyword),
+    ) || EGG_POKEMON_NAMES.some((name) => pokemonText.includes(name))
+  );
+}
+
+/** Returns whether a cleaned row value is a usable egg-location name. */
+export function isEggLocationName(location: string): boolean {
+  const normalizedLocation = location.toLowerCase();
+
+  return (
+    location.length > 2 &&
+    !normalizedLocation.includes("pokemon") &&
+    !normalizedLocation.includes("egg") &&
+    LOCATION_KEYWORDS.some((keyword) => normalizedLocation.includes(keyword))
+  );
+}
+
 /**
  * Loads Pokemon data for name-to-ID mapping
  */
@@ -152,52 +208,10 @@ async function scrapeGiftsAndTradesForEggs(
         const locationCell = cells.eq(1).text().trim();
         const notesCell = cells.length > 3 ? cells.eq(3).text().trim() : "";
 
-        // Look for egg-related entries with more comprehensive detection
-        const isEggRelated =
-          pokemonCell.toLowerCase().includes("egg") ||
-          notesCell.toLowerCase().includes("egg") ||
-          pokemonCell.toLowerCase().includes("as egg") ||
-          notesCell.toLowerCase().includes("as egg") ||
-          pokemonCell.toLowerCase().includes("daycare egg") ||
-          notesCell.toLowerCase().includes("daycare egg") ||
-          pokemonCell.toLowerCase().includes("random egg") ||
-          notesCell.toLowerCase().includes("random egg") ||
-          // Look for specific egg Pokémon
-          pokemonCell.toLowerCase().includes("togepi") ||
-          pokemonCell.toLowerCase().includes("azurill") ||
-          pokemonCell.toLowerCase().includes("pichu") ||
-          pokemonCell.toLowerCase().includes("cleffa") ||
-          pokemonCell.toLowerCase().includes("igglybuff") ||
-          pokemonCell.toLowerCase().includes("bonsly") ||
-          pokemonCell.toLowerCase().includes("mantyke") ||
-          pokemonCell.toLowerCase().includes("happiny") ||
-          pokemonCell.toLowerCase().includes("elekid") ||
-          pokemonCell.toLowerCase().includes("magby") ||
-          pokemonCell.toLowerCase().includes("smoochum") ||
-          pokemonCell.toLowerCase().includes("ralts") ||
-          pokemonCell.toLowerCase().includes("pawniard") ||
-          pokemonCell.toLowerCase().includes("bagon");
-
-        if (isEggRelated) {
+        if (isEggRelated(pokemonCell, notesCell)) {
           const cleanedLocation = cleanLocationName(locationCell);
           // Validate that this is actually a location name, not a Pokémon name
-          if (
-            cleanedLocation &&
-            cleanedLocation.length > 2 &&
-            !cleanedLocation.toLowerCase().includes("pokemon") &&
-            !cleanedLocation.toLowerCase().includes("egg") &&
-            // Check if it looks like a location (contains route, city, town, etc.)
-            (cleanedLocation.toLowerCase().includes("route") ||
-              cleanedLocation.toLowerCase().includes("city") ||
-              cleanedLocation.toLowerCase().includes("town") ||
-              cleanedLocation.toLowerCase().includes("island") ||
-              cleanedLocation.toLowerCase().includes("park") ||
-              cleanedLocation.toLowerCase().includes("daycare") ||
-              cleanedLocation.toLowerCase().includes("mt.") ||
-              cleanedLocation.toLowerCase().includes("mountain") ||
-              cleanedLocation.toLowerCase().includes("cave") ||
-              cleanedLocation.toLowerCase().includes("forest"))
-          ) {
+          if (cleanedLocation && isEggLocationName(cleanedLocation)) {
             // Extract Pokemon name and get its data
             const extractedPokemonName = extractPokemonName(pokemonCell);
             const pokemonData = extractedPokemonName

--- a/scripts/scrape-egg-locations.ts
+++ b/scripts/scrape-egg-locations.ts
@@ -82,6 +82,43 @@ export function isEggLocationName(location: string): boolean {
   );
 }
 
+/** Returns the nest location encoded by a nearby wiki link, when usable. */
+export function getNestLocationName(
+  href: string,
+  parentText: string,
+  hasNestImage: boolean,
+): string | null {
+  if (
+    !href.includes("/wiki/") ||
+    (!parentText.toLowerCase().includes("nest") && !hasNestImage)
+  ) {
+    return null;
+  }
+
+  const urlMatch = href.match(/\/wiki\/([^/]+)/);
+  if (!urlMatch) {
+    return null;
+  }
+
+  const routeName = decodeURIComponent(urlMatch[1])
+    .replace(/_/g, " ")
+    .replace(/%20/g, " ")
+    .trim();
+  const normalizedRouteName = routeName.toLowerCase();
+
+  if (
+    routeName.length <= 2 ||
+    normalizedRouteName.includes("pokemon") ||
+    normalizedRouteName.includes("nest") ||
+    normalizedRouteName.includes("egg") ||
+    normalizedRouteName.includes("file:")
+  ) {
+    return null;
+  }
+
+  return routeName;
+}
+
 /**
  * Loads Pokemon data for name-to-ID mapping
  */
@@ -307,35 +344,12 @@ async function scrapePokemonNestsForEggs(
 
       // Check if this link is near a nest image or nest text
       const $parent = $link.parent();
-      const parentText = $parent.text().toLowerCase();
+      const parentText = $parent.text();
       const hasNestImage = $parent.find('img[alt*="nest"]').length > 0;
 
-      // Look for location links that are near nest content
-      if (
-        href.includes("/wiki/") &&
-        (parentText.includes("nest") || hasNestImage)
-      ) {
-        // Extract the page name from the URL
-        const urlMatch = href.match(/\/wiki\/([^/]+)/);
-        if (urlMatch) {
-          const pageName = decodeURIComponent(urlMatch[1]);
-          const routeName = pageName
-            .replace(/_/g, " ")
-            .replace(/%20/g, " ")
-            .trim();
-
-          // Validate the route name
-          if (
-            routeName &&
-            routeName.length > 2 &&
-            !routeName.toLowerCase().includes("pokemon") &&
-            !routeName.toLowerCase().includes("nest") &&
-            !routeName.toLowerCase().includes("egg") &&
-            !routeName.toLowerCase().includes("file:")
-          ) {
-            locationSet.add(routeName);
-          }
-        }
+      const routeName = getNestLocationName(href, parentText, hasNestImage);
+      if (routeName) {
+        locationSet.add(routeName);
       }
     });
 

--- a/scripts/scrape-egg-locations.ts
+++ b/scripts/scrape-egg-locations.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as cheerio from "cheerio";
 import { ConsoleFormatter } from "./utils/console-utils";
+import { cleanLocationName } from "./utils/location-utils";
 import { fetchWikiPageHtml } from "./utils/wiki-fetch-utils";
 
 const GIFTS_AND_TRADES_URL =
@@ -23,26 +24,6 @@ interface EggLocation {
   description: string;
   pokemonName?: string;
   pokemonId?: number;
-}
-
-/**
- * Cleans location names to match the standard format
- */
-function cleanLocationName(location: string): string {
-  return (
-    location
-      // Remove wiki links
-      .replace(/\[\[([^\]]+)\]\]/g, "$1")
-      .replace(/\[\[([^\]]+)\|([^\]]+)\]\]/g, "$2")
-      // Remove extra context in parentheses
-      .replace(/\s*\([^)]*\)/g, "")
-      // Standardize Pokémon -> Pokemon
-      .replace(/Pokémon/g, "Pokemon")
-      // Standardize S.S. Anne
-      .replace(/S\.S\.\s*Anne/g, "S.S. Anne")
-      // Remove extra whitespace
-      .trim()
-  );
 }
 
 /**

--- a/scripts/scrape-legendary-encounters.ts
+++ b/scripts/scrape-legendary-encounters.ts
@@ -51,11 +51,18 @@ function addLegendaryHeadingEncounters(
 ): void {
   const $heading = $(heading);
   const pokemonName = $heading.find("span.mw-headline").text().trim();
-  if (!isPotentialPokemonName(pokemonName)) {
+  const pokemonNames = pokemonName
+    .split("/")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (
+    pokemonNames.length === 0 ||
+    pokemonNames.some((name) => !isPotentialPokemonName(name))
+  ) {
     return;
   }
 
-  for (const name of pokemonName.split("/").map((part) => part.trim())) {
+  for (const name of pokemonNames) {
     const pokemonIds = getLegendaryPokemonIds(name, pokemonNameMap);
     if (pokemonIds.length === 0) {
       ConsoleFormatter.warn(`Could not find any forms for legendary: ${name}`);

--- a/scripts/scrape-legendary-encounters.ts
+++ b/scripts/scrape-legendary-encounters.ts
@@ -10,6 +10,10 @@ import {
   isPotentialPokemonName,
 } from "./utils/pokemon-name-utils";
 import { processRouteName } from "./utils/route-utils";
+import {
+  exitOnScriptError,
+  runDirectScript,
+} from "./utils/script-runtime-utils";
 import { fetchWikiPageHtml } from "./utils/wiki-fetch-utils";
 
 const LEGENDARY_POKEMON_URL =
@@ -204,14 +208,8 @@ async function main() {
     );
     ConsoleFormatter.info(`Total duration: ${(duration / 1000).toFixed(2)}s`);
   } catch (error) {
-    ConsoleFormatter.error(
-      `Legendary scraping failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
-    process.exit(1);
+    exitOnScriptError("Legendary scraping failed", error);
   }
 }
 
-// Run the script
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
-}
+runDirectScript(import.meta.url, main);

--- a/scripts/scrape-legendary-encounters.ts
+++ b/scripts/scrape-legendary-encounters.ts
@@ -8,6 +8,7 @@ import { loadPokemonNameMap } from "./utils/data-loading-utils";
 import {
   findPokemonId,
   isPotentialPokemonName,
+  type PokemonNameMap,
 } from "./utils/pokemon-name-utils";
 import { processRouteName } from "./utils/route-utils";
 import {
@@ -24,6 +25,119 @@ interface LegendaryRoute {
   encounters: number[]; // Array of Pokémon IDs
 }
 
+type CheerioInput = Parameters<ReturnType<typeof cheerio.load>>[0];
+
+export function collectLegendaryRouteMapFromHtml(
+  html: string,
+  pokemonNameMap: PokemonNameMap,
+): Map<string, number[]> {
+  const $ = cheerio.load(html);
+  const routeMap = new Map<string, number[]>();
+  const headings = $(".mw-parser-output").find("h3");
+
+  ConsoleFormatter.info(`Found ${headings.length} h3 headings`);
+  headings.each((_index, heading) => {
+    addLegendaryHeadingEncounters($, heading, pokemonNameMap, routeMap);
+  });
+
+  return routeMap;
+}
+
+function addLegendaryHeadingEncounters(
+  $: ReturnType<typeof cheerio.load>,
+  heading: CheerioInput,
+  pokemonNameMap: PokemonNameMap,
+  routeMap: Map<string, number[]>,
+): void {
+  const $heading = $(heading);
+  const pokemonName = $heading.find("span.mw-headline").text().trim();
+  if (!isPotentialPokemonName(pokemonName)) {
+    return;
+  }
+
+  for (const name of pokemonName.split("/").map((part) => part.trim())) {
+    const pokemonIds = getLegendaryPokemonIds(name, pokemonNameMap);
+    if (pokemonIds.length === 0) {
+      ConsoleFormatter.warn(`Could not find any forms for legendary: ${name}`);
+      continue;
+    }
+
+    const routeName = findLegendaryRouteName($heading);
+    if (routeName) {
+      addLegendaryIdsToRoute(routeMap, routeName, pokemonIds);
+      ConsoleFormatter.success(
+        `Added ${pokemonIds.length} forms of ${name} to route: ${routeName}`,
+      );
+    }
+  }
+}
+
+function getLegendaryPokemonIds(
+  name: string,
+  pokemonNameMap: PokemonNameMap,
+): number[] {
+  const pokemonIds: number[] = [];
+  const exactMatch = findPokemonId(name, pokemonNameMap);
+  if (exactMatch) {
+    pokemonIds.push(exactMatch);
+  }
+
+  for (const [pokemonName, id] of pokemonNameMap.nameToId.entries()) {
+    if (pokemonName.startsWith(`${name} `) && pokemonName !== name) {
+      pokemonIds.push(id);
+    }
+  }
+
+  return pokemonIds;
+}
+
+function findLegendaryRouteName(
+  $heading: ReturnType<ReturnType<typeof cheerio.load>>,
+): string {
+  let nextElement = $heading.next();
+
+  for (
+    let siblingsChecked = 0;
+    nextElement.length > 0 && siblingsChecked < 10;
+    siblingsChecked += 1, nextElement = nextElement.next()
+  ) {
+    if (nextElement.is("table.article-table")) {
+      return getRouteNameFromLegendaryTable(nextElement);
+    }
+    if (nextElement.is("h3")) {
+      return "";
+    }
+  }
+
+  return "";
+}
+
+function getRouteNameFromLegendaryTable(
+  $table: ReturnType<ReturnType<typeof cheerio.load>>,
+): string {
+  const $cell = $table.find("tr").first().find("td").first();
+  if ($cell.length === 0) {
+    return "";
+  }
+
+  const anchors = $cell.find("a");
+  const rawRouteName =
+    anchors.length > 0 ? anchors.last().text().trim() : $cell.text().trim();
+  const { cleanName } = processRouteName(rawRouteName);
+
+  return cleanName === "Location" ? "" : cleanName;
+}
+
+function addLegendaryIdsToRoute(
+  routeMap: Map<string, number[]>,
+  routeName: string,
+  pokemonIds: number[],
+): void {
+  const encounters = routeMap.get(routeName) ?? [];
+  encounters.push(...pokemonIds);
+  routeMap.set(routeName, encounters);
+}
+
 async function scrapeLegendaryEncounters(): Promise<LegendaryRoute[]> {
   ConsoleFormatter.printHeader(
     "Scraping Legendary Pokémon",
@@ -37,128 +151,8 @@ async function scrapeLegendaryEncounters(): Promise<LegendaryRoute[]> {
       () => fetchWikiPageHtml(LEGENDARY_POKEMON_URL),
     );
 
-    const $ = cheerio.load(html);
     const pokemonNameMap = await loadPokemonNameMap();
-
-    // Focus on main content area
-    const mainContent = $(".mw-parser-output");
-    const routeMap = new Map<string, number[]>(); // routeName -> array of pokemon IDs
-
-    // Find all h3 headings with mw-headline spans (legendary names)
-    const headings = mainContent.find("h3");
-
-    ConsoleFormatter.info(`Found ${headings.length} h3 headings`);
-
-    headings.each((_index: number, heading: any) => {
-      const $heading = $(heading);
-      const headlineSpan = $heading.find("span.mw-headline");
-
-      if (headlineSpan.length === 0) {
-        return; // Skip if no mw-headline span
-      }
-
-      const pokemonName = headlineSpan.text().trim();
-
-      // Skip if it's not a Pokémon name
-      if (!isPotentialPokemonName(pokemonName)) {
-        return;
-      }
-
-      // Handle multiple Pokémon names separated by " / "
-      const pokemonNames = pokemonName.split("/").map((name) => name.trim());
-
-      for (const name of pokemonNames) {
-        // Try to find all forms of this Pokémon
-        const pokemonIds: number[] = [];
-
-        // Look for exact match first
-        const exactMatch = findPokemonId(name, pokemonNameMap);
-        if (exactMatch) {
-          pokemonIds.push(exactMatch);
-        }
-
-        // Also look for entries that start with the name (for forms)
-        for (const [pokemonName, id] of pokemonNameMap.nameToId.entries()) {
-          if (pokemonName.startsWith(`${name} `) && pokemonName !== name) {
-            pokemonIds.push(id);
-          }
-        }
-
-        if (pokemonIds.length === 0) {
-          ConsoleFormatter.warn(
-            `Could not find any forms for legendary: ${name}`,
-          );
-          continue;
-        }
-
-        let nextElement = $heading.next();
-        let tablesChecked = 0;
-
-        while (nextElement.length > 0 && tablesChecked < 10) {
-          if (nextElement.is("table.article-table")) {
-            // Process the table - extract route name from first row
-            let routeName = "";
-
-            $(nextElement)
-              .find("tr")
-              .each((rowIndex: number, row: any) => {
-                const $row = $(row);
-                const cells = $row.find("td");
-
-                // Get the route name from the first row, first cell
-                if (rowIndex === 0 && cells.length >= 1) {
-                  const $cell = $(cells[0]);
-                  const anchors = $cell.find("a");
-                  let rawRouteName = "";
-
-                  if (anchors.length > 0) {
-                    // Use the text from the last anchor tag
-                    rawRouteName = anchors.last().text().trim();
-                  } else {
-                    // Fallback to cell text if no anchors found
-                    rawRouteName = $cell.text().trim();
-                  }
-
-                  const { cleanName } = processRouteName(rawRouteName);
-                  routeName = cleanName;
-                }
-              });
-
-            // If we have a valid route name, add all pokemon forms to that route
-            if (routeName && routeName !== "Location" && routeName !== "") {
-              if (!routeMap.has(routeName)) {
-                routeMap.set(routeName, []);
-              }
-
-              const routeEncounters = routeMap.get(routeName);
-              if (routeEncounters === undefined) {
-                throw new Error(
-                  `Failed to initialize route encounters for ${routeName}`,
-                );
-              }
-
-              // Add all forms of this pokemon
-              for (const id of pokemonIds) {
-                routeEncounters.push(id);
-              }
-              ConsoleFormatter.success(
-                `Added ${pokemonIds.length} forms of ${name} to route: ${routeName}`,
-              );
-            }
-
-            break; // Found and processed one table, stop looking
-          }
-
-          // Stop if we hit another h3 heading
-          if (nextElement.is("h3")) {
-            break;
-          }
-
-          tablesChecked++;
-          nextElement = nextElement.next();
-        }
-      }
-    });
+    const routeMap = collectLegendaryRouteMapFromHtml(html, pokemonNameMap);
 
     // Convert map to array format
     const routes: LegendaryRoute[] = Array.from(routeMap.entries()).map(

--- a/scripts/scrape-pokemon-icons.ts
+++ b/scripts/scrape-pokemon-icons.ts
@@ -3,10 +3,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ConsoleFormatter } from "./utils/console-utils";
+import { normalizePokemonNameForSprite } from "./utils/pokemon-name-utils";
 import {
-  normalizePokemonNameForSprite,
-  stripPokemonFormSuffix,
-} from "./utils/pokemon-name-utils";
+  downloadSpriteImage,
+  type SpriteDownloadConfig,
+  type SpriteDownloadIcon,
+  spriteFileExists,
+} from "./utils/sprite-download-utils";
 import {
   getSpriteSourcePaths,
   loadJsonFile,
@@ -30,20 +33,8 @@ export type PokemonEntry = {
   name: string;
 };
 
-export type PokemonIcon = {
-  id: number;
-  name: string;
-  url: string;
-  filename: string;
-  generation: "gen7" | "gen8";
-};
-
-export type GenerationConfig = {
-  name: "gen7" | "gen8";
-  baseUrl: string;
-  spritesDir: string;
-  eggSpriteUrl: string;
-};
+export type PokemonIcon = SpriteDownloadIcon;
+export type GenerationConfig = SpriteDownloadConfig;
 
 const GENERATIONS: GenerationConfig[] = [
   {
@@ -61,121 +52,54 @@ const GENERATIONS: GenerationConfig[] = [
   },
 ];
 
+type DownloadStats = {
+  downloaded: number;
+  skipped: number;
+  errors: number;
+};
+
+function getGenerationConfig(
+  generation: PokemonIcon["generation"],
+): GenerationConfig {
+  const config = GENERATIONS.find((item) => item.name === generation);
+  if (!config)
+    throw new Error(`Missing sprite configuration for ${generation}`);
+  return config;
+}
+
+async function downloadIconBatch(icons: PokemonIcon[]): Promise<DownloadStats> {
+  const results = await Promise.all(
+    icons.map(async (icon) => {
+      const config = getGenerationConfig(icon.generation);
+      const filePath = path.join(config.spritesDir, icon.filename);
+      const skipped = await spriteFileExists(filePath);
+      const success = await downloadSpriteImage(
+        icon,
+        config,
+        ConsoleFormatter.error,
+      );
+      return { skipped, success };
+    }),
+  );
+
+  return results.reduce<DownloadStats>(
+    (stats, { skipped, success }) => {
+      if (success === false) {
+        stats.errors++;
+      } else if (skipped) {
+        stats.skipped++;
+      } else {
+        stats.downloaded++;
+      }
+      return stats;
+    },
+    { downloaded: 0, skipped: 0, errors: 0 },
+  );
+}
+
 /**
  * Check if a file already exists
  */
-async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    await fs.access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Download a single image with retry logic and fallback to base name
- */
-async function downloadImage(
-  icon: PokemonIcon,
-  config: GenerationConfig,
-  retries = 3,
-): Promise<boolean> {
-  const filePath = path.join(config.spritesDir, icon.filename);
-
-  // Check if file already exists
-  if (await fileExists(filePath)) {
-    return true; // Skip download, file already exists
-  }
-
-  // Special handling for egg sprite (ID -1)
-  if (icon.id === -1) {
-    try {
-      const response = await fetch(config.eggSpriteUrl, {
-        headers: {
-          "User-Agent": "Infinite-Fusion-Scraper/1.0",
-        },
-      });
-
-      if (!response.ok) {
-        ConsoleFormatter.error(
-          `Failed to download ${config.name} egg sprite: HTTP ${response.status}`,
-        );
-        return false;
-      }
-
-      const buffer = await response.arrayBuffer();
-      await fs.writeFile(filePath, Buffer.from(buffer));
-      return true;
-    } catch (error) {
-      ConsoleFormatter.error(
-        `Failed to download ${config.name} egg sprite: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
-      return false;
-    }
-  }
-
-  // Try the full form name first
-  for (let attempt = 1; attempt <= retries; attempt++) {
-    try {
-      const response = await fetch(icon.url, {
-        headers: {
-          "User-Agent": "Infinite-Fusion-Scraper/1.0",
-        },
-      });
-
-      if (!response.ok) {
-        // If it's a 404 and this is the first attempt, try fallback to base name
-        if (response.status === 404 && attempt === 1) {
-          const baseName = stripPokemonFormSuffix(icon.name);
-          if (baseName && baseName !== icon.name) {
-            const baseUrlName = normalizePokemonNameForSprite(baseName);
-            const baseFilename = `${baseUrlName}.png`;
-            const baseUrl = `${config.baseUrl}/${baseFilename}`;
-            const baseFilePath = path.join(config.spritesDir, baseFilename);
-
-            // Try to download the base form
-            try {
-              const baseResponse = await fetch(baseUrl, {
-                headers: {
-                  "User-Agent": "Infinite-Fusion-Scraper/1.0",
-                },
-              });
-
-              if (baseResponse.ok) {
-                const baseBuffer = await baseResponse.arrayBuffer();
-                await fs.writeFile(baseFilePath, Buffer.from(baseBuffer));
-                return true;
-              }
-            } catch {
-              // Continue to retry with original name
-            }
-          }
-        }
-
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      const buffer = await response.arrayBuffer();
-      await fs.writeFile(filePath, Buffer.from(buffer));
-      return true;
-    } catch (error) {
-      if (attempt === retries) {
-        ConsoleFormatter.error(
-          `Failed to download ${icon.name} (${config.name}) after ${retries} attempts: ${
-            error instanceof Error ? error.message : "Unknown error"
-          }`,
-        );
-        return false;
-      }
-
-      // Wait before retry with exponential backoff (shorter delays)
-      await new Promise((resolve) => setTimeout(resolve, 2 ** attempt * 200));
-    }
-  }
-  return false;
-}
-
 /**
  * Load Pokemon data and construct icon URLs for both generations
  */
@@ -256,9 +180,7 @@ async function downloadAllIcons(
     `Gen 7 icons: ${gen7Icons.length}, Gen 8 icons: ${gen8Icons.length}`,
   );
 
-  let downloadedCount = 0;
-  let skippedCount = 0;
-  let errorCount = 0;
+  const stats: DownloadStats = { downloaded: 0, skipped: 0, errors: 0 };
 
   const batchSize = 10; // Smaller batch size to be more respectful to the server
   const progressBar = ConsoleFormatter.createProgressBar(icons.length);
@@ -268,30 +190,13 @@ async function downloadAllIcons(
   for (let i = 0; i < gen7Icons.length; i += batchSize) {
     const batch = gen7Icons.slice(i, i + batchSize);
 
-    const results = await Promise.all(
-      batch.map(async (icon) => {
-        const config = GENERATIONS.find((g) => g.name === icon.generation)!;
-        const filePath = path.join(config.spritesDir, icon.filename);
-        const existed = await fileExists(filePath);
-        const success = await downloadImage(icon, config);
-        return { icon, success, wasSkipped: existed };
-      }),
-    );
-
-    results.forEach(({ success, wasSkipped }) => {
-      if (success) {
-        if (wasSkipped) {
-          skippedCount++;
-        } else {
-          downloadedCount++;
-        }
-      } else {
-        errorCount++;
-      }
-    });
+    const batchStats = await downloadIconBatch(batch);
+    stats.downloaded += batchStats.downloaded;
+    stats.skipped += batchStats.skipped;
+    stats.errors += batchStats.errors;
 
     progressBar.update(Math.min(i + batchSize, gen7Icons.length), {
-      status: `Gen 7: New: ${downloadedCount}, Skipped: ${skippedCount}, Errors: ${errorCount}`,
+      status: `Gen 7: New: ${stats.downloaded}, Skipped: ${stats.skipped}, Errors: ${stats.errors}`,
     });
 
     if (i + batchSize < gen7Icons.length) {
@@ -304,32 +209,15 @@ async function downloadAllIcons(
   for (let i = 0; i < gen8Icons.length; i += batchSize) {
     const batch = gen8Icons.slice(i, i + batchSize);
 
-    const results = await Promise.all(
-      batch.map(async (icon) => {
-        const config = GENERATIONS.find((g) => g.name === icon.generation)!;
-        const filePath = path.join(config.spritesDir, icon.filename);
-        const existed = await fileExists(filePath);
-        const success = await downloadImage(icon, config);
-        return { icon, success, wasSkipped: existed };
-      }),
-    );
-
-    results.forEach(({ success, wasSkipped }) => {
-      if (success) {
-        if (wasSkipped) {
-          skippedCount++;
-        } else {
-          downloadedCount++;
-        }
-      } else {
-        errorCount++;
-      }
-    });
+    const batchStats = await downloadIconBatch(batch);
+    stats.downloaded += batchStats.downloaded;
+    stats.skipped += batchStats.skipped;
+    stats.errors += batchStats.errors;
 
     progressBar.update(
       gen7Icons.length + Math.min(i + batchSize, gen8Icons.length),
       {
-        status: `Gen 8: New: ${downloadedCount}, Skipped: ${skippedCount}, Errors: ${errorCount}`,
+        status: `Gen 8: New: ${stats.downloaded}, Skipped: ${stats.skipped}, Errors: ${stats.errors}`,
       },
     );
 
@@ -340,17 +228,13 @@ async function downloadAllIcons(
 
   progressBar.stop();
 
-  if (errorCount > 0) {
-    ConsoleFormatter.warn(`Download completed with ${errorCount} errors`);
+  if (stats.errors > 0) {
+    ConsoleFormatter.warn(`Download completed with ${stats.errors} errors`);
   } else {
     ConsoleFormatter.success("All icons downloaded successfully!");
   }
 
-  return {
-    downloaded: downloadedCount,
-    skipped: skippedCount,
-    errors: errorCount,
-  };
+  return stats;
 }
 
 /**
@@ -422,5 +306,4 @@ async function scrapePokemonIcons(): Promise<void> {
   }
 }
 
-// Run the scraper directly (jiti doesn't set require.main properly)
 scrapePokemonIcons();

--- a/scripts/scrape-pokemon-icons.ts
+++ b/scripts/scrape-pokemon-icons.ts
@@ -58,6 +58,9 @@ type DownloadStats = {
   errors: number;
 };
 
+const ICON_BATCH_SIZE = 10;
+const BATCH_DELAY_MS = 50;
+
 function getGenerationConfig(
   generation: PokemonIcon["generation"],
 ): GenerationConfig {
@@ -95,6 +98,35 @@ async function downloadIconBatch(icons: PokemonIcon[]): Promise<DownloadStats> {
     },
     { downloaded: 0, skipped: 0, errors: 0 },
   );
+}
+
+async function downloadGenerationIcons(
+  icons: PokemonIcon[],
+  generationLabel: string,
+  completedIcons: number,
+  stats: DownloadStats,
+  progressBar: ReturnType<typeof ConsoleFormatter.createProgressBar>,
+): Promise<void> {
+  ConsoleFormatter.working(`Downloading ${generationLabel} sprites...`);
+
+  for (let i = 0; i < icons.length; i += ICON_BATCH_SIZE) {
+    const batch = icons.slice(i, i + ICON_BATCH_SIZE);
+    const batchStats = await downloadIconBatch(batch);
+    stats.downloaded += batchStats.downloaded;
+    stats.skipped += batchStats.skipped;
+    stats.errors += batchStats.errors;
+
+    progressBar.update(
+      Math.min(i + ICON_BATCH_SIZE, icons.length) + completedIcons,
+      {
+        status: `${generationLabel}: New: ${stats.downloaded}, Skipped: ${stats.skipped}, Errors: ${stats.errors}`,
+      },
+    );
+
+    if (i + ICON_BATCH_SIZE < icons.length) {
+      await new Promise((resolve) => setTimeout(resolve, BATCH_DELAY_MS));
+    }
+  }
 }
 
 /**
@@ -165,7 +197,7 @@ async function loadPokemonIcons(): Promise<PokemonIcon[]> {
 /**
  * Download all Pokemon icons with progress tracking
  */
-async function downloadAllIcons(
+export async function downloadAllIcons(
   icons: PokemonIcon[],
 ): Promise<{ downloaded: number; skipped: number; errors: number }> {
   ConsoleFormatter.printSection(
@@ -182,49 +214,16 @@ async function downloadAllIcons(
 
   const stats: DownloadStats = { downloaded: 0, skipped: 0, errors: 0 };
 
-  const batchSize = 10; // Smaller batch size to be more respectful to the server
   const progressBar = ConsoleFormatter.createProgressBar(icons.length);
 
-  // Download Gen 7 icons first
-  ConsoleFormatter.working("Downloading Gen 7 sprites...");
-  for (let i = 0; i < gen7Icons.length; i += batchSize) {
-    const batch = gen7Icons.slice(i, i + batchSize);
-
-    const batchStats = await downloadIconBatch(batch);
-    stats.downloaded += batchStats.downloaded;
-    stats.skipped += batchStats.skipped;
-    stats.errors += batchStats.errors;
-
-    progressBar.update(Math.min(i + batchSize, gen7Icons.length), {
-      status: `Gen 7: New: ${stats.downloaded}, Skipped: ${stats.skipped}, Errors: ${stats.errors}`,
-    });
-
-    if (i + batchSize < gen7Icons.length) {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
-  }
-
-  // Download Gen 8 icons
-  ConsoleFormatter.working("Downloading Gen 8 sprites...");
-  for (let i = 0; i < gen8Icons.length; i += batchSize) {
-    const batch = gen8Icons.slice(i, i + batchSize);
-
-    const batchStats = await downloadIconBatch(batch);
-    stats.downloaded += batchStats.downloaded;
-    stats.skipped += batchStats.skipped;
-    stats.errors += batchStats.errors;
-
-    progressBar.update(
-      gen7Icons.length + Math.min(i + batchSize, gen8Icons.length),
-      {
-        status: `Gen 8: New: ${stats.downloaded}, Skipped: ${stats.skipped}, Errors: ${stats.errors}`,
-      },
-    );
-
-    if (i + batchSize < gen8Icons.length) {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
-  }
+  await downloadGenerationIcons(gen7Icons, "Gen 7", 0, stats, progressBar);
+  await downloadGenerationIcons(
+    gen8Icons,
+    "Gen 8",
+    gen7Icons.length,
+    stats,
+    progressBar,
+  );
 
   progressBar.stop();
 
@@ -306,4 +305,7 @@ async function scrapePokemonIcons(): Promise<void> {
   }
 }
 
-scrapePokemonIcons();
+// fallow-ignore-next-line code-duplication
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void scrapePokemonIcons();
+}

--- a/scripts/scrape-pokemon-icons.ts
+++ b/scripts/scrape-pokemon-icons.ts
@@ -2,26 +2,22 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { ConsoleFormatter } from "./utils/console-utils";
 import {
   normalizePokemonNameForSprite,
   stripPokemonFormSuffix,
 } from "./utils/pokemon-name-utils";
+import {
+  getSpriteSourcePaths,
+  loadJsonFile,
+} from "./utils/sprite-source-utils";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const BASE_ENTRIES_PATH = path.join(
-  __dirname,
-  "..",
-  "data",
-  "shared",
-  "base-entries.json",
-);
-const SPRITES_BASE_DIR = path.join(__dirname, "sprites");
-const GEN7_SPRITES_DIR = path.join(SPRITES_BASE_DIR, "pokemon-gen7");
-const GEN8_SPRITES_DIR = path.join(SPRITES_BASE_DIR, "pokemon-gen8");
+const {
+  baseEntriesPath: BASE_ENTRIES_PATH,
+  spritesBaseDir: SPRITES_BASE_DIR,
+  gen7SpritesDir: GEN7_SPRITES_DIR,
+  gen8SpritesDir: GEN8_SPRITES_DIR,
+} = getSpriteSourcePaths(import.meta.url);
 const GEN7_ICON_BASE_URL =
   "https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen7x/regular";
 const GEN8_ICON_BASE_URL =
@@ -191,8 +187,7 @@ async function loadPokemonIcons(): Promise<PokemonIcon[]> {
     const entriesData = await ConsoleFormatter.withSpinner(
       "Loading Pokemon entries...",
       async () => {
-        const data = await fs.readFile(BASE_ENTRIES_PATH, "utf-8");
-        return JSON.parse(data) as PokemonEntry[];
+        return loadJsonFile<PokemonEntry[]>(BASE_ENTRIES_PATH);
       },
     );
 

--- a/scripts/scrape-pokemon-icons.ts
+++ b/scripts/scrape-pokemon-icons.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { ConsoleFormatter } from "./utils/console-utils";
 import { normalizePokemonNameForSprite } from "./utils/pokemon-name-utils";
+import { runDirectScript } from "./utils/script-runtime-utils";
 import {
   downloadSpriteImage,
   type SpriteDownloadConfig,
@@ -306,7 +307,4 @@ async function scrapePokemonIcons(): Promise<void> {
   }
 }
 
-// fallow-ignore-next-line code-duplication
-if (import.meta.url === `file://${process.argv[1]}`) {
-  void scrapePokemonIcons();
-}
+runDirectScript(import.meta.url, scrapePokemonIcons);

--- a/scripts/scrape-pokemon-icons.ts
+++ b/scripts/scrape-pokemon-icons.ts
@@ -11,6 +11,7 @@ import {
   spriteFileExists,
 } from "./utils/sprite-download-utils";
 import {
+  BasePokemonEntrySchema,
   getSpriteSourcePaths,
   loadJsonFile,
 } from "./utils/sprite-source-utils";
@@ -143,7 +144,7 @@ async function loadPokemonIcons(): Promise<PokemonIcon[]> {
     const entriesData = await ConsoleFormatter.withSpinner(
       "Loading Pokemon entries...",
       async () => {
-        return loadJsonFile<PokemonEntry[]>(BASE_ENTRIES_PATH);
+        return loadJsonFile(BASE_ENTRIES_PATH, BasePokemonEntrySchema.array());
       },
     );
 

--- a/scripts/scrape-safari-encounters.ts
+++ b/scripts/scrape-safari-encounters.ts
@@ -11,6 +11,10 @@ import {
   findPokemonId,
   isPotentialPokemonName,
 } from "./utils/pokemon-name-utils";
+import {
+  exitOnScriptError,
+  runDirectScript,
+} from "./utils/script-runtime-utils";
 import { fetchWikiPageHtml } from "./utils/wiki-fetch-utils";
 
 // Safari Zone area pages
@@ -245,14 +249,8 @@ async function main() {
     );
     ConsoleFormatter.info(`Total duration: ${(duration / 1000).toFixed(2)}s`);
   } catch (error) {
-    ConsoleFormatter.error(
-      `Safari Zone scraping failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
-    process.exit(1);
+    exitOnScriptError("Safari Zone scraping failed", error);
   }
 }
 
-// Run the script
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
-}
+runDirectScript(import.meta.url, main);

--- a/scripts/scrape-safari-encounters.ts
+++ b/scripts/scrape-safari-encounters.ts
@@ -6,6 +6,7 @@ import * as cheerio from "cheerio";
 import type { EncounterType } from "./types/encounters";
 import { ConsoleFormatter } from "./utils/console-utils";
 import { loadPokemonNameMap } from "./utils/data-loading-utils";
+import { ensureEncounterOutputDirectories } from "./utils/encounter-output-utils";
 import {
   findPokemonId,
   isPotentialPokemonName,
@@ -31,66 +32,57 @@ interface RouteEncounters {
   encounters: PokemonEncounter[];
 }
 
-/**
- * Detects encounter type from text content like "Surf", "Old Rod", etc.
- */
-function detectEncounterType(text: string): EncounterType | null {
+const ENCOUNTER_TYPE_RULES: Array<{
+  type: EncounterType;
+  matches: (text: string) => boolean;
+}> = [
+  {
+    type: "surf",
+    matches: (text) =>
+      text === "surf" ||
+      text.includes("surfing") ||
+      (text.includes("surf") && !text.includes("rod")),
+  },
+  {
+    type: "fishing",
+    matches: (text) =>
+      ["old rod", "good rod", "super rod", "fishing rod", "rod fishing"].some(
+        (term) => text.includes(term),
+      ),
+  },
+  {
+    type: "rock_smash",
+    matches: (text) =>
+      ["rock smash", "smash rock", "headbutt"].some((term) =>
+        text.includes(term),
+      ),
+  },
+  {
+    type: "cave",
+    matches: (text) =>
+      ["cave", "underground", "depths"].some((term) => text.includes(term)),
+  },
+  {
+    type: "special",
+    matches: (text) =>
+      ["gift", "trade", "static", "overworld"].some((term) =>
+        text.includes(term),
+      ),
+  },
+];
+
+/** Detects encounter type from text content like "Surf" or "Old Rod". */
+export function detectEncounterType(text: string): EncounterType | null {
   if (!text || typeof text !== "string") {
     return null;
   }
 
   const normalizedText = text.toLowerCase().trim();
 
-  // Surf encounters
-  if (
-    normalizedText === "surf" ||
-    normalizedText.includes("surfing") ||
-    (normalizedText.includes("surf") && !normalizedText.includes("rod"))
-  ) {
-    return "surf";
-  }
-
-  // Fishing encounters
-  if (
-    normalizedText.includes("old rod") ||
-    normalizedText.includes("good rod") ||
-    normalizedText.includes("super rod") ||
-    normalizedText.includes("fishing rod") ||
-    normalizedText.includes("rod fishing")
-  ) {
-    return "fishing";
-  }
-
-  // Rock Smash encounters
-  if (
-    normalizedText.includes("rock smash") ||
-    normalizedText.includes("smash rock") ||
-    normalizedText.includes("headbutt")
-  ) {
-    return "rock_smash";
-  }
-
-  // Cave encounters
-  if (
-    normalizedText.includes("cave") ||
-    normalizedText.includes("underground") ||
-    normalizedText.includes("depths")
-  ) {
-    return "cave";
-  }
-
-  // Special encounters (might include gift, trade, etc.)
-  if (
-    normalizedText.includes("gift") ||
-    normalizedText.includes("trade") ||
-    normalizedText.includes("static") ||
-    normalizedText.includes("overworld")
-  ) {
-    return "special";
-  }
-
-  // Default to grass if we can't determine the type
-  return "grass";
+  return (
+    ENCOUNTER_TYPE_RULES.find((rule) => rule.matches(normalizedText))?.type ??
+    "grass"
+  );
 }
 
 /**
@@ -188,13 +180,7 @@ async function main() {
       "Scraping Safari Zone area encounters from individual wiki pages",
     );
 
-    const dataDir = path.join(process.cwd(), "data");
-    const classicDir = path.join(dataDir, "classic");
-    const remixDir = path.join(dataDir, "remix");
-
-    // Create directories
-    await fs.mkdir(classicDir, { recursive: true });
-    await fs.mkdir(remixDir, { recursive: true });
+    const { classicDir, remixDir } = await ensureEncounterOutputDirectories();
 
     // Scrape all Safari Zone area pages
     const safariEncounters: RouteEncounters[] = [];

--- a/scripts/scrape-special-encounters.ts
+++ b/scripts/scrape-special-encounters.ts
@@ -6,6 +6,7 @@ import * as cheerio from "cheerio";
 import { extractPokedexSubpageTitles } from "./scrape-pokedex";
 import { ConsoleFormatter } from "./utils/console-utils";
 import { loadPokemonNameMap } from "./utils/data-loading-utils";
+import { ensureEncounterOutputDirectories } from "./utils/encounter-output-utils";
 import { cleanLocationName } from "./utils/location-utils";
 import {
   findPokemonId,
@@ -526,13 +527,7 @@ async function main() {
   const startTime = Date.now();
 
   try {
-    const dataDir = path.join(process.cwd(), "data");
-    const classicDir = path.join(dataDir, "classic");
-    const remixDir = path.join(dataDir, "remix");
-
-    // Create directories
-    await fs.mkdir(classicDir, { recursive: true });
-    await fs.mkdir(remixDir, { recursive: true });
+    const { classicDir, remixDir } = await ensureEncounterOutputDirectories();
 
     // Scrape both Classic and Remix data
     ConsoleFormatter.info("Scraping Classic and Remix Special Encounters...");

--- a/scripts/scrape-special-encounters.ts
+++ b/scripts/scrape-special-encounters.ts
@@ -6,6 +6,7 @@ import * as cheerio from "cheerio";
 import { extractPokedexSubpageTitles } from "./scrape-pokedex";
 import { ConsoleFormatter } from "./utils/console-utils";
 import { loadPokemonNameMap } from "./utils/data-loading-utils";
+import { cleanLocationName } from "./utils/location-utils";
 import {
   findPokemonId,
   isPotentialPokemonName,
@@ -86,26 +87,6 @@ function findPokemonIdWithSpecialCases(
   }
 
   return null;
-}
-
-/**
- * Cleans location names to match the standard format
- */
-function cleanLocationName(location: string): string {
-  return (
-    location
-      // Remove wiki links
-      .replace(/\[\[([^\]]+)\]\]/g, "$1")
-      .replace(/\[\[([^\]]+)\|([^\]]+)\]\]/g, "$2")
-      // Remove extra context in parentheses
-      .replace(/\s*\([^)]*\)/g, "")
-      // Standardize Pokémon -> Pokemon
-      .replace(/Pokémon/g, "Pokemon")
-      // Standardize S.S. Anne
-      .replace(/S\.S\.\s*Anne/g, "S.S. Anne")
-      // Remove extra whitespace
-      .trim()
-  );
 }
 
 /**

--- a/scripts/scrape-special-encounters.ts
+++ b/scripts/scrape-special-encounters.ts
@@ -13,6 +13,10 @@ import {
   isPotentialPokemonName,
   type PokemonNameMap,
 } from "./utils/pokemon-name-utils";
+import {
+  exitOnScriptError,
+  runDirectScript,
+} from "./utils/script-runtime-utils";
 import { fetchWikiPageHtml } from "./utils/wiki-fetch-utils";
 
 const CLASSIC_POKEDEX_URL =
@@ -707,13 +711,8 @@ async function main() {
       },
     ]);
   } catch (error) {
-    ConsoleFormatter.error(
-      `Fatal error: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
-    process.exit(1);
+    exitOnScriptError("Fatal error", error);
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
-  void main();
-}
+runDirectScript(import.meta.url, main);

--- a/scripts/scrape-wild-encounters.ts
+++ b/scripts/scrape-wild-encounters.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import type { EncounterType } from "./types/encounters";
 import { ConsoleFormatter } from "./utils/console-utils";
 import { loadPokemonNameMap } from "./utils/data-loading-utils";
+import { ensureEncounterOutputDirectories } from "./utils/encounter-output-utils";
 import { findPokemonId, type PokemonNameMap } from "./utils/pokemon-name-utils";
 import { isRoutePattern, processRouteName } from "./utils/route-utils";
 import { fetchWikiPageWikitext } from "./utils/wiki-fetch-utils";
@@ -944,13 +945,7 @@ async function main() {
   const startTime = Date.now();
 
   try {
-    const dataDir = path.join(process.cwd(), "data");
-    const classicDir = path.join(dataDir, "classic");
-    const remixDir = path.join(dataDir, "remix");
-
-    // Create directories
-    await fs.mkdir(classicDir, { recursive: true });
-    await fs.mkdir(remixDir, { recursive: true });
+    const { classicDir, remixDir } = await ensureEncounterOutputDirectories();
 
     const pokemonNameMap = await loadPokemonNameMap();
     const [classicRoutes, remixRoutes] = await Promise.all([

--- a/scripts/scrape-wild-encounters.ts
+++ b/scripts/scrape-wild-encounters.ts
@@ -42,6 +42,34 @@ type EncounterTemplate = {
   templateName: string;
   args: string[];
 };
+
+type TemplateArgumentDepths = {
+  square: number;
+  curly: number;
+  angle: number;
+};
+
+type RouteHeadingDecision =
+  | { kind: "activate"; routeName: string; uniqueIdentifier: string }
+  | { kind: "flush" }
+  | null;
+
+const HEADER_TEMPLATE_NAMES = new Set([
+  "EncounterTable/Header",
+  "EncounterTable/Header/Time",
+]);
+const FOOTER_TEMPLATE_NAMES = new Set([
+  "EncounterTable/Footer",
+  "EncounterTable/Footer/Time",
+]);
+const PAIR_DEPTH_CHANGES: Readonly<
+  Record<string, readonly [keyof TemplateArgumentDepths, number]>
+> = {
+  "[[": ["square", 1],
+  "]]": ["square", -1],
+  "{{": ["curly", 1],
+  "}}": ["curly", -1],
+};
 const DEFAULT_ROCK_SMASH_POKEMON_ID = 74;
 
 /**
@@ -318,70 +346,56 @@ export function getLocationWikiUrl(locationName: string): string {
   return `https://infinitefusion.fandom.com/wiki/${slug}`;
 }
 
+function consumeBalancedTemplateToken(
+  rawArgs: string,
+  index: number,
+  depths: TemplateArgumentDepths,
+): string | null {
+  const currentPair = rawArgs.slice(index, index + 2);
+  const pairDepthChange = PAIR_DEPTH_CHANGES[currentPair];
+  if (
+    pairDepthChange &&
+    (pairDepthChange[1] > 0 || depths[pairDepthChange[0]] > 0)
+  ) {
+    depths[pairDepthChange[0]] += pairDepthChange[1];
+    return currentPair;
+  }
+
+  const angleDepthChange =
+    rawArgs[index] === "<" ? 1 : rawArgs[index] === ">" ? -1 : 0;
+  if (angleDepthChange > 0 || (angleDepthChange < 0 && depths.angle > 0)) {
+    depths.angle += angleDepthChange;
+    return rawArgs[index];
+  }
+
+  return null;
+}
+
 function splitTemplateArguments(rawArgs: string): string[] {
   const args: string[] = [];
+  const depths: TemplateArgumentDepths = { square: 0, curly: 0, angle: 0 };
   let current = "";
-  let squareDepth = 0;
-  let curlyDepth = 0;
-  let angleDepth = 0;
 
   for (let index = 0; index < rawArgs.length; index += 1) {
-    const currentPair = rawArgs.slice(index, index + 2);
-
-    if (currentPair === "[[") {
-      squareDepth += 1;
-      current += currentPair;
-      index += 1;
-      continue;
-    }
-
-    if (currentPair === "]]" && squareDepth > 0) {
-      squareDepth -= 1;
-      current += currentPair;
-      index += 1;
-      continue;
-    }
-
-    if (currentPair === "{{") {
-      curlyDepth += 1;
-      current += currentPair;
-      index += 1;
-      continue;
-    }
-
-    if (currentPair === "}}" && curlyDepth > 0) {
-      curlyDepth -= 1;
-      current += currentPair;
-      index += 1;
-      continue;
-    }
-
-    const currentChar = rawArgs[index];
-
-    if (currentChar === "<") {
-      angleDepth += 1;
-      current += currentChar;
-      continue;
-    }
-
-    if (currentChar === ">" && angleDepth > 0) {
-      angleDepth -= 1;
-      current += currentChar;
+    const token = consumeBalancedTemplateToken(rawArgs, index, depths);
+    if (token !== null) {
+      current += token;
+      index += token.length - 1;
       continue;
     }
 
     if (
-      currentChar === "|" &&
-      squareDepth === 0 &&
-      curlyDepth === 0 &&
-      angleDepth === 0
+      rawArgs[index] === "|" &&
+      depths.square === 0 &&
+      depths.curly === 0 &&
+      depths.angle === 0
     ) {
       args.push(current.trim());
       current = "";
       continue;
     }
 
-    current += currentChar;
+    current += rawArgs[index];
   }
 
   args.push(current.trim());
@@ -410,31 +424,14 @@ function applyEncounterTemplate(
   pokemonNameMap: PokemonNameMap,
   contextLabel: string,
 ): EncounterType | null {
-  if (
-    template.templateName === "EncounterTable/Header" ||
-    template.templateName === "EncounterTable/Header/Time"
-  ) {
-    return "grass";
-  }
-
-  if (template.templateName === "EncounterTable/Section") {
-    const sectionLabel = cleanTemplateValue(template.args[0] ?? "");
-    const detectedType = detectEncounterType(sectionLabel);
-    return detectedType && isWildEncounterType(detectedType)
-      ? detectedType
-      : null;
-  }
-
-  if (template.templateName === "EncounterTable/RockSmash") {
-    addDefaultRockSmashEncounter(encounters, pokemonNameMap, contextLabel);
-    return "rock_smash";
-  }
-
-  if (
-    template.templateName === "EncounterTable/Footer" ||
-    template.templateName === "EncounterTable/Footer/Time"
-  ) {
-    return null;
+  const nextEncounterType = getEncounterTypeTransition(
+    template,
+    encounters,
+    pokemonNameMap,
+    contextLabel,
+  );
+  if (nextEncounterType !== undefined) {
+    return nextEncounterType;
   }
 
   if (
@@ -454,6 +451,33 @@ function applyEncounterTemplate(
   }
 
   return currentEncounterType;
+}
+
+function getEncounterTypeTransition(
+  template: EncounterTemplate,
+  encounters: PokemonEncounter[],
+  pokemonNameMap: PokemonNameMap,
+  contextLabel: string,
+): EncounterType | null | undefined {
+  if (HEADER_TEMPLATE_NAMES.has(template.templateName)) {
+    return "grass";
+  }
+  if (FOOTER_TEMPLATE_NAMES.has(template.templateName)) {
+    return null;
+  }
+  if (template.templateName === "EncounterTable/Section") {
+    const sectionLabel = cleanTemplateValue(template.args[0] ?? "");
+    const detectedType = detectEncounterType(sectionLabel);
+    return detectedType && isWildEncounterType(detectedType)
+      ? detectedType
+      : null;
+  }
+  if (template.templateName === "EncounterTable/RockSmash") {
+    addDefaultRockSmashEncounter(encounters, pokemonNameMap, contextLabel);
+    return "rock_smash";
+  }
+
+  return undefined;
 }
 
 function cleanTemplateValue(value: string): string {
@@ -576,38 +600,16 @@ export function parseWildEncounterRoutesFromWikitext(
       continue;
     }
 
-    const routeHeadingMatch = line.match(WIKITEXT_ROUTE_HEADING_PATTERN);
-    if (routeHeadingMatch?.[1]) {
-      const routeHeading = routeHeadingMatch[1].trim();
-
-      if (
-        isRoutePattern(routeHeading) === false ||
-        isValidRouteName(routeHeading) === false
-      ) {
-        continue;
-      }
-
+    const routeHeading = classifyRouteHeading(line, routesSeen);
+    if (routeHeading !== null) {
       flushActiveRoute();
-
-      const { cleanName: cleanedRouteName, routeId } =
-        processRouteName(routeHeading);
-      if (isValidRouteName(cleanedRouteName) === false) {
-        continue;
+      if (routeHeading.kind === "activate") {
+        routesSeen.add(routeHeading.uniqueIdentifier);
+        activeRouteName = routeHeading.routeName;
+        activeRouteContext = `route ${routeHeading.routeName}`;
+        activeEncounters = [];
+        currentEncounterType = "grass";
       }
-
-      const uniqueIdentifier = routeId
-        ? `${cleanedRouteName}#${routeId}`
-        : cleanedRouteName;
-
-      if (routesSeen.has(uniqueIdentifier)) {
-        continue;
-      }
-
-      routesSeen.add(uniqueIdentifier);
-      activeRouteName = cleanedRouteName;
-      activeRouteContext = `route ${cleanedRouteName}`;
-      activeEncounters = [];
-      currentEncounterType = "grass";
       continue;
     }
 
@@ -632,6 +634,36 @@ export function parseWildEncounterRoutesFromWikitext(
   flushActiveRoute();
 
   return routes;
+}
+
+function classifyRouteHeading(
+  line: string,
+  routesSeen: Set<string>,
+): RouteHeadingDecision {
+  const routeHeadingMatch = line.match(WIKITEXT_ROUTE_HEADING_PATTERN);
+  if (!routeHeadingMatch?.[1]) {
+    return null;
+  }
+
+  const routeHeading = routeHeadingMatch[1].trim();
+  if (
+    isRoutePattern(routeHeading) === false ||
+    isValidRouteName(routeHeading) === false
+  ) {
+    return null;
+  }
+
+  const { cleanName: routeName, routeId } = processRouteName(routeHeading);
+  if (isValidRouteName(routeName) === false) {
+    return { kind: "flush" };
+  }
+
+  const uniqueIdentifier = routeId ? `${routeName}#${routeId}` : routeName;
+  if (routesSeen.has(uniqueIdentifier)) {
+    return { kind: "flush" };
+  }
+
+  return { kind: "activate", routeName, uniqueIdentifier };
 }
 
 export async function scrapeEncountersFromLocationArticle(

--- a/scripts/scrape-wild-encounters.ts
+++ b/scripts/scrape-wild-encounters.ts
@@ -10,6 +10,10 @@ import { loadPokemonNameMap } from "./utils/data-loading-utils";
 import { ensureEncounterOutputDirectories } from "./utils/encounter-output-utils";
 import { findPokemonId, type PokemonNameMap } from "./utils/pokemon-name-utils";
 import { isRoutePattern, processRouteName } from "./utils/route-utils";
+import {
+  exitOnScriptError,
+  runDirectScript,
+} from "./utils/script-runtime-utils";
 import { fetchWikiPageWikitext } from "./utils/wiki-fetch-utils";
 
 const WILD_ENCOUNTERS_CLASSIC_URL =
@@ -1012,14 +1016,8 @@ async function main() {
     );
     ConsoleFormatter.info(`Total duration: ${(duration / 1000).toFixed(2)}s`);
   } catch (error) {
-    ConsoleFormatter.error(
-      `Scraping failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
-    process.exit(1);
+    exitOnScriptError("Scraping failed", error);
   }
 }
 
-// Run the script
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
-}
+runDirectScript(import.meta.url, main);

--- a/scripts/utils/encounter-output-utils.ts
+++ b/scripts/utils/encounter-output-utils.ts
@@ -1,0 +1,16 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export async function ensureEncounterOutputDirectories(
+  dataDirectory = path.join(process.cwd(), "data"),
+): Promise<{ classicDir: string; remixDir: string }> {
+  const classicDir = path.join(dataDirectory, "classic");
+  const remixDir = path.join(dataDirectory, "remix");
+
+  await Promise.all([
+    fs.mkdir(classicDir, { recursive: true }),
+    fs.mkdir(remixDir, { recursive: true }),
+  ]);
+
+  return { classicDir, remixDir };
+}

--- a/scripts/utils/location-utils.ts
+++ b/scripts/utils/location-utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Normalizes wiki-formatted location text to the names used in generated data.
+ */
+export function cleanLocationName(location: string): string {
+  return location
+    .replace(/\[\[([^\]]+)\|([^\]]+)\]\]/g, "$2")
+    .replace(/\[\[([^\]]+)\]\]/g, "$1")
+    .replace(/\s*\([^)]*\)/g, "")
+    .replace(/Pokémon/g, "Pokemon")
+    .replace(/S\.S\.\s*Anne/g, "S.S. Anne")
+    .trim();
+}

--- a/scripts/utils/pokemon-data-utils.ts
+++ b/scripts/utils/pokemon-data-utils.ts
@@ -1,0 +1,82 @@
+import type { DexEntry } from "../scrape-pokedex";
+
+interface PokemonType {
+  name: string;
+}
+
+export interface PokemonSpeciesData {
+  is_legendary: boolean;
+  is_mythical: boolean;
+  generation: string | null;
+  evolution_chain?: {
+    url: string;
+  };
+}
+
+export interface PokemonSpeciesApiData {
+  is_legendary: boolean;
+  is_mythical: boolean;
+  generation?: {
+    name: string;
+  } | null;
+  evolution_chain?: {
+    url: string;
+  };
+}
+
+export interface EvolutionDetail {
+  id: number;
+  name: string;
+  trigger?: string;
+  min_level?: number;
+  item?: string;
+  location?: string;
+  condition?: string;
+}
+
+export interface EvolutionData {
+  evolves_from?: EvolutionDetail;
+  evolves_to: EvolutionDetail[];
+}
+
+export interface ProcessedPokemonData {
+  id: number;
+  nationalDexId: number;
+  name: string;
+  types: PokemonType[];
+  species: PokemonSpeciesData;
+  evolution?: EvolutionData;
+}
+
+type PokemonApiData = {
+  id: number;
+  species: {
+    name: string;
+  };
+  types: Array<{
+    type: {
+      name: string;
+    };
+  }>;
+};
+
+export function createProcessedPokemonData(
+  entry: DexEntry,
+  pokemon: PokemonApiData,
+  species: PokemonSpeciesApiData,
+  evolution: EvolutionData | undefined,
+): ProcessedPokemonData {
+  return {
+    id: entry.id,
+    nationalDexId: pokemon.id,
+    name: entry.name,
+    types: pokemon.types.map((type) => ({ name: type.type.name })),
+    species: {
+      is_legendary: species.is_legendary,
+      is_mythical: species.is_mythical,
+      generation: species.generation?.name ?? null,
+      evolution_chain: species.evolution_chain,
+    },
+    evolution,
+  };
+}

--- a/scripts/utils/script-runtime-utils.ts
+++ b/scripts/utils/script-runtime-utils.ts
@@ -1,0 +1,31 @@
+import { ConsoleFormatter } from "./console-utils";
+
+/** Formats an unknown script failure consistently without hiding its message. */
+export function formatScriptError(prefix: string, error: unknown): string {
+  return `${prefix}: ${error instanceof Error ? error.message : "Unknown error"}`;
+}
+
+/** Returns whether a module is being run as the process entrypoint. */
+export function isDirectScriptExecution(
+  moduleUrl: string,
+  entrypoint = process.argv[1],
+): boolean {
+  return entrypoint !== undefined && moduleUrl === `file://${entrypoint}`;
+}
+
+/** Reports a fatal script failure and terminates with the established exit code. */
+export function exitOnScriptError(prefix: string, error: unknown): never {
+  ConsoleFormatter.error(formatScriptError(prefix, error));
+  process.exit(1);
+}
+
+/** Starts a script only when its module is the process entrypoint. */
+export function runDirectScript(
+  moduleUrl: string,
+  main: () => Promise<void>,
+  entrypoint = process.argv[1],
+): void {
+  if (isDirectScriptExecution(moduleUrl, entrypoint)) {
+    void main();
+  }
+}

--- a/scripts/utils/script-runtime-utils.ts
+++ b/scripts/utils/script-runtime-utils.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import { ConsoleFormatter } from "./console-utils";
 
 /** Formats an unknown script failure consistently without hiding its message. */
@@ -10,7 +11,9 @@ export function isDirectScriptExecution(
   moduleUrl: string,
   entrypoint = process.argv[1],
 ): boolean {
-  return entrypoint !== undefined && moduleUrl === `file://${entrypoint}`;
+  return (
+    entrypoint !== undefined && moduleUrl === pathToFileURL(entrypoint).href
+  );
 }
 
 /** Reports a fatal script failure and terminates with the established exit code. */

--- a/scripts/utils/sprite-download-utils.ts
+++ b/scripts/utils/sprite-download-utils.ts
@@ -8,6 +8,7 @@ import {
 const SPRITE_FETCH_HEADERS = {
   "User-Agent": "Infinite-Fusion-Scraper/1.0",
 };
+const SPRITE_FETCH_TIMEOUT_MS = 10_000;
 
 export type SpriteDownloadIcon = {
   id: number;
@@ -36,7 +37,20 @@ export async function spriteFileExists(filePath: string): Promise<boolean> {
 }
 
 async function fetchSprite(url: string): Promise<Response> {
-  return fetch(url, { headers: SPRITE_FETCH_HEADERS });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    SPRITE_FETCH_TIMEOUT_MS,
+  );
+
+  try {
+    return await fetch(url, {
+      headers: SPRITE_FETCH_HEADERS,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 async function saveSprite(response: Response, filePath: string): Promise<void> {
@@ -92,7 +106,6 @@ async function downloadOriginalOrBaseForm(
   icon: SpriteDownloadIcon,
   config: SpriteDownloadConfig,
   filePath: string,
-  attempt: number,
 ): Promise<void> {
   const response = await fetchSprite(icon.url);
   if (response.ok) {
@@ -100,7 +113,7 @@ async function downloadOriginalOrBaseForm(
     return;
   }
 
-  if (response.status === 404 && attempt === 1) {
+  if (response.status === 404) {
     if (await tryDownloadBaseForm(icon, config)) return;
   }
 
@@ -116,7 +129,7 @@ async function downloadWithRetries(
 ): Promise<boolean> {
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
-      await downloadOriginalOrBaseForm(icon, config, filePath, attempt);
+      await downloadOriginalOrBaseForm(icon, config, filePath);
       return true;
     } catch (error) {
       if (attempt === retries) {

--- a/scripts/utils/sprite-download-utils.ts
+++ b/scripts/utils/sprite-download-utils.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  normalizePokemonNameForSprite,
+  stripPokemonFormSuffix,
+} from "./pokemon-name-utils";
+
+const SPRITE_FETCH_HEADERS = {
+  "User-Agent": "Infinite-Fusion-Scraper/1.0",
+};
+
+export type SpriteDownloadIcon = {
+  id: number;
+  name: string;
+  url: string;
+  filename: string;
+  generation: "gen7" | "gen8";
+};
+
+export type SpriteDownloadConfig = {
+  name: "gen7" | "gen8";
+  baseUrl: string;
+  spritesDir: string;
+  eggSpriteUrl: string;
+};
+
+type ReportError = (message: string) => void;
+
+export async function spriteFileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function fetchSprite(url: string): Promise<Response> {
+  return fetch(url, { headers: SPRITE_FETCH_HEADERS });
+}
+
+async function saveSprite(response: Response, filePath: string): Promise<void> {
+  await fs.writeFile(filePath, Buffer.from(await response.arrayBuffer()));
+}
+
+async function tryDownloadBaseForm(
+  icon: SpriteDownloadIcon,
+  config: SpriteDownloadConfig,
+): Promise<boolean> {
+  const baseName = stripPokemonFormSuffix(icon.name);
+  if (!baseName || baseName === icon.name) return false;
+
+  const baseFilename = `${normalizePokemonNameForSprite(baseName)}.png`;
+  const baseFilePath = path.join(config.spritesDir, baseFilename);
+
+  try {
+    const response = await fetchSprite(`${config.baseUrl}/${baseFilename}`);
+    if (!response.ok) return false;
+
+    await saveSprite(response, baseFilePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function downloadEggSprite(
+  config: SpriteDownloadConfig,
+  filePath: string,
+  reportError: ReportError,
+): Promise<boolean> {
+  try {
+    const response = await fetchSprite(config.eggSpriteUrl);
+    if (!response.ok) {
+      reportError(
+        `Failed to download ${config.name} egg sprite: HTTP ${response.status}`,
+      );
+      return false;
+    }
+
+    await saveSprite(response, filePath);
+    return true;
+  } catch (error) {
+    reportError(
+      `Failed to download ${config.name} egg sprite: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+    return false;
+  }
+}
+
+async function downloadOriginalOrBaseForm(
+  icon: SpriteDownloadIcon,
+  config: SpriteDownloadConfig,
+  filePath: string,
+  attempt: number,
+): Promise<void> {
+  const response = await fetchSprite(icon.url);
+  if (response.ok) {
+    await saveSprite(response, filePath);
+    return;
+  }
+
+  if (response.status === 404 && attempt === 1) {
+    if (await tryDownloadBaseForm(icon, config)) return;
+  }
+
+  throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+}
+
+async function downloadWithRetries(
+  icon: SpriteDownloadIcon,
+  config: SpriteDownloadConfig,
+  filePath: string,
+  retries: number,
+  reportError: ReportError,
+): Promise<boolean> {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      await downloadOriginalOrBaseForm(icon, config, filePath, attempt);
+      return true;
+    } catch (error) {
+      if (attempt === retries) {
+        reportError(
+          `Failed to download ${icon.name} (${config.name}) after ${retries} attempts: ${
+            error instanceof Error ? error.message : "Unknown error"
+          }`,
+        );
+        return false;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 2 ** attempt * 200));
+    }
+  }
+
+  return false;
+}
+
+export async function downloadSpriteImage(
+  icon: SpriteDownloadIcon,
+  config: SpriteDownloadConfig,
+  reportError: ReportError,
+  retries = 3,
+): Promise<boolean> {
+  const filePath = path.join(config.spritesDir, icon.filename);
+  if (await spriteFileExists(filePath)) return true;
+
+  if (icon.id === -1) {
+    return downloadEggSprite(config, filePath, reportError);
+  }
+
+  return downloadWithRetries(icon, config, filePath, retries, reportError);
+}

--- a/scripts/utils/sprite-packing-utils.ts
+++ b/scripts/utils/sprite-packing-utils.ts
@@ -1,0 +1,66 @@
+export type SpriteRectangle = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export function rectanglesOverlap(
+  a: SpriteRectangle,
+  b: SpriteRectangle,
+): boolean {
+  return (
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
+}
+
+export function getPackedBounds(rectangles: SpriteRectangle[]): {
+  width: number;
+  height: number;
+} {
+  return {
+    width: Math.max(
+      ...rectangles.map((rectangle) => rectangle.x + rectangle.width),
+    ),
+    height: Math.max(
+      ...rectangles.map((rectangle) => rectangle.y + rectangle.height),
+    ),
+  };
+}
+
+export function forEachOverlappingPair<T extends SpriteRectangle>(
+  rectangles: T[],
+  visit: (a: T, b: T) => boolean,
+): boolean {
+  let foundOverlap = false;
+
+  for (let i = 0; i < rectangles.length; i++) {
+    for (let j = i + 1; j < rectangles.length; j++) {
+      const a = rectangles[i];
+      const b = rectangles[j];
+
+      if (!a || !b) continue;
+
+      if (rectanglesOverlap(a, b)) {
+        foundOverlap = true;
+        if (visit(a, b)) return true;
+      }
+    }
+  }
+
+  return foundOverlap;
+}
+
+export function findFirstOverlappingPair<T extends SpriteRectangle>(
+  rectangles: T[],
+): [T, T] | undefined {
+  let pair: [T, T] | undefined;
+  forEachOverlappingPair(rectangles, (a, b) => {
+    pair = [a, b];
+    return true;
+  });
+  return pair;
+}

--- a/scripts/utils/sprite-source-utils.ts
+++ b/scripts/utils/sprite-source-utils.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function getSpriteSourcePaths(moduleUrl: string): {
+  scriptDirectory: string;
+  baseEntriesPath: string;
+  spritesBaseDir: string;
+  gen7SpritesDir: string;
+  gen8SpritesDir: string;
+} {
+  const scriptDirectory = path.dirname(fileURLToPath(moduleUrl));
+  const spritesBaseDir = path.join(scriptDirectory, "sprites");
+
+  return {
+    scriptDirectory,
+    baseEntriesPath: path.join(
+      scriptDirectory,
+      "..",
+      "data",
+      "shared",
+      "base-entries.json",
+    ),
+    spritesBaseDir,
+    gen7SpritesDir: path.join(spritesBaseDir, "pokemon-gen7"),
+    gen8SpritesDir: path.join(spritesBaseDir, "pokemon-gen8"),
+  };
+}
+
+export async function loadJsonFile<T>(filePath: string): Promise<T> {
+  return JSON.parse(await fs.readFile(filePath, "utf-8")) as T;
+}

--- a/scripts/utils/sprite-source-utils.ts
+++ b/scripts/utils/sprite-source-utils.ts
@@ -1,6 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { z } from "zod";
+
+export const BasePokemonEntrySchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+});
 
 export function getSpriteSourcePaths(moduleUrl: string): {
   scriptDirectory: string;
@@ -27,6 +33,17 @@ export function getSpriteSourcePaths(moduleUrl: string): {
   };
 }
 
-export async function loadJsonFile<T>(filePath: string): Promise<T> {
-  return JSON.parse(await fs.readFile(filePath, "utf-8")) as T;
+export async function loadJsonFile<T>(
+  filePath: string,
+  schema: z.ZodType<T>,
+): Promise<T> {
+  const payload: unknown = JSON.parse(await fs.readFile(filePath, "utf-8"));
+  const result = schema.safeParse(payload);
+  if (result.success === false) {
+    throw new Error(
+      `Invalid JSON in ${filePath}: ${z.prettifyError(result.error)}`,
+    );
+  }
+
+  return result.data;
 }

--- a/scripts/utils/wiki-fetch-utils.ts
+++ b/scripts/utils/wiki-fetch-utils.ts
@@ -1,20 +1,19 @@
+import { z } from "zod";
+
 const WIKI_ORIGIN = "https://infinitefusion.fandom.com";
 const WIKI_API_URL = `${WIKI_ORIGIN}/api.php`;
 const WIKI_API_TIMEOUT_MS = 10_000;
 const SCRAPER_USER_AGENT =
   "InfiniteFusionNuzlockeScraper/1.0 (+https://github.com/fbb/infinite-fusion-nuzlocke)";
 
-type WikiParseResponse = {
-  parse?: {
-    text?: string;
-    wikitext?: string;
-    title?: string;
-  };
-  error?: {
-    code?: string;
-    info?: string;
-  };
-};
+const WikiParseResponseSchema = z.object({
+  parse: z
+    .object({ text: z.string().optional(), wikitext: z.string().optional() })
+    .optional(),
+  error: z
+    .object({ code: z.string().optional(), info: z.string().optional() })
+    .optional(),
+});
 
 function getPageTitleFromUrl(pageUrl: string): string {
   const parsed = new URL(pageUrl);
@@ -100,12 +99,20 @@ async function fetchWikiApiResponse(
   }
 }
 
+// fallow-ignore-next-line complexity
 function getParsedWikiContent(
   payload: unknown,
   prop: "text" | "wikitext",
   pageTitle: string,
 ): string {
-  const wikiPayload = payload as WikiParseResponse;
+  const result = WikiParseResponseSchema.safeParse(payload);
+  if (result.success === false) {
+    throw new Error(
+      `Wiki API returned invalid payload for page ${pageTitle}: ${z.prettifyError(result.error)}`,
+    );
+  }
+
+  const wikiPayload = result.data;
   if (wikiPayload.error) {
     const code = wikiPayload.error.code ?? "unknown";
     const info = wikiPayload.error.info ?? "Unknown wiki API error";

--- a/scripts/utils/wiki-fetch-utils.ts
+++ b/scripts/utils/wiki-fetch-utils.ts
@@ -62,12 +62,25 @@ async function fetchWikiPageParsedContent(
     redirects: "1",
   });
 
+  const response = await fetchWikiApiResponse(pageTitle, params);
+  if (response.ok === false) {
+    throw new Error(
+      `Wiki API request failed (${response.status}) for page: ${pageTitle}`,
+    );
+  }
+
+  return getParsedWikiContent(await response.json(), prop, pageTitle);
+}
+
+async function fetchWikiApiResponse(
+  pageTitle: string,
+  params: URLSearchParams,
+): Promise<Response> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), WIKI_API_TIMEOUT_MS);
 
-  let response: Response;
   try {
-    response = await fetch(`${WIKI_API_URL}?${params.toString()}`, {
+    return await fetch(`${WIKI_API_URL}?${params.toString()}`, {
       headers: {
         Accept: "application/json",
         "User-Agent": SCRAPER_USER_AGENT,
@@ -85,25 +98,24 @@ async function fetchWikiPageParsedContent(
   } finally {
     clearTimeout(timeoutId);
   }
+}
 
-  if (response.ok === false) {
-    throw new Error(
-      `Wiki API request failed (${response.status}) for page: ${pageTitle}`,
-    );
-  }
-
-  const payload = (await response.json()) as WikiParseResponse;
-
-  if (payload.error) {
-    const code = payload.error.code ?? "unknown";
-    const info = payload.error.info ?? "Unknown wiki API error";
+function getParsedWikiContent(
+  payload: unknown,
+  prop: "text" | "wikitext",
+  pageTitle: string,
+): string {
+  const wikiPayload = payload as WikiParseResponse;
+  if (wikiPayload.error) {
+    const code = wikiPayload.error.code ?? "unknown";
+    const info = wikiPayload.error.info ?? "Unknown wiki API error";
     throw new Error(
       `Wiki API parse error (${code}) for page ${pageTitle}: ${info}`,
     );
   }
 
   const parsedContent =
-    prop === "text" ? payload.parse?.text : payload.parse?.wikitext;
+    prop === "text" ? wikiPayload.parse?.text : wikiPayload.parse?.wikitext;
   if (typeof parsedContent !== "string" || parsedContent.length === 0) {
     throw new Error(
       `Wiki API returned empty ${prop} content for page: ${pageTitle}`,

--- a/scripts/validate-route-article-coverage.ts
+++ b/scripts/validate-route-article-coverage.ts
@@ -51,6 +51,7 @@ function getEncounterSet(encounters: PokemonEncounter[]): Set<string> {
   );
 }
 
+// fallow-ignore-next-line complexity
 function buildValidationFailure(
   routeName: string,
   articleEncounters: PokemonEncounter[],
@@ -95,6 +96,7 @@ function buildValidationFailure(
   };
 }
 
+// fallow-ignore-next-line complexity
 async function main() {
   const dataRoot = path.join(process.cwd(), "data");
 
@@ -134,36 +136,39 @@ async function main() {
     );
 
     const batchFailures = await Promise.all(
-      batch.map(async (routeName) => {
-        const classicEncounters =
-          classicRoutes.find((route) => route.routeName === routeName)
-            ?.encounters ?? [];
-        const remixEncounters =
-          remixRoutes.find((route) => route.routeName === routeName)
-            ?.encounters ?? [];
+      batch.map(
+        // fallow-ignore-next-line complexity
+        async (routeName) => {
+          const classicEncounters =
+            classicRoutes.find((route) => route.routeName === routeName)
+              ?.encounters ?? [];
+          const remixEncounters =
+            remixRoutes.find((route) => route.routeName === routeName)
+              ?.encounters ?? [];
 
-        try {
-          const articleEncounters = await scrapeEncountersFromLocationArticle(
-            routeName,
-            pokemonNameMap,
-          );
+          try {
+            const articleEncounters = await scrapeEncountersFromLocationArticle(
+              routeName,
+              pokemonNameMap,
+            );
 
-          return buildValidationFailure(
-            routeName,
-            articleEncounters,
-            classicEncounters,
-            remixEncounters,
-          );
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : "unknown scrape error";
+            return buildValidationFailure(
+              routeName,
+              articleEncounters,
+              classicEncounters,
+              remixEncounters,
+            );
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : "unknown scrape error";
 
-          return {
-            routeName,
-            reasons: [`failed to scrape matching article: ${message}`],
-          } satisfies RouteValidationFailure;
-        }
-      }),
+            return {
+              routeName,
+              reasons: [`failed to scrape matching article: ${message}`],
+            } satisfies RouteValidationFailure;
+          }
+        },
+      ),
     );
 
     for (const failure of batchFailures) {

--- a/src/app/api/sprite/variants/route.ts
+++ b/src/app/api/sprite/variants/route.ts
@@ -1,34 +1,14 @@
 import { type NextRequest, NextResponse } from "next/server";
+import {
+  generateSpriteVariantUrl,
+  getSpriteVariantSuffix,
+} from "@/lib/spriteVariants";
 import type { SpriteVariantsResponse } from "@/types/sprites";
 
 export const revalidate = 86400;
 
 // Request deduplication cache for CDN optimization
 const processingCache = new Map<string, Promise<NextResponse>>();
-
-/**
- * Generate variant suffix for index (0='', 1='a', 2='b', etc.)
- */
-function getVariantSuffix(index: number): string {
-  if (index === 0) return "";
-
-  let result = "";
-  index = index - 1; // Convert to 0-based
-
-  do {
-    result = String.fromCharCode(97 + (index % 26)) + result;
-    index = Math.floor(index / 26);
-  } while (index > 0);
-
-  return result;
-}
-
-/**
- * Generate sprite URL for a fusion or single Pokémon
- */
-function generateSpriteUrl(id: string, variant = ""): string {
-  return `https://ifd-spaces.sfo2.cdn.digitaloceanspaces.com/custom/${id}${variant}.png`;
-}
 
 /**
  * Handle CORS preflight requests
@@ -171,8 +151,8 @@ async function processSpriteVariants(
 
   // Check variants sequentially to maintain order and break early
   for (let i = 0; i < maxVariants; i++) {
-    const variant = getVariantSuffix(i);
-    const url = generateSpriteUrl(id, variant);
+    const variant = getSpriteVariantSuffix(i);
+    const url = generateSpriteVariantUrl(id, variant);
 
     if (await checkSpriteExists(url)) {
       variants.push(variant);

--- a/src/components/Header/MenuItems.tsx
+++ b/src/components/Header/MenuItems.tsx
@@ -10,6 +10,15 @@ const PokemonPCSheet = dynamic(() => import("@/components/pc/PokemonPCSheet"), {
   ssr: false,
 });
 
+const menuActionClassName = clsx(
+  "inline-flex h-10 w-10 items-center justify-center rounded-md lg:h-9 lg:w-9",
+  "bg-transparent text-gray-500 dark:text-gray-400",
+  "hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-700 dark:hover:text-gray-300",
+  "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1",
+  "transition-all duration-150 cursor-pointer",
+  "border border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500",
+);
+
 export default function MenuItems() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<"team" | "box" | "graveyard">(
@@ -25,63 +34,51 @@ export default function MenuItems() {
     setDrawerOpen(false);
   };
 
+  const menuActions = [
+    {
+      label: "Settings",
+      description: "Configure app preferences and options",
+      ariaLabel: "Open Settings",
+      icon: Settings,
+      onClick: () => setSettingsOpen(true),
+    },
+    {
+      label: "Pokémon PC",
+      description: "Manage your team, box, and graveyard",
+      ariaLabel: "Open Pokémon PC",
+      icon: Computer,
+      onClick: handleOpenDrawer,
+    },
+  ];
+
   return (
     <>
       <div className="flex items-center gap-1 lg:mr-3">
-        <CursorTooltip
-          content={
-            <div className="flex flex-col gap-1 min-w-32">
-              <div className="font-medium text-sm">Settings</div>
-              <div className="text-xs text-gray-600 dark:text-gray-300">
-                Configure app preferences and options
-              </div>
-            </div>
-          }
-          delay={300}
-        >
-          <button
-            type="button"
-            className={clsx(
-              "inline-flex h-10 w-10 items-center justify-center rounded-md lg:h-9 lg:w-9",
-              "bg-transparent text-gray-500 dark:text-gray-400",
-              "hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-700 dark:hover:text-gray-300",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1",
-              "transition-all duration-150 cursor-pointer",
-              "border border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500",
-            )}
-            aria-label="Open Settings"
-            onClick={() => setSettingsOpen(true)}
-          >
-            <Settings className="h-4 w-4" />
-          </button>
-        </CursorTooltip>
-        <CursorTooltip
-          content={
-            <div className="flex flex-col gap-1 min-w-32">
-              <div className="font-medium text-sm">Pokémon PC</div>
-              <div className="text-xs text-gray-600 dark:text-gray-300">
-                Manage your team, box, and graveyard
-              </div>
-            </div>
-          }
-          delay={300}
-        >
-          <button
-            type="button"
-            className={clsx(
-              "inline-flex h-10 w-10 items-center justify-center rounded-md lg:h-9 lg:w-9",
-              "bg-transparent text-gray-500 dark:text-gray-400",
-              "hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-700 dark:hover:text-gray-300",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1",
-              "transition-all duration-150 cursor-pointer",
-              "border border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500",
-            )}
-            aria-label="Open Pokémon PC"
-            onClick={handleOpenDrawer}
-          >
-            <Computer className="h-4 w-4" />
-          </button>
-        </CursorTooltip>
+        {menuActions.map(
+          ({ label, description, ariaLabel, icon: Icon, onClick }) => (
+            <CursorTooltip
+              key={label}
+              content={
+                <div className="flex flex-col gap-1 min-w-32">
+                  <div className="font-medium text-sm">{label}</div>
+                  <div className="text-xs text-gray-600 dark:text-gray-300">
+                    {description}
+                  </div>
+                </div>
+              }
+              delay={300}
+            >
+              <button
+                type="button"
+                className={menuActionClassName}
+                aria-label={ariaLabel}
+                onClick={onClick}
+              >
+                <Icon className="h-4 w-4" />
+              </button>
+            </CursorTooltip>
+          ),
+        )}
       </div>
 
       <PokemonPCSheet

--- a/src/lib/__tests__/spriteVariants.test.ts
+++ b/src/lib/__tests__/spriteVariants.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateSpriteVariantUrl,
+  getSpriteVariantSuffix,
+} from "../spriteVariants";
+
+describe("sprite variants", () => {
+  it.each([
+    [0, ""],
+    [1, "a"],
+    [26, "z"],
+    [27, "ba"],
+  ])("maps variant index %i to %s", (index, expected) => {
+    expect(getSpriteVariantSuffix(index)).toBe(expected);
+  });
+
+  it("builds a CDN URL from a sprite ID and variant", () => {
+    expect(generateSpriteVariantUrl("25.125", "b")).toBe(
+      "https://ifd-spaces.sfo2.cdn.digitaloceanspaces.com/custom/25.125b.png",
+    );
+  });
+});

--- a/src/lib/spriteVariants.ts
+++ b/src/lib/spriteVariants.ts
@@ -1,0 +1,20 @@
+const SPRITE_CDN_BASE_URL =
+  "https://ifd-spaces.sfo2.cdn.digitaloceanspaces.com/custom";
+
+export function getSpriteVariantSuffix(index: number): string {
+  if (index === 0) return "";
+
+  let suffix = "";
+  let remaining = index - 1;
+
+  do {
+    suffix = String.fromCharCode(97 + (remaining % 26)) + suffix;
+    remaining = Math.floor(remaining / 26);
+  } while (remaining > 0);
+
+  return suffix;
+}
+
+export function generateSpriteVariantUrl(id: string, variant = ""): string {
+  return `${SPRITE_CDN_BASE_URL}/${id}${variant}.png`;
+}

--- a/src/lib/sprites.ts
+++ b/src/lib/sprites.ts
@@ -1,4 +1,5 @@
 import { getCacheBuster } from "@/lib/persistence";
+import { generateSpriteVariantUrl } from "@/lib/spriteVariants";
 import type {
   SpriteVariantsError,
   SpriteVariantsResponse,
@@ -37,24 +38,7 @@ export function generateSpriteUrl(
   variant = "",
 ): string {
   const id = headId && bodyId ? `${headId}.${bodyId}` : headId || bodyId || "";
-  return `https://ifd-spaces.sfo2.cdn.digitaloceanspaces.com/custom/${id}${variant}.png`;
-}
-
-/**
- * Generate variant suffix for index (0='', 1='a', 2='b', etc.)
- */
-function getVariantSuffix(index: number): string {
-  if (index === 0) return "";
-
-  let result = "";
-  index = index - 1; // Convert to 0-based
-
-  do {
-    result = String.fromCharCode(97 + (index % 26)) + result;
-    index = Math.floor(index / 26);
-  } while (index > 0);
-
-  return result;
+  return generateSpriteVariantUrl(id.toString(), variant);
 }
 
 /**

--- a/src/stores/playthroughs/__tests__/persistence.initialization.test.ts
+++ b/src/stores/playthroughs/__tests__/persistence.initialization.test.ts
@@ -176,6 +176,21 @@ describe("playthrough persistence initialization regression cases", () => {
     expect(state.isLoading).toBe(false);
   });
 
+  it("keeps the fallback usable when localStorage is only partially implemented", async () => {
+    const state = createState();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: { getItem: () => null },
+      configurable: true,
+    });
+    idbMocks.keys.mockRejectedValue(new Error("indexeddb unavailable"));
+
+    await expect(loadFromIndexedDB(state)).resolves.toBeUndefined();
+
+    expect(state.playthroughs).toHaveLength(1);
+    expect(state.activePlaythroughId).toBeDefined();
+    expect(state.isLoading).toBe(false);
+  });
+
   it("migrates old team-member schema when loading a single playthrough", async () => {
     idbMocks.get.mockResolvedValue({
       id: "legacy",

--- a/src/stores/playthroughs/persistence.ts
+++ b/src/stores/playthroughs/persistence.ts
@@ -15,19 +15,35 @@ export const playthroughsStore_idb = createStore("playthroughs", "data");
 export const ACTIVE_PLAYTHROUGH_KEY = "activePlaythroughId";
 
 // LocalStorage helpers for active playthrough ID
-const getActivePlaythroughId = (): string | null => {
+const getLocalStorage = (): Storage | null => {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem(ACTIVE_PLAYTHROUGH_KEY);
+
+  try {
+    return globalThis.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const getActivePlaythroughId = (): string | null => {
+  const storage = getLocalStorage();
+  return typeof storage?.getItem === "function"
+    ? storage.getItem(ACTIVE_PLAYTHROUGH_KEY)
+    : null;
 };
 
 const setActivePlaythroughId = (id: string): void => {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(ACTIVE_PLAYTHROUGH_KEY, id);
+  const storage = getLocalStorage();
+  if (typeof storage?.setItem === "function") {
+    storage.setItem(ACTIVE_PLAYTHROUGH_KEY, id);
+  }
 };
 
 const removeActivePlaythroughId = (): void => {
-  if (typeof window === "undefined") return;
-  localStorage.removeItem(ACTIVE_PLAYTHROUGH_KEY);
+  const storage = getLocalStorage();
+  if (typeof storage?.removeItem === "function") {
+    storage.removeItem(ACTIVE_PLAYTHROUGH_KEY);
+  }
 };
 
 // Migration function to move activePlaythroughId from IndexedDB to LocalStorage

--- a/tests/encounter-output-utils.test.ts
+++ b/tests/encounter-output-utils.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureEncounterOutputDirectories } from "../scripts/utils/encounter-output-utils";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("encounter output directories", () => {
+  it("creates classic and remix directories under the given data directory", async () => {
+    const dataDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), "encounter-output-"),
+    );
+    temporaryDirectories.push(dataDirectory);
+
+    const directories = await ensureEncounterOutputDirectories(dataDirectory);
+
+    expect(directories).toEqual({
+      classicDir: path.join(dataDirectory, "classic"),
+      remixDir: path.join(dataDirectory, "remix"),
+    });
+    await expect(fs.stat(directories.classicDir)).resolves.toMatchObject({
+      isDirectory: expect.any(Function),
+    });
+    await expect(fs.stat(directories.remixDir)).resolves.toMatchObject({
+      isDirectory: expect.any(Function),
+    });
+  });
+});

--- a/tests/generate-data-pr-body.test.ts
+++ b/tests/generate-data-pr-body.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { flattenLocationPokemonEntries } from "../scripts/generate-data-pr-body";
+
+describe("data refresh location normalization", () => {
+  it("preserves encounter precedence and direct-location ordering", () => {
+    expect(
+      flattenLocationPokemonEntries("data/classic/safari-encounters.json", {
+        locations: [
+          {
+            routeName: "Route 1",
+            encounters: [16, { pokemonId: 27, encounterType: "cave" }],
+            pokemonIds: [41],
+            pokemonId: 54,
+          },
+          {
+            routeName: "Route 2",
+            pokemonIds: [41],
+            pokemonId: 54,
+            source: "Gift",
+          },
+        ],
+      }),
+    ).toEqual([
+      { location: "Route 1", source: "Safari Encounters", pokemonId: 16 },
+      { location: "Route 1", source: "cave", pokemonId: 27 },
+      { location: "Route 2", source: "Safari Encounters", pokemonId: 41 },
+      { location: "Route 2", source: "Gift", pokemonId: 54 },
+    ]);
+  });
+
+  it("returns no entries for a non-array payload", () => {
+    expect(
+      flattenLocationPokemonEntries("data/shared/egg-locations.json", {}),
+    ).toEqual([]);
+  });
+});

--- a/tests/generate-spritesheet.test.ts
+++ b/tests/generate-spritesheet.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  fixOverlaps,
+  packSprites,
+  type SpriteInfo,
+} from "../scripts/generate-spritesheet";
+import { rectanglesOverlap } from "../scripts/utils/sprite-packing-utils";
+
+function createSprite(overrides: Partial<SpriteInfo> = {}): SpriteInfo {
+  return {
+    id: 1,
+    name: "Pikachu",
+    filename: "pikachu.png",
+    exists: true,
+    generation: "gen7",
+    originalWidth: 20,
+    originalHeight: 20,
+    contentBounds: { x: 0, y: 0, width: 20, height: 20 },
+    x: 0,
+    y: 0,
+    width: 20,
+    height: 20,
+    ...overrides,
+  };
+}
+
+describe("spritesheet packing policies", () => {
+  it("packs valid sprites without moving missing records", () => {
+    const sprites = [
+      createSprite({ id: 1, width: 40, height: 20 }),
+      createSprite({ id: 2, width: 20, height: 30 }),
+      createSprite({ id: 3, exists: false, contentBounds: null, x: 9, y: 9 }),
+    ];
+
+    const result = packSprites(sprites);
+
+    expect(result.width).toBeGreaterThanOrEqual(40);
+    expect(result.height).toBeGreaterThanOrEqual(30);
+    expect(
+      rectanglesOverlap(sprites[0] as SpriteInfo, sprites[1] as SpriteInfo),
+    ).toBe(false);
+    expect(sprites[2]).toMatchObject({ x: 9, y: 9 });
+  });
+
+  it("repairs a pair by its overlap plus one pixel", () => {
+    const sprites = [
+      createSprite({ x: 0, y: 0, width: 10, height: 10 }),
+      createSprite({ id: 2, x: 5, y: 6, width: 10, height: 10 }),
+    ];
+
+    expect(fixOverlaps(sprites)).toBe(true);
+    expect(sprites[1]).toMatchObject({ x: 11, y: 11 });
+    expect(
+      rectanglesOverlap(sprites[0] as SpriteInfo, sprites[1] as SpriteInfo),
+    ).toBe(false);
+  });
+});

--- a/tests/location-name-normalization.test.ts
+++ b/tests/location-name-normalization.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { cleanLocationName } from "../scripts/utils/location-utils";
+
+describe("location-name normalization", () => {
+  it("returns the stable route name from wiki-formatted input", () => {
+    expect(
+      cleanLocationName("  [[S.S. Anne|S.S. Anne]] (dock) Pokémon Center  "),
+    ).toBe("S.S. Anne Pokemon Center");
+  });
+});

--- a/tests/pokemon-data-processing.test.ts
+++ b/tests/pokemon-data-processing.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { createProcessedPokemonData } from "../scripts/utils/pokemon-data-utils";
+
+describe("Pokemon data processing", () => {
+  it("preserves the project entry identity while assembling PokeAPI data", () => {
+    expect(
+      createProcessedPokemonData(
+        { id: 25, name: "Pikachu" },
+        {
+          id: 25,
+          species: { name: "pikachu" },
+          types: [{ type: { name: "electric" } }],
+        },
+        {
+          is_legendary: false,
+          is_mythical: false,
+          generation: { name: "generation-i" },
+          evolution_chain: {
+            url: "https://pokeapi.co/api/v2/evolution-chain/10/",
+          },
+        },
+        {
+          evolves_from: { id: 172, name: "pichu" },
+          evolves_to: [{ id: 26, name: "raichu" }],
+        },
+      ),
+    ).toEqual({
+      id: 25,
+      nationalDexId: 25,
+      name: "Pikachu",
+      types: [{ name: "electric" }],
+      species: {
+        is_legendary: false,
+        is_mythical: false,
+        generation: "generation-i",
+        evolution_chain: {
+          url: "https://pokeapi.co/api/v2/evolution-chain/10/",
+        },
+      },
+      evolution: {
+        evolves_from: { id: 172, name: "pichu" },
+        evolves_to: [{ id: 26, name: "raichu" }],
+      },
+    });
+  });
+});

--- a/tests/scrape-legendary-encounters.test.ts
+++ b/tests/scrape-legendary-encounters.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { collectLegendaryRouteMapFromHtml } from "../scripts/scrape-legendary-encounters";
+import { buildPokemonNameMap } from "../scripts/utils/pokemon-name-utils";
+
+const pokemonNameMap = buildPokemonNameMap([
+  { id: 144, name: "Articuno" },
+  { id: 1001, name: "Articuno Galarian" },
+  { id: 145, name: "Zapdos" },
+  { id: 1002, name: "Zapdos Galarian" },
+]);
+
+describe("legendary encounter DOM traversal", () => {
+  it("collects forms from the first table after a valid heading", () => {
+    const html = `
+      <div class="mw-parser-output">
+        <h3><span class="mw-headline">Articuno / Zapdos</span></h3>
+        <div>intro</div>
+        <table class="article-table">
+          <tr><td><a>Ignored</a><a>Route 1 (ID 10)</a></td></tr>
+        </table>
+      </div>`;
+
+    expect(
+      Array.from(collectLegendaryRouteMapFromHtml(html, pokemonNameMap)),
+    ).toEqual([["Route 1", [144, 1001, 145, 1002]]]);
+  });
+
+  it("stops searching at a following heading or after ten siblings", () => {
+    const ignoredTable = `<table class="article-table"><tr><td>Route 2</td></tr></table>`;
+    const html = `
+      <div class="mw-parser-output">
+        <h3><span class="mw-headline">Articuno</span></h3>
+        <div></div><div></div><div></div><div></div><div></div>
+        <div></div><div></div><div></div><div></div><div></div>
+        ${ignoredTable}
+        <h3><span class="mw-headline">Table Notes</span></h3>
+        ${ignoredTable}
+      </div>`;
+
+    expect(collectLegendaryRouteMapFromHtml(html, pokemonNameMap)).toEqual(
+      new Map(),
+    );
+  });
+});

--- a/tests/scrape-pokemon-icons.test.ts
+++ b/tests/scrape-pokemon-icons.test.ts
@@ -2,15 +2,18 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  downloadSpriteImage,
-  type SpriteDownloadConfig,
-  type SpriteDownloadIcon,
+import { downloadAllIcons } from "../scripts/scrape-pokemon-icons";
+import { ConsoleFormatter } from "../scripts/utils/console-utils";
+import type {
+  SpriteDownloadConfig,
+  SpriteDownloadIcon,
 } from "../scripts/utils/sprite-download-utils";
+import * as spriteDownloadUtils from "../scripts/utils/sprite-download-utils";
 
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
   await Promise.all(
     temporaryDirectories
@@ -52,9 +55,9 @@ describe("Pokemon icon downloads", () => {
     vi.stubGlobal("fetch", fetchMock);
     await fs.writeFile(path.join(config.spritesDir, icon.filename), "existing");
 
-    await expect(downloadSpriteImage(icon, config, vi.fn())).resolves.toBe(
-      true,
-    );
+    await expect(
+      spriteDownloadUtils.downloadSpriteImage(icon, config, vi.fn()),
+    ).resolves.toBe(true);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -64,7 +67,7 @@ describe("Pokemon icon downloads", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      downloadSpriteImage(
+      spriteDownloadUtils.downloadSpriteImage(
         createIcon({ id: -1, filename: "egg.png" }),
         config,
         vi.fn(),
@@ -92,9 +95,9 @@ describe("Pokemon icon downloads", () => {
       .mockResolvedValueOnce(new Response("base form"));
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(downloadSpriteImage(icon, config, vi.fn(), 1)).resolves.toBe(
-      true,
-    );
+    await expect(
+      spriteDownloadUtils.downloadSpriteImage(icon, config, vi.fn(), 1),
+    ).resolves.toBe(true);
 
     await expect(
       fs.readFile(path.join(config.spritesDir, "lycanroc.png"), "utf-8"),
@@ -104,5 +107,47 @@ describe("Pokemon icon downloads", () => {
       "https://sprites.example/lycanroc.png",
       { headers: { "User-Agent": "Infinite-Fusion-Scraper/1.0" } },
     );
+  });
+
+  it("downloads generation batches in order with cumulative progress", async () => {
+    const progressBar = { stop: vi.fn(), update: vi.fn() };
+    vi.spyOn(ConsoleFormatter, "createProgressBar").mockReturnValue(
+      progressBar as never,
+    );
+    vi.spyOn(ConsoleFormatter, "working").mockImplementation(() => {});
+    vi.spyOn(ConsoleFormatter, "success").mockImplementation(() => {});
+    vi.spyOn(ConsoleFormatter, "warn").mockImplementation(() => {});
+    vi.spyOn(spriteDownloadUtils, "spriteFileExists")
+      .mockResolvedValueOnce(true)
+      .mockResolvedValue(false);
+    vi.spyOn(spriteDownloadUtils, "downloadSpriteImage").mockResolvedValue(
+      true,
+    );
+
+    const gen7Icons = Array.from({ length: 11 }, (_, index) =>
+      createIcon({ filename: `gen7-${index}.png`, generation: "gen7" }),
+    );
+    const gen8Icon = createIcon({ filename: "gen8.png", generation: "gen8" });
+
+    await expect(downloadAllIcons([...gen7Icons, gen8Icon])).resolves.toEqual({
+      downloaded: 11,
+      skipped: 1,
+      errors: 0,
+    });
+    expect(progressBar.update).toHaveBeenNthCalledWith(
+      1,
+      10,
+      expect.objectContaining({
+        status: "Gen 7: New: 9, Skipped: 1, Errors: 0",
+      }),
+    );
+    expect(progressBar.update).toHaveBeenNthCalledWith(
+      3,
+      12,
+      expect.objectContaining({
+        status: "Gen 8: New: 11, Skipped: 1, Errors: 0",
+      }),
+    );
+    expect(progressBar.stop).toHaveBeenCalledOnce();
   });
 });

--- a/tests/scrape-pokemon-icons.test.ts
+++ b/tests/scrape-pokemon-icons.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  downloadSpriteImage,
+  type SpriteDownloadConfig,
+  type SpriteDownloadIcon,
+} from "../scripts/utils/sprite-download-utils";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { force: true, recursive: true })),
+  );
+});
+
+async function createConfig(): Promise<SpriteDownloadConfig> {
+  const spritesDir = await fs.mkdtemp(path.join(os.tmpdir(), "sprite-icons-"));
+  temporaryDirectories.push(spritesDir);
+
+  return {
+    name: "gen8",
+    baseUrl: "https://sprites.example",
+    spritesDir,
+    eggSpriteUrl: "https://sprites.example/egg.png",
+  };
+}
+
+function createIcon(
+  overrides: Partial<SpriteDownloadIcon> = {},
+): SpriteDownloadIcon {
+  return {
+    id: 25,
+    name: "Pikachu",
+    url: "https://sprites.example/pikachu.png",
+    filename: "pikachu.png",
+    generation: "gen8",
+    ...overrides,
+  };
+}
+
+describe("Pokemon icon downloads", () => {
+  it("skips an existing sprite without fetching", async () => {
+    const config = await createConfig();
+    const icon = createIcon();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await fs.writeFile(path.join(config.spritesDir, icon.filename), "existing");
+
+    await expect(downloadSpriteImage(icon, config, vi.fn())).resolves.toBe(
+      true,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("writes the configured egg sprite", async () => {
+    const config = await createConfig();
+    const fetchMock = vi.fn().mockResolvedValue(new Response("egg"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      downloadSpriteImage(
+        createIcon({ id: -1, filename: "egg.png" }),
+        config,
+        vi.fn(),
+      ),
+    ).resolves.toBe(true);
+
+    await expect(
+      fs.readFile(path.join(config.spritesDir, "egg.png"), "utf-8"),
+    ).resolves.toBe("egg");
+    expect(fetchMock).toHaveBeenCalledWith(config.eggSpriteUrl, {
+      headers: { "User-Agent": "Infinite-Fusion-Scraper/1.0" },
+    });
+  });
+
+  it("falls back to the base form after a first-attempt 404", async () => {
+    const config = await createConfig();
+    const icon = createIcon({
+      name: "Lycanroc Midday Form",
+      url: "https://sprites.example/lycanroc-midday.png",
+      filename: "lycanroc-midday.png",
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response("base form"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(downloadSpriteImage(icon, config, vi.fn(), 1)).resolves.toBe(
+      true,
+    );
+
+    await expect(
+      fs.readFile(path.join(config.spritesDir, "lycanroc.png"), "utf-8"),
+    ).resolves.toBe("base form");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://sprites.example/lycanroc.png",
+      { headers: { "User-Agent": "Infinite-Fusion-Scraper/1.0" } },
+    );
+  });
+});

--- a/tests/scrape-pokemon-icons.test.ts
+++ b/tests/scrape-pokemon-icons.test.ts
@@ -79,6 +79,7 @@ describe("Pokemon icon downloads", () => {
     ).resolves.toBe("egg");
     expect(fetchMock).toHaveBeenCalledWith(config.eggSpriteUrl, {
       headers: { "User-Agent": "Infinite-Fusion-Scraper/1.0" },
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -105,7 +106,10 @@ describe("Pokemon icon downloads", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       "https://sprites.example/lycanroc.png",
-      { headers: { "User-Agent": "Infinite-Fusion-Scraper/1.0" } },
+      {
+        headers: { "User-Agent": "Infinite-Fusion-Scraper/1.0" },
+        signal: expect.any(AbortSignal),
+      },
     );
   });
 

--- a/tests/scrape-safari-encounters.test.ts
+++ b/tests/scrape-safari-encounters.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { detectEncounterType } from "../scripts/scrape-safari-encounters";
+
+describe("Safari encounter type detection", () => {
+  it.each([
+    ["Surf", "surf"],
+    ["Super Rod", "fishing"],
+    ["Headbutt encounters", "rock_smash"],
+    ["Underground cave", "cave"],
+    ["Overworld gift", "special"],
+    ["Tall grass", "grass"],
+  ] as const)("maps %s to %s", (text, expectedType) => {
+    expect(detectEncounterType(text)).toBe(expectedType);
+  });
+});

--- a/tests/scrape-wild-encounters-wikitext.test.ts
+++ b/tests/scrape-wild-encounters-wikitext.test.ts
@@ -71,6 +71,47 @@ describe("Wild encounter wikitext parser", () => {
     expect(encounters).toEqual([{ pokemonId: 27, encounterType: "grass" }]);
   });
 
+  it("keeps nested link pipes within their template argument", () => {
+    const wikitext = [
+      "{{EncounterTable/Header}}",
+      "{{EncounterTable/Section|Grass}}",
+      "{{EncounterTable/Data|invalid|[[Psyduck|Psyduck]]|8|100%}}",
+      "{{EncounterTable/Footer}}",
+    ].join("\n");
+
+    expect(
+      parseEncounterTemplatesFromWikitext(
+        wikitext,
+        pokemonNameMap,
+        "unit test",
+      ),
+    ).toEqual([{ pokemonId: 54, encounterType: "grass" }]);
+  });
+
+  it("stops adding data after unsupported sections and footers", () => {
+    const wikitext = [
+      "{{EncounterTable/Header}}",
+      "{{EncounterTable/Data|016|Pidgey|3|100%}}",
+      "{{EncounterTable/Section|Special}}",
+      "{{EncounterTable/Data|027|Sandshrew|3|100%}}",
+      "{{EncounterTable/Header}}",
+      "{{EncounterTable/Data|041|Zubat|3|100%}}",
+      "{{EncounterTable/Footer}}",
+      "{{EncounterTable/Data|054|Psyduck|3|100%}}",
+    ].join("\n");
+
+    expect(
+      parseEncounterTemplatesFromWikitext(
+        wikitext,
+        pokemonNameMap,
+        "unit test",
+      ),
+    ).toEqual([
+      { pokemonId: 16, encounterType: "grass" },
+      { pokemonId: 41, encounterType: "grass" },
+    ]);
+  });
+
   it("throws on unresolved EncounterTable/Data rows to avoid silent partial output", () => {
     const wikitext = [
       "{{EncounterTable/Header}}",

--- a/tests/script-runtime-utils.test.ts
+++ b/tests/script-runtime-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  formatScriptError,
+  isDirectScriptExecution,
+  runDirectScript,
+} from "../scripts/utils/script-runtime-utils";
+
+describe("script runtime utilities", () => {
+  it("formats known and unknown script failures", () => {
+    expect(
+      formatScriptError("Scraping failed", new Error("network down")),
+    ).toBe("Scraping failed: network down");
+    expect(formatScriptError("Scraping failed", "network down")).toBe(
+      "Scraping failed: Unknown error",
+    );
+  });
+
+  it("identifies only the direct script entrypoint", () => {
+    expect(
+      isDirectScriptExecution(
+        "file:///workspace/scripts/scrape-wild-encounters.ts",
+        "/workspace/scripts/scrape-wild-encounters.ts",
+      ),
+    ).toBe(true);
+    expect(
+      isDirectScriptExecution(
+        "file:///workspace/scripts/scrape-wild-encounters.ts",
+        "/workspace/tests/scrape-wild-encounters.test.ts",
+      ),
+    ).toBe(false);
+  });
+
+  it("starts only direct-entry script modules", () => {
+    const main = vi.fn().mockResolvedValue(undefined);
+
+    runDirectScript(
+      "file:///workspace/scripts/scrape-wild-encounters.ts",
+      main,
+      "/workspace/scripts/scrape-wild-encounters.ts",
+    );
+
+    expect(main).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/sprite-packing-utils.test.ts
+++ b/tests/sprite-packing-utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  findFirstOverlappingPair,
+  forEachOverlappingPair,
+  getPackedBounds,
+  rectanglesOverlap,
+} from "../scripts/utils/sprite-packing-utils";
+
+describe("sprite packing geometry", () => {
+  it("treats shared edges as non-overlapping", () => {
+    expect(
+      rectanglesOverlap(
+        { x: 0, y: 0, width: 10, height: 10 },
+        { x: 10, y: 0, width: 10, height: 10 },
+      ),
+    ).toBe(false);
+  });
+
+  it("detects intersecting rectangles", () => {
+    expect(
+      rectanglesOverlap(
+        { x: 0, y: 0, width: 10, height: 10 },
+        { x: 9, y: 9, width: 10, height: 10 },
+      ),
+    ).toBe(true);
+  });
+
+  it("returns the outer bounds of packed rectangles", () => {
+    expect(
+      getPackedBounds([
+        { x: 0, y: 0, width: 12, height: 8 },
+        { x: 12, y: 3, width: 10, height: 11 },
+      ]),
+    ).toEqual({ width: 22, height: 14 });
+  });
+
+  it("finds and visits overlapping pairs without visiting disjoint rectangles", () => {
+    const rectangles = [
+      { x: 0, y: 0, width: 10, height: 10 },
+      { x: 9, y: 0, width: 10, height: 10 },
+      { x: 30, y: 0, width: 10, height: 10 },
+    ];
+    const visited: Array<[number, number]> = [];
+
+    expect(
+      forEachOverlappingPair(rectangles, (a, b) => {
+        visited.push([rectangles.indexOf(a), rectangles.indexOf(b)]);
+        return false;
+      }),
+    ).toBe(true);
+    expect(visited).toEqual([[0, 1]]);
+    expect(findFirstOverlappingPair(rectangles)).toEqual([
+      rectangles[0],
+      rectangles[1],
+    ]);
+  });
+});

--- a/tests/sprite-source-utils.test.ts
+++ b/tests/sprite-source-utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getSpriteSourcePaths } from "../scripts/utils/sprite-source-utils";
+
+describe("sprite source paths", () => {
+  it("derives the shared source and generation directories from a script URL", () => {
+    expect(
+      getSpriteSourcePaths(
+        "file:///tmp/project/scripts/generate-spritesheet.ts",
+      ),
+    ).toEqual({
+      scriptDirectory: "/tmp/project/scripts",
+      baseEntriesPath: "/tmp/project/data/shared/base-entries.json",
+      spritesBaseDir: "/tmp/project/scripts/sprites",
+      gen7SpritesDir: "/tmp/project/scripts/sprites/pokemon-gen7",
+      gen8SpritesDir: "/tmp/project/scripts/sprites/pokemon-gen8",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Consolidate scraper, sprite, and data-refresh pipeline logic behind deterministic helpers and focused tests. The remaining UI/store cleanup stays outside this change.

## Changes
- Extract shared sprite, encounter-output, runtime, and data-normalization helpers.
- Make script imports safe for direct policy and fixture tests.
- Split wild-wikitext parsing, legendary traversal, spritesheet packing, and wiki transport into testable stages.
- Harden playthrough persistence when browser storage is incomplete.
- Record completed pipeline stages and narrow CLI complexity exceptions in the remediation plan.

## Risk
Script refactors preserve output order, source-specific summaries, parser failure behavior, and direct-execution guards. License generation and route-article validation retain narrow Fallow suppressions because their CLI orchestration combines subprocess, filesystem, network, and process-exit behavior.

## Testing
- `pnpm type-check`
- `pnpm test:run` (1053 passed, 2 skipped)
- `pnpm validate`
- `pnpm quality:graph:json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence behavior when browser storage is unavailable or incomplete.
  * Improved sprite variant URL generation and fallback downloading.
  * Improved encounter, location, Pokémon, and wiki data processing reliability.

* **Enhancements**
  * Scraping now formats generated data automatically.
  * Added more robust sprite packing, overlap handling, and image downloading.
  * Standardized script execution and error handling.

* **Tests**
  * Added coverage for scraping, data processing, sprite handling, storage fallback, route parsing, and encounter output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->