### PR TITLE
feat(motion): respect reduced motion

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,11 @@ const nextConfig: NextConfig = {
   // Enable React Compiler for automatic performance optimizations
   reactCompiler: true,
 
+  experimental: {
+    // TypeScript 7 has no compiler API for Next's default type checker.
+    useTypeScriptCli: true,
+  },
+
   // Enable Turbopack for faster development builds
   turbopack: {
     // Use default Turbopack configuration

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "lucide-react": "^1.26.0",
     "mitt": "^3.0.1",
     "ms": "^2.1.3",
-    "next": "16.2.10",
+    "next": "16.2.12",
     "next-themes": "^0.4.6",
     "poke-types": "^1.0.22",
     "pokedex-promise-v2": "^4.2.3",
@@ -94,7 +94,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.5",
-    "@next/bundle-analyzer": "^16.2.11",
+    "@next/bundle-analyzer": "^16.2.12",
     "@svgr/webpack": "^8.1.0",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/jest-dom": "^6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
         version: 3.14.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.1(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
@@ -81,8 +81,8 @@ importers:
         specifier: ^2.1.3
         version: 2.1.3
       next:
-        specifier: 16.2.10
-        version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 16.2.12
+        version: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -130,8 +130,8 @@ importers:
         specifier: ^2.5.5
         version: 2.5.5
       '@next/bundle-analyzer':
-        specifier: ^16.2.11
-        version: 16.2.11(bufferutil@4.0.9)
+        specifier: ^16.2.12
+        version: 16.2.12(bufferutil@4.0.9)
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@7.0.2)
@@ -943,6 +943,9 @@ packages:
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
@@ -1431,60 +1434,60 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/bundle-analyzer@16.2.11':
-    resolution: {integrity: sha512-C5228wy1RC0g7uOSvmQhrZXCuEeLIPureKkqramAkySmqY2Y0yw6K+TyAxXXvtrYe4uehnZs3YMFfJcorBRwpg==}
+  '@next/bundle-analyzer@16.2.12':
+    resolution: {integrity: sha512-0dYhmCYsTMFYUFaoEUx+VKw/oYP6b3XiGgq47EujXTE2UGgwVWAaur2tbko2pxfUka3WRZ9YWxa3PlSv3luWNQ==}
 
-  '@next/env@16.2.10':
-    resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
+  '@next/env@16.2.12':
+    resolution: {integrity: sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==}
 
-  '@next/swc-darwin-arm64@16.2.10':
-    resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
+  '@next/swc-darwin-arm64@16.2.12':
+    resolution: {integrity: sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.10':
-    resolution: {integrity: sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==}
+  '@next/swc-darwin-x64@16.2.12':
+    resolution: {integrity: sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.10':
-    resolution: {integrity: sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==}
+  '@next/swc-linux-arm64-gnu@16.2.12':
+    resolution: {integrity: sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.10':
-    resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
+  '@next/swc-linux-arm64-musl@16.2.12':
+    resolution: {integrity: sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.10':
-    resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
+  '@next/swc-linux-x64-gnu@16.2.12':
+    resolution: {integrity: sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.10':
-    resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
+  '@next/swc-linux-x64-musl@16.2.12':
+    resolution: {integrity: sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.10':
-    resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
+  '@next/swc-win32-arm64-msvc@16.2.12':
+    resolution: {integrity: sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.10':
-    resolution: {integrity: sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==}
+  '@next/swc-win32-x64-msvc@16.2.12':
+    resolution: {integrity: sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2755,6 +2758,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.11.3:
+    resolution: {integrity: sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -3938,8 +3946,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.10:
-    resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
+  next@16.2.12:
+    resolution: {integrity: sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4900,8 +4908,8 @@ packages:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
     engines: {node: '>=20'}
 
-  ws@7.5.12:
-    resolution: {integrity: sha512-1xGnbYN3zbog9CwuNDQULNRrTCLIn46/WmpR1f0w6PsCYQHkylZr5vkd6kfMZYV6pRnQkcPNRyiA8LsrNKyhpg==}
+  ws@7.5.13:
+    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
     engines: {node: '>=8.3.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5842,6 +5850,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
@@ -6133,7 +6146,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/runtime': 1.11.3
     optional: true
 
   '@img/sharp-wasm32@0.35.3':
@@ -6217,37 +6230,37 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@next/bundle-analyzer@16.2.11(bufferutil@4.0.9)':
+  '@next/bundle-analyzer@16.2.12(bufferutil@4.0.9)':
     dependencies:
       webpack-bundle-analyzer: 4.10.1(bufferutil@4.0.9)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@next/env@16.2.10': {}
+  '@next/env@16.2.12': {}
 
-  '@next/swc-darwin-arm64@16.2.10':
+  '@next/swc-darwin-arm64@16.2.12':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.10':
+  '@next/swc-darwin-x64@16.2.12':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.10':
+  '@next/swc-linux-arm64-gnu@16.2.12':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.10':
+  '@next/swc-linux-arm64-musl@16.2.12':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.10':
+  '@next/swc-linux-x64-gnu@16.2.12':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.10':
+  '@next/swc-linux-x64-musl@16.2.12':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.10':
+  '@next/swc-win32-arm64-msvc@16.2.12':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.10':
+  '@next/swc-win32-x64-msvc@16.2.12':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6966,14 +6979,14 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@vercel/analytics@2.0.1(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/analytics@2.0.1(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
-      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
-  '@vercel/speed-insights@2.0.0(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/speed-insights@2.0.0(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
-      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
   '@vitejs/plugin-react@6.0.4(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(jiti@2.7.0)(terser@5.43.1)(yaml@2.9.0))':
@@ -7253,6 +7266,8 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.43: {}
+
+  baseline-browser-mapping@2.11.3: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -8491,25 +8506,25 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 16.2.10
+      '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.43
+      baseline-browser-mapping: 2.11.3
       caniuse-lite: 1.0.30001806
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.10
-      '@next/swc-darwin-x64': 16.2.10
-      '@next/swc-linux-arm64-gnu': 16.2.10
-      '@next/swc-linux-arm64-musl': 16.2.10
-      '@next/swc-linux-x64-gnu': 16.2.10
-      '@next/swc-linux-x64-musl': 16.2.10
-      '@next/swc-win32-arm64-msvc': 16.2.10
-      '@next/swc-win32-x64-msvc': 16.2.10
+      '@next/swc-darwin-arm64': 16.2.12
+      '@next/swc-darwin-x64': 16.2.12
+      '@next/swc-linux-arm64-gnu': 16.2.12
+      '@next/swc-linux-arm64-musl': 16.2.12
+      '@next/swc-linux-x64-gnu': 16.2.12
+      '@next/swc-linux-x64-musl': 16.2.12
+      '@next/swc-win32-arm64-msvc': 16.2.12
+      '@next/swc-win32-x64-msvc': 16.2.12
       '@opentelemetry/api': 1.9.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
@@ -9563,7 +9578,7 @@ snapshots:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      ws: 7.5.12(bufferutil@4.0.9)
+      ws: 7.5.13(bufferutil@4.0.9)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9650,7 +9665,7 @@ snapshots:
       string-width: 8.2.2
       strip-ansi: 7.2.0
 
-  ws@7.5.12(bufferutil@4.0.9):
+  ws@7.5.13(bufferutil@4.0.9):
     optionalDependencies:
       bufferutil: 4.0.9
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -456,3 +456,35 @@ button:disabled,
 [aria-disabled="true"] {
   @apply cursor-not-allowed;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  html:not([data-reduced-motion]),
+  html:not([data-reduced-motion]) * {
+    scroll-behavior: auto !important;
+  }
+
+  html:not([data-reduced-motion]) *,
+  html:not([data-reduced-motion]) *::before,
+  html:not([data-reduced-motion]) *::after {
+    animation-duration: 0.01ms !important;
+    animation-delay: 0ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+  }
+}
+
+html[data-reduced-motion="true"],
+html[data-reduced-motion="true"] * {
+  scroll-behavior: auto !important;
+}
+
+html[data-reduced-motion="true"] *,
+html[data-reduced-motion="true"] *::before,
+html[data-reduced-motion="true"] *::after {
+  animation-duration: 0.01ms !important;
+  animation-delay: 0ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  transition-delay: 0ms !important;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -466,11 +466,8 @@ button:disabled,
   html:not([data-reduced-motion]) *,
   html:not([data-reduced-motion]) *::before,
   html:not([data-reduced-motion]) *::after {
-    animation-duration: 0.01ms !important;
-    animation-delay: 0ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    transition-delay: 0ms !important;
+    animation: none !important;
+    transition: none !important;
   }
 }
 
@@ -482,9 +479,6 @@ html[data-reduced-motion="true"] * {
 html[data-reduced-motion="true"] *,
 html[data-reduced-motion="true"] *::before,
 html[data-reduced-motion="true"] *::after {
-  animation-duration: 0.01ms !important;
-  animation-delay: 0ms !important;
-  animation-iteration-count: 1 !important;
-  transition-duration: 0.01ms !important;
-  transition-delay: 0ms !important;
+  animation: none !important;
+  transition: none !important;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,7 +73,7 @@ const REDUCED_MOTION_INITIALIZER = `
     if (typeof preference === "boolean") {
       document.documentElement.dataset.reducedMotion = String(preference);
     }
-  } catch {}
+  } catch (error) {}
 `;
 
 const STRUCTURED_DATA_JSON = JSON.stringify(STRUCTURED_DATA);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,6 +65,17 @@ const STRUCTURED_DATA = {
   ],
 };
 
+const REDUCED_MOTION_INITIALIZER = `
+  try {
+    const versioned = localStorage.getItem("settings:v1");
+    const stored = versioned || localStorage.getItem("settings");
+    const preference = stored ? JSON.parse(stored).reducedMotion : undefined;
+    if (typeof preference === "boolean") {
+      document.documentElement.dataset.reducedMotion = String(preference);
+    }
+  } catch {}
+`;
+
 const STRUCTURED_DATA_JSON = JSON.stringify(STRUCTURED_DATA);
 
 export const metadata: Metadata = {
@@ -159,6 +170,7 @@ export default function RootLayout({
           content="Infinite Fusion Nuzlocke Tracker"
         />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <script>{REDUCED_MOTION_INITIALIZER}</script>
         <script type="application/ld+json">{STRUCTURED_DATA_JSON}</script>
       </head>
       <body className="antialiased font-sans">

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { ReducedMotionController } from "@/components/ReducedMotionController";
 import { ThemeProvider } from "@/components/theme/ThemeProvider";
 import { GlobalTooltipProvider } from "@/contexts/GlobalTooltipContext";
 import { queryClient } from "@/lib/client";
@@ -14,6 +15,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       )}
       <ThemeProvider>
         <GlobalTooltipProvider>
+          <ReducedMotionController />
           <PlaythroughResumeObserver />
           {children}
         </GlobalTooltipProvider>

--- a/src/components/CursorTooltip.tsx
+++ b/src/components/CursorTooltip.tsx
@@ -28,7 +28,9 @@ import {
 import { twMerge } from "tailwind-merge";
 import { useSnapshot } from "valtio";
 import { useGlobalTooltip } from "@/contexts/GlobalTooltipContext";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { useWindowVisibility } from "@/hooks/useWindowVisibility";
+import { settingsStore } from "@/stores/settings";
 import { dragStore } from "../stores/dragStore";
 
 // Helper functions to calculate offsets based on placement
@@ -91,6 +93,8 @@ export function CursorTooltip(props: CursorTooltipProps) {
   }, [animationState]);
   const isWindowVisible = useWindowVisibility();
   const dragSnapshot = useSnapshot(dragStore);
+  const settings = useSnapshot(settingsStore);
+  const reducedMotion = useReducedMotion(settings.reducedMotion);
   const { isAnyTooltipVisible, registerTooltip } = useGlobalTooltip();
   const shouldDisableTooltip =
     disabled ||
@@ -123,8 +127,17 @@ export function CursorTooltip(props: CursorTooltipProps) {
           );
         }
         setIsOpen(true);
+        if (reducedMotion) {
+          setAnimationState(null);
+          return;
+        }
         setAnimationState("entering");
       } else {
+        if (reducedMotion) {
+          setIsOpen(false);
+          setAnimationState(null);
+          return;
+        }
         setAnimationState("exiting");
       }
 

--- a/src/components/CursorTooltip.tsx
+++ b/src/components/CursorTooltip.tsx
@@ -128,12 +128,14 @@ export function CursorTooltip(props: CursorTooltipProps) {
         }
         setIsOpen(true);
         if (reducedMotion) {
+          animationBatchRef.current += 1;
           setAnimationState(null);
           return;
         }
         setAnimationState("entering");
       } else {
         if (reducedMotion) {
+          animationBatchRef.current += 1;
           setIsOpen(false);
           setAnimationState(null);
           return;
@@ -257,6 +259,7 @@ export function CursorTooltip(props: CursorTooltipProps) {
 
   const clientPointFloating = useClientPoint(context, {
     axis: "both",
+    enabled: !reducedMotion,
   });
 
   // Normalize delay to object format

--- a/src/components/CursorTooltip.tsx
+++ b/src/components/CursorTooltip.tsx
@@ -21,6 +21,7 @@ import {
   isValidElement,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -206,6 +207,12 @@ export function CursorTooltip(props: CursorTooltipProps) {
       return cleanup;
     },
   });
+
+  useLayoutEffect(() => {
+    if (!reducedMotion || !refs.domReference.current) return;
+
+    refs.setPositionReference(refs.domReference.current);
+  }, [reducedMotion, refs]);
 
   useEffect(() => {
     if (!tooltipId) return;

--- a/src/components/Header/SettingsModal.tsx
+++ b/src/components/Header/SettingsModal.tsx
@@ -10,10 +10,11 @@ import {
   Switch,
 } from "@headlessui/react";
 import clsx from "clsx";
-import { Monitor, Moon, Move, Sun, X } from "lucide-react";
+import { Monitor, Moon, Move, Rabbit, Sun, X } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useSnapshot } from "valtio";
 import { useMounted } from "@/hooks/useMounted";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { settingsActions, settingsStore } from "@/stores/settings";
 
 interface SettingsModalProps {
@@ -25,6 +26,7 @@ export default function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const { theme, setTheme } = useTheme();
   const mounted = useMounted();
   const settings = useSnapshot(settingsStore);
+  const reducedMotion = useReducedMotion(settings.reducedMotion);
 
   if (mounted === false) {
     return null;
@@ -121,6 +123,29 @@ export default function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               <Switch
                 checked={settings.moveEncountersBetweenLocations}
                 onChange={settingsActions.toggleMoveEncountersBetweenLocations}
+                className="group inline-flex h-6 w-11 items-center rounded-full bg-gray-200 dark:bg-gray-700 transition data-checked:bg-blue-600"
+              >
+                <span className="size-4 translate-x-1 rounded-full bg-white transition group-data-checked:translate-x-6" />
+              </Switch>
+            </Field>
+
+            <Field className="flex items-center justify-between p-3 rounded-lg border border-gray-200 dark:border-gray-700">
+              <div className="flex items-center gap-3">
+                <div className="flex-shrink-0 p-2 rounded-md bg-gray-100 dark:bg-gray-800">
+                  <Rabbit className="h-4 w-4 text-gray-600 dark:text-gray-300" />
+                </div>
+                <div>
+                  <Label className="text-sm font-medium text-gray-900 dark:text-white">
+                    Reduced Motion
+                  </Label>
+                  <Description className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    Limit animations and smooth scrolling
+                  </Description>
+                </div>
+              </div>
+              <Switch
+                checked={reducedMotion}
+                onChange={settingsActions.setReducedMotion}
                 className="group inline-flex h-6 w-11 items-center rounded-full bg-gray-200 dark:bg-gray-700 transition data-checked:bg-blue-600"
               >
                 <span className="size-4 translate-x-1 rounded-full bg-white transition group-data-checked:translate-x-6" />

--- a/src/components/Header/__tests__/SettingsModal.test.tsx
+++ b/src/components/Header/__tests__/SettingsModal.test.tsx
@@ -1,0 +1,63 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SettingsModal from "../SettingsModal";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "system", setTheme: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useMounted", () => ({
+  useMounted: () => true,
+}));
+
+vi.mock("@/stores/settings", async () => {
+  const { proxy } = await import("valtio");
+  const settingsStore = proxy({
+    moveEncountersBetweenLocations: false,
+    reducedMotion: undefined as boolean | undefined,
+  });
+
+  return {
+    settingsStore,
+    settingsActions: {
+      setReducedMotion: (reducedMotion: boolean) => {
+        settingsStore.reducedMotion = reducedMotion;
+      },
+      toggleMoveEncountersBetweenLocations: () => {
+        settingsStore.moveEncountersBetweenLocations =
+          !settingsStore.moveEncountersBetweenLocations;
+      },
+    },
+  };
+});
+
+describe("SettingsModal", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it.each([true, false])(
+    "initially reflects the browser reduced-motion preference (%s)",
+    (matches) => {
+      vi.stubGlobal(
+        "matchMedia",
+        vi.fn().mockReturnValue({
+          matches,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }),
+      );
+
+      render(<SettingsModal isOpen={true} onClose={vi.fn()} />);
+
+      expect(
+        screen
+          .getByRole("switch", { name: "Reduced Motion" })
+          .getAttribute("aria-checked"),
+      ).toBe(String(matches));
+    },
+  );
+});

--- a/src/components/PokemonSummaryCard/FusionSprite.tsx
+++ b/src/components/PokemonSummaryCard/FusionSprite.tsx
@@ -5,10 +5,12 @@ import type React from "react";
 import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
 
 import { twMerge } from "tailwind-merge";
+import { useSnapshot } from "valtio";
 import Rays from "@/assets/images/rays.svg";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { usePreferredVariantState } from "@/hooks/useSprite";
-
 import type { PokemonOptionType } from "@/loaders/pokemon";
+import { settingsStore } from "@/stores/settings";
 import { useAnimatedSprite } from "./useAnimatedSprite";
 import {
   getAltText,
@@ -44,6 +46,8 @@ export const FusionSprite = forwardRef<FusionSpriteHandle, FusionSpriteProps>(
     ref,
   ) {
     const hasHovered = useRef(false);
+    const settings = useSnapshot(settingsStore);
+    const reducedMotion = useReducedMotion(settings.reducedMotion);
 
     const head = headPokemon;
     const body = bodyPokemon;
@@ -92,6 +96,7 @@ export const FusionSprite = forwardRef<FusionSpriteHandle, FusionSpriteProps>(
       playEvolutionAnimation,
     } = useAnimatedSprite({
       canAnimate: statusState.canAnimate,
+      reducedMotion,
     });
 
     useImperativeHandle(

--- a/src/components/PokemonSummaryCard/useAnimatedSprite.ts
+++ b/src/components/PokemonSummaryCard/useAnimatedSprite.ts
@@ -1,19 +1,35 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 interface UseAnimatedSpriteOptions {
   canAnimate: boolean;
+  reducedMotion: boolean;
 }
 
-export function useAnimatedSprite({ canAnimate }: UseAnimatedSpriteOptions) {
+export function useAnimatedSprite({
+  canAnimate,
+  reducedMotion,
+}: UseAnimatedSpriteOptions) {
   const imageRef = useRef<HTMLImageElement>(null);
   const shadowRef = useRef<HTMLImageElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
   const raysSvgRef = useRef<HTMLDivElement>(null);
   const hoverRef = useRef<boolean>(false);
+  const reducedMotionRef = useRef(reducedMotion);
+
+  reducedMotionRef.current = reducedMotion;
+
+  useEffect(() => {
+    if (!reducedMotion) return;
+
+    hoverRef.current = false;
+    [imageRef, shadowRef, overlayRef, raysSvgRef].forEach((ref) => {
+      ref.current?.getAnimations().forEach((animation) => animation.cancel());
+    });
+  }, [reducedMotion]);
 
   const handleMouseEnter = () => {
     hoverRef.current = true;
-    if (imageRef.current && canAnimate) {
+    if (imageRef.current && canAnimate && !reducedMotion) {
       // Cancel any running animations so the new one will replay
       imageRef.current.getAnimations().forEach((anim) => {
         anim.cancel();
@@ -25,6 +41,8 @@ export function useAnimatedSprite({ canAnimate }: UseAnimatedSpriteOptions) {
       }
 
       const animateSprite = () => {
+        if (!hoverRef.current || reducedMotionRef.current) return;
+
         const animation = imageRef.current?.animate(
           [
             { transform: "translateY(0px)" },
@@ -59,7 +77,7 @@ export function useAnimatedSprite({ canAnimate }: UseAnimatedSpriteOptions) {
 
         if (animation) {
           animation.onfinish = () => {
-            if (hoverRef.current) {
+            if (hoverRef.current && !reducedMotionRef.current) {
               window.requestAnimationFrame(animateSprite);
             }
           };
@@ -95,7 +113,8 @@ export function useAnimatedSprite({ canAnimate }: UseAnimatedSpriteOptions) {
   };
 
   const playEvolutionAnimation = () => {
-    // Evolution animations should always play regardless of canAnimate state
+    if (reducedMotion) return;
+
     // Cancel any existing animations
     imageRef.current?.getAnimations().forEach((a) => {
       a.cancel();

--- a/src/components/PokemonSummaryCard/useAnimatedSprite.ts
+++ b/src/components/PokemonSummaryCard/useAnimatedSprite.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 
 interface UseAnimatedSpriteOptions {
   canAnimate: boolean;
@@ -16,9 +16,8 @@ export function useAnimatedSprite({
   const hoverRef = useRef<boolean>(false);
   const reducedMotionRef = useRef(reducedMotion);
 
-  reducedMotionRef.current = reducedMotion;
-
-  useEffect(() => {
+  useLayoutEffect(() => {
+    reducedMotionRef.current = reducedMotion;
     if (!reducedMotion) return;
 
     hoverRef.current = false;

--- a/src/components/ReducedMotionController.tsx
+++ b/src/components/ReducedMotionController.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSnapshot } from "valtio";
+import { settingsStore } from "@/stores/settings";
+
+export function ReducedMotionController() {
+  const settings = useSnapshot(settingsStore);
+
+  useEffect(() => {
+    if (typeof settings.reducedMotion === "boolean") {
+      document.documentElement.dataset.reducedMotion = String(
+        settings.reducedMotion,
+      );
+      return;
+    }
+
+    delete document.documentElement.dataset.reducedMotion;
+  }, [settings.reducedMotion]);
+
+  return null;
+}

--- a/src/components/playthrough/PlaythroughSelector.tsx
+++ b/src/components/playthrough/PlaythroughSelector.tsx
@@ -235,6 +235,7 @@ export default function PlaythroughSelector({
                 />
               </PopoverButton>
               <PopoverPanel
+                transition
                 anchor={{ to: "bottom end", gap: "12px" }}
                 className={clsx(
                   "z-[50] rounded-xl",
@@ -243,6 +244,7 @@ export default function PlaythroughSelector({
                   "border border-gray-200/50 dark:border-gray-600/50",
                   "w-80 max-w-[calc(100vw-2rem)] sm:w-96",
                   "origin-top-right",
+                  "transition-opacity duration-150 data-closed:opacity-0",
                 )}
               >
                 {/* Current playthroughs section */}

--- a/src/hooks/__tests__/useReducedMotion.test.ts
+++ b/src/hooks/__tests__/useReducedMotion.test.ts
@@ -1,0 +1,49 @@
+/** @vitest-environment jsdom */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useReducedMotion } from "../useReducedMotion";
+
+describe("useReducedMotion", () => {
+  let matches = false;
+  let listener: (() => void) | undefined;
+
+  beforeEach(() => {
+    matches = false;
+    listener = undefined;
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation(() => ({
+        get matches() {
+          return matches;
+        },
+        addEventListener: (_event: string, callback: () => void) => {
+          listener = callback;
+        },
+        removeEventListener: vi.fn(),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("updates when the browser preference changes without an override", () => {
+    const { result } = renderHook(() => useReducedMotion(undefined));
+    expect(result.current).toBe(false);
+
+    matches = true;
+    act(() => listener?.());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("uses an explicit app override over the browser preference", () => {
+    matches = true;
+
+    const { result } = renderHook(() => useReducedMotion(false));
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useReducedMotion.test.ts
+++ b/src/hooks/__tests__/useReducedMotion.test.ts
@@ -46,4 +46,32 @@ describe("useReducedMotion", () => {
 
     expect(result.current).toBe(false);
   });
+
+  it("subscribes through legacy media-query listeners", () => {
+    let legacyListener: ((event: MediaQueryListEvent) => void) | undefined;
+    const addListener = vi.fn(
+      (listener: (event: MediaQueryListEvent) => void) => {
+        legacyListener = listener;
+      },
+    );
+
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        get matches() {
+          return matches;
+        },
+        addListener,
+        removeListener: vi.fn(),
+      }),
+    );
+
+    const { result } = renderHook(() => useReducedMotion(undefined));
+    expect(addListener).toHaveBeenCalledOnce();
+
+    matches = true;
+    act(() => legacyListener?.({} as MediaQueryListEvent));
+
+    expect(result.current).toBe(true);
+  });
 });

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -12,8 +12,13 @@ const subscribeToBrowserReducedMotion = (onStoreChange: () => void) => {
   }
 
   const query = window.matchMedia(mediaQuery);
-  query.addEventListener("change", onStoreChange);
-  return () => query.removeEventListener("change", onStoreChange);
+  if (typeof query.addEventListener === "function") {
+    query.addEventListener("change", onStoreChange);
+    return () => query.removeEventListener("change", onStoreChange);
+  }
+
+  query.addListener(onStoreChange);
+  return () => query.removeListener(onStoreChange);
 };
 
 export function useReducedMotion(preference: boolean | undefined): boolean {

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,27 @@
+import { useSyncExternalStore } from "react";
+import { getBrowserReducedMotion } from "@/lib/reducedMotion";
+
+const mediaQuery = "(prefers-reduced-motion: reduce)";
+
+const subscribeToBrowserReducedMotion = (onStoreChange: () => void) => {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return () => {};
+  }
+
+  const query = window.matchMedia(mediaQuery);
+  query.addEventListener("change", onStoreChange);
+  return () => query.removeEventListener("change", onStoreChange);
+};
+
+export function useReducedMotion(preference: boolean | undefined): boolean {
+  const browserPreference = useSyncExternalStore(
+    subscribeToBrowserReducedMotion,
+    getBrowserReducedMotion,
+    () => false,
+  );
+
+  return preference ?? browserPreference;
+}

--- a/src/lib/reducedMotion.ts
+++ b/src/lib/reducedMotion.ts
@@ -1,0 +1,20 @@
+export const getBrowserReducedMotion = (): boolean => {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+};
+
+export const getDocumentReducedMotion = (): boolean => {
+  if (typeof document === "undefined") return getBrowserReducedMotion();
+
+  const preference = document.documentElement.dataset.reducedMotion;
+  if (preference === "true") return true;
+  if (preference === "false") return false;
+
+  return getBrowserReducedMotion();
+};

--- a/src/stores/__tests__/settings.browser.test.ts
+++ b/src/stores/__tests__/settings.browser.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getActivePlaythrough, playthroughsStore } from "../playthroughs/store";
-import { SettingsSchema, settingsActions, settingsStore } from "../settings";
+import {
+  getEffectiveReducedMotion,
+  SettingsSchema,
+  settingsActions,
+  settingsStore,
+} from "../settings";
 
 // Mock the playthroughs store
 vi.mock("../playthroughs/store", async () => {
@@ -30,6 +35,7 @@ describe("Settings Store", () => {
   afterEach(() => {
     // Clear localStorage after each test
     clearLocalStorage();
+    vi.unstubAllGlobals();
   });
 
   describe("SettingsSchema", () => {
@@ -67,6 +73,34 @@ describe("Settings Store", () => {
 
       const result = SettingsSchema.safeParse(invalidSettings);
       expect(result.success).toBe(false);
+    });
+
+    it("preserves an absent reduced-motion override", () => {
+      const result = SettingsSchema.safeParse({});
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.reducedMotion).toBeUndefined();
+      }
+    });
+  });
+
+  describe("Reduced Motion Preference", () => {
+    it("uses the browser preference when no app override exists", () => {
+      const matchMedia = vi.fn().mockReturnValue({ matches: true });
+      vi.stubGlobal("matchMedia", matchMedia);
+
+      expect(getEffectiveReducedMotion(undefined)).toBe(true);
+      expect(matchMedia).toHaveBeenCalledWith(
+        "(prefers-reduced-motion: reduce)",
+      );
+    });
+
+    it("uses an explicit app override over the browser preference", () => {
+      vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: true }));
+
+      expect(getEffectiveReducedMotion(false)).toBe(false);
+      expect(getEffectiveReducedMotion(true)).toBe(true);
     });
   });
 
@@ -379,6 +413,7 @@ describe("Settings Store", () => {
       clearLocalStorage();
       Object.assign(settingsStore, {
         moveEncountersBetweenLocations: false,
+        reducedMotion: undefined,
         version: "1.0.0",
       });
     });
@@ -393,9 +428,18 @@ describe("Settings Store", () => {
       expect(settingsStore.moveEncountersBetweenLocations).toBe(false);
     });
 
+    it("sets an explicit reduced-motion override", () => {
+      settingsActions.setReducedMotion(true);
+      expect(settingsStore.reducedMotion).toBe(true);
+
+      settingsActions.setReducedMotion(false);
+      expect(settingsStore.reducedMotion).toBe(false);
+    });
+
     it("resets to dynamic defaults", () => {
       // Set to non-default value
       settingsStore.moveEncountersBetweenLocations = true;
+      settingsStore.reducedMotion = true;
 
       // Mock old playthrough (should default to enabled)
       mockGetActivePlaythrough.mockReturnValue({
@@ -406,6 +450,7 @@ describe("Settings Store", () => {
 
       settingsActions.resetToDefaults();
       expect(settingsStore.moveEncountersBetweenLocations).toBe(true);
+      expect(settingsStore.reducedMotion).toBeUndefined();
 
       // Mock new playthrough (should default to disabled)
       mockGetActivePlaythrough.mockReturnValue({
@@ -504,6 +549,16 @@ describe("Settings Store", () => {
       const stored = localStorage.getItem("settings:v1");
       expect(stored).not.toBeNull();
       expect(stored!).toContain('"moveEncountersBetweenLocations":true');
+    });
+
+    it("persists an explicit reduced-motion override", async () => {
+      settingsActions.setReducedMotion(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(localStorage.getItem("settings:v1")).toContain(
+        '"reducedMotion":true',
+      );
     });
 
     it("validates settings before saving", async () => {

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,5 +1,6 @@
 import { proxy, subscribe } from "valtio";
 import { z } from "zod";
+import { getBrowserReducedMotion } from "@/lib/reducedMotion";
 import {
   getActivePlaythrough,
   playthroughsStore,
@@ -11,6 +12,7 @@ const LEGACY_SETTINGS_STORAGE_KEY = "settings";
 // Zod schema for settings validation
 export const SettingsSchema = z.object({
   moveEncountersBetweenLocations: z.boolean().default(false),
+  reducedMotion: z.boolean().optional(),
   version: z.string().default("1.0.0"),
 });
 
@@ -92,6 +94,13 @@ const loadSettings = (): Settings => {
 
 export const settingsStore = proxy<Settings>(loadSettings());
 
+export const getEffectiveReducedMotion = (
+  preference = settingsStore.reducedMotion,
+): boolean => {
+  if (typeof preference === "boolean") return preference;
+  return getBrowserReducedMotion();
+};
+
 // Subscribe to changes and save to localStorage with validation
 if (typeof window !== "undefined") {
   subscribe(settingsStore, () => {
@@ -130,9 +139,13 @@ export const settingsActions = {
     });
   },
 
+  setReducedMotion: (reducedMotion: boolean) => {
+    updateSettings({ reducedMotion });
+  },
+
   // Helper function to reset settings to defaults
   resetToDefaults: () => {
-    updateSettings(getDefaultSettings());
+    updateSettings({ ...getDefaultSettings(), reducedMotion: undefined });
   },
 
   // Helper function to update multiple settings at once

--- a/src/utils/__tests__/scrollToLocation.browser.test.ts
+++ b/src/utils/__tests__/scrollToLocation.browser.test.ts
@@ -129,6 +129,8 @@ describe("scrollToTableRow", () => {
   afterEach(() => {
     document.body.removeChild(container);
     document.body.removeChild(row);
+    delete document.documentElement.dataset.reducedMotion;
+    vi.unstubAllGlobals();
   });
 
   it("should scroll to center the target row in the container", () => {
@@ -145,6 +147,18 @@ describe("scrollToTableRow", () => {
 
     // The actual scroll behavior depends on DOM layout and may not be testable in this environment
     // We're testing that the function completes successfully
+  });
+
+  it("uses immediate scrolling when reduced motion is preferred", () => {
+    const scrollTo = vi.fn();
+    container.scrollTo = scrollTo;
+    document.documentElement.dataset.reducedMotion = "true";
+
+    scrollToTableRow(container, row, "smooth");
+
+    expect(scrollTo).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: "auto" }),
+    );
   });
 
   it("should handle null elements gracefully", () => {

--- a/src/utils/scrollToLocation.ts
+++ b/src/utils/scrollToLocation.ts
@@ -1,8 +1,12 @@
 import { emitScrollToLocation } from "@/lib/events";
+import { getDocumentReducedMotion } from "@/lib/reducedMotion";
 import type { EncounterData } from "@/stores/playthroughs/types";
 
 // Keep teardown timers per overlay element across calls to avoid flicker
 const overlayHideTimers = new WeakMap<HTMLElement, number>();
+
+const getScrollBehavior = (behavior: ScrollBehavior): ScrollBehavior =>
+  behavior === "smooth" && getDocumentReducedMotion() ? "auto" : behavior;
 
 /**
  * Find the most recently filled out location based on encounter updatedAt timestamps
@@ -49,7 +53,7 @@ export function scrollToTableRow(
 
   tableContainerElement.scrollTo({
     top: targetTop - containerHeight / 2 + targetHeight / 2,
-    behavior,
+    behavior: getScrollBehavior(behavior),
   });
 }
 
@@ -76,15 +80,19 @@ export function scrollToMostRecentLocation(
 ): boolean {
   if (!tableContainerElement || !tableElement) return false;
 
+  const normalizedBehavior = getScrollBehavior(behavior);
   const recentLocationId = findMostRecentlyFilledLocation(encounters);
   if (!recentLocationId) return false;
 
   const targetRow = findTableRowByLocationId(tableElement, recentLocationId);
   if (!targetRow) {
-    return emitScrollToLocation({ behavior, locationId: recentLocationId });
+    return emitScrollToLocation({
+      behavior: normalizedBehavior,
+      locationId: recentLocationId,
+    });
   }
 
-  scrollToTableRow(tableContainerElement, targetRow, behavior);
+  scrollToTableRow(tableContainerElement, targetRow, normalizedBehavior);
   return true;
 }
 
@@ -217,7 +225,7 @@ export function scrollToLocationById(
 ): boolean {
   if (!locationId) return false;
 
-  const behavior = options?.behavior ?? "smooth";
+  const behavior = getScrollBehavior(options?.behavior ?? "smooth");
 
   const tableElement = document.querySelector(
     'table[aria-label="Locations table"]',
@@ -230,7 +238,7 @@ export function scrollToLocationById(
 
   const targetRow = findTableRowByLocationId(tableElement, locationId);
   if (!targetRow) {
-    return emitScrollToLocation({ locationId, ...options });
+    return emitScrollToLocation({ locationId, ...options, behavior });
   }
 
   // Determine if target row is already fully visible within container


### PR DESCRIPTION
## Summary
Respect the browser's reduced-motion preference by default while allowing people to persist an explicit application override.

## Changes
- add a Reduced Motion setting with browser-derived default behavior
- suppress CSS, sprite, and smooth-scroll motion when reduction is active
- apply persisted overrides before hydration and react to browser preference changes
- cover preference resolution, reset behavior, media-query updates, and scroll handling

## Testing
- `pnpm type-check`
- `pnpm validate`
- `pnpm test:run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Reduced Motion** setting and saved it to your preferences.
  * When no override is set, the app now automatically follows your device’s **“reduce motion”** preference.
* **Bug Fixes**
  * Reduced-motion mode now disables or cancels interactive animations (including sprite and evolution animations, plus tooltip transitions).
  * Scrolling now uses instant behavior (“auto”) instead of smooth when reduced motion is active, including relevant in-page navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->