### PR TITLE
refactor(react): address quality findings

### DIFF
--- a/.github/workflows/vercel-preview-on-demand.yml
+++ b/.github/workflows/vercel-preview-on-demand.yml
@@ -33,9 +33,6 @@ jobs:
     env:
       ENABLE_EXPERIMENTAL_COREPACK: '1'
       VERCEL_NEXT_BUNDLED_SERVER: '1'
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
     steps:
       - name: Resolve PR metadata
@@ -93,6 +90,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Validate Vercel secrets
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           for required_var in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
             if [ -z "${!required_var}" ]; then
@@ -105,13 +106,25 @@ jobs:
         uses: ./.github/actions/install-vercel-cli
 
       - name: Pull Vercel preview settings
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
 
       - name: Build preview artifacts
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: vercel build --yes --token="$VERCEL_TOKEN"
 
       - name: Deploy prebuilt preview artifacts
         id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           deployment_url="$(vercel deploy --prebuilt --yes --token="$VERCEL_TOKEN")"
           if [[ "$deployment_url" != http* ]]; then

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Track Pokemon Infinite Fusion Nuzlocke runs with encounter logging, team and box
 
 [![Next.js](https://img.shields.io/badge/Next.js-16-black)](https://nextjs.org/)
 [![React](https://img.shields.io/badge/React-19-149eca)](https://react.dev/)
-[![React Doctor](https://img.shields.io/badge/React_Doctor-43%2F100-orange)](https://github.com/millionco/react-doctor)
+[![React Doctor](https://img.shields.io/badge/React_Doctor-49%2F100-orange)](https://github.com/millionco/react-doctor)
 [![TypeScript](https://img.shields.io/badge/TypeScript-7-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Coverage](docs/coverage.svg)](https://app.codecov.io/gh/fbosch/infinite-fusion-nuzlocke)

--- a/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
+++ b/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
@@ -83,11 +83,12 @@ Acceptance criteria:
 
 Purpose: address concrete runtime costs without speculative micro-optimization.
 
-- [ ] Review chained array iterations and array lookups in loops; consolidate only on verified hot paths or where the simpler implementation is equally clear.
+- [x] Review chained array iterations and array lookups in loops; consolidate only on verified hot paths or where the simpler implementation is equally clear.
+- [x] Consolidate ordered collection transforms and repeated membership lookups in API routes, loaders, stores, and search helpers while preserving output order and identity.
 - [x] Replace `transition: all` declarations with the specific animated properties.
-- [ ] Review await-in-loop findings for required ordering before introducing concurrency.
-- [ ] Replace JSON parse/stringify cloning only when the data shape, supported values, and copy semantics are known.
-- [ ] Address set-state-in-effect findings after confirming their derived-state behavior.
+- [x] Review await-in-loop findings for required ordering before introducing concurrency; retain sequential loader and team-death updates because their data-source and mutation semantics require ordering.
+- [x] Replace JSON parse/stringify cloning only when the data shape, supported values, and copy semantics are known.
+- [x] Address set-state-in-effect findings after confirming their behavior; the remaining mount and analytics updates are browser-only synchronization, not derived state.
 
 Acceptance criteria:
 

--- a/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
+++ b/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
@@ -59,8 +59,9 @@ Acceptance criteria:
 
 Purpose: determine whether snapshot reads in callbacks are stale-state risks before changing state access patterns.
 
-- [ ] Audit the 23 `valtio-no-snapshot-in-callback` findings individually or by shared callback pattern.
-- [ ] Prioritize `src/components/LocationTable/FusionToggleButton.tsx` and `src/components/PokemonCombobox/useComboboxDragAndDrop.ts`, which contain the highest concentrations.
+- [ ] Audit the remaining 8 `valtio-no-snapshot-in-callback` findings individually or by shared callback pattern.
+- [x] Fix `src/components/LocationTable/FusionToggleButton.tsx`: its drop handlers now capture current drag state at event time and preserve the source across the asynchronous fusion operation; its render snapshot remains limited to the drop affordance.
+- [ ] Prioritize `src/components/PokemonCombobox/useComboboxDragAndDrop.ts`, which contains the highest remaining concentration.
 - [ ] For each finding, decide whether the callback needs render-time snapshot data or current store state.
 - [ ] Add regression coverage for callbacks whose state source changes.
 
@@ -106,7 +107,7 @@ pnpm type-check
 pnpm test:run
 pnpm validate
 pnpm quality:graph
-pnpm quality:react --base master
+pnpm quality:react
 ```
 
 Use a full advisory scan to measure baseline progress without changing the enforcement scope:

--- a/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
+++ b/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
@@ -105,6 +105,7 @@ Acceptance criteria:
 
 Purpose: retain React Doctor's maintainability observations as optional context without creating a competing gate.
 
+- [x] Remove React Compiler-redundant manual memoization across the app; the full scan no longer reports `react-compiler-no-manual-memoization` findings.
 - [ ] Use Fallow findings and existing architecture plans to prioritize large components and manual memoization patterns.
 - [ ] Consider `src/components/LocationTable/EncounterCell.tsx`, `src/components/PokemonSummaryCard/LocationSelector.tsx`, and `src/components/PokemonCombobox/useComboboxDragAndDrop.ts` only within a focused Fallow-led refactor.
 - [ ] Do not change runtime code solely to improve the React Doctor score.

--- a/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
+++ b/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
@@ -90,6 +90,12 @@ Purpose: address concrete runtime costs without speculative micro-optimization.
 - [x] Replace JSON parse/stringify cloning only when the data shape, supported values, and copy semantics are known.
 - [x] Address set-state-in-effect findings after confirming their behavior; the remaining mount and analytics updates are browser-only synchronization, not derived state.
 
+Remaining warnings require stronger evidence before a behavior change:
+
+- The three loader and team-action `await` loops need a representative cold-load latency trace before changing ordering or request concurrency.
+- The analytics debug counter refresh needs a source-level subscription before its immediate external-state refresh can be removed.
+- The logo precision warning needs an asset-size budget or visual comparison before altering its path data.
+
 Acceptance criteria:
 
 - Performance changes preserve ordering, cancellation, and rendering semantics.

--- a/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
+++ b/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
@@ -71,8 +71,8 @@ Purpose: determine whether snapshot reads in callbacks are stale-state risks bef
 - [x] Fix `src/components/LocationTable/FusionToggleButton.tsx`: its drop handlers now capture current drag state at event time and preserve the source across the asynchronous fusion operation; its render snapshot remains limited to the drop affordance.
 - [x] Fix `src/components/PokemonCombobox/useComboboxDragAndDrop.ts`: capture a drop's drag value before async lookup, check current drag data before publishing previews, and preserve the name that scheduled each preview lookup.
 - [x] Fix the remaining callbacks in `src/components/PokemonCombobox/DraggableComboboxSprite.tsx` and `src/stores/playthroughs/hooks.ts` to read the current proxy state when authorizing a drag or deciding whether to load playthroughs.
-- [ ] For each finding, decide whether the callback needs render-time snapshot data or current store state.
-- [ ] Add regression coverage for callbacks whose state source changes.
+- [x] For each finding, decide whether the callback needs render-time snapshot data or current store state; the audit and fixes above retain snapshots only for render-derived values and effect subscriptions.
+- [x] Add regression coverage for callbacks whose state source changes, including drag cleanup during asynchronous lookups and preserving a dropped Pokemon's source through asynchronous fusion.
 
 Acceptance criteria:
 

--- a/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
+++ b/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
@@ -59,24 +59,24 @@ Acceptance criteria:
 
 Purpose: determine whether snapshot reads in callbacks are stale-state risks before changing state access patterns.
 
-- [ ] Audit the remaining 3 `valtio-no-snapshot-in-callback` findings individually or by shared callback pattern.
+- [x] Audit all `valtio-no-snapshot-in-callback` findings individually or by shared callback pattern.
 - [x] Fix `src/components/LocationTable/FusionToggleButton.tsx`: its drop handlers now capture current drag state at event time and preserve the source across the asynchronous fusion operation; its render snapshot remains limited to the drop affordance.
 - [x] Fix `src/components/PokemonCombobox/useComboboxDragAndDrop.ts`: capture a drop's drag value before async lookup, check current drag data before publishing previews, and preserve the name that scheduled each preview lookup.
-- [ ] Audit the remaining findings in `src/components/PokemonCombobox/DraggableComboboxSprite.tsx` and `src/stores/playthroughs/hooks.ts`.
+- [x] Fix the remaining callbacks in `src/components/PokemonCombobox/DraggableComboboxSprite.tsx` and `src/stores/playthroughs/hooks.ts` to read the current proxy state when authorizing a drag or deciding whether to load playthroughs.
 - [ ] For each finding, decide whether the callback needs render-time snapshot data or current store state.
 - [ ] Add regression coverage for callbacks whose state source changes.
 
 Acceptance criteria:
 
 - No callback fix changes a state transition without direct behavioral coverage.
-- Remaining findings have an explicit reason for retaining render-time snapshot reads.
+- All callback snapshot findings are resolved; render-time snapshots remain only for render-derived values and effect subscriptions.
 
 ## Phase 4: Targeted Performance Cleanup
 
 Purpose: address concrete runtime costs without speculative micro-optimization.
 
 - [ ] Review chained array iterations and array lookups in loops; consolidate only on verified hot paths or where the simpler implementation is equally clear.
-- [ ] Replace `transition: all` declarations with the specific animated properties.
+- [x] Replace `transition: all` declarations with the specific animated properties.
 - [ ] Review await-in-loop findings for required ordering before introducing concurrency.
 - [ ] Replace JSON parse/stringify cloning only when the data shape, supported values, and copy semantics are known.
 - [ ] Address set-state-in-effect findings after confirming their derived-state behavior.

--- a/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
+++ b/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
@@ -36,6 +36,12 @@ Purpose: resolve or classify every blocking diagnostic before broad warning clea
 - [x] Move the file-change cleanup handler out of `usePlaythroughImportExport` so its `try`/`finally` is not lowered by React Compiler.
 - [x] Harden package installation with a one-day minimum release age and a no-downgrade trust policy.
 - [x] Scope Vercel preview credentials to the validation, pull, build, and deploy steps so dependency installation runs without secrets. Build steps still receive credentials because the Vercel CLI requires them.
+- [x] Remove `ContextMenu`'s unused open-state callback, which only caused a parent update after every local state transition (including mount).
+- [x] Guard `PokemonGridItem`'s asynchronous Pokémon lookup so stale requests cannot overwrite a newer item's type data.
+- [x] Complete the LocationTable virtualization audit: track replaceable table refs in effect dependencies and retain its convergent measurement pass behind a documented narrow suppression.
+- [x] Derive each LocationTable row's effective fusion ID during render so its animation effect depends only on the transition value it observes.
+- [x] Remove `useLocalStorage`'s routine manual memoization so its validated snapshot parsing and setter derive directly from canonical hook inputs.
+- [x] Derive TeamSlots' animation inputs from canonical team data inside its effect so unrelated renders do not continually reschedule its animation frame.
 
 Acceptance criteria:
 

--- a/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
+++ b/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
@@ -34,6 +34,8 @@ Purpose: resolve or classify every blocking diagnostic before broad warning clea
 - [x] Remove compiler-blocking manual memoization from `DraggableComboboxSprite`, `PokemonPCSheet`, and `TeamSlots`; each value is now a direct derivation from its canonical inputs.
 - [x] Retain the existing compiler opt-outs for TanStack Table and Virtual, adding narrow documented incompatible-library exceptions at their boundaries.
 - [x] Move the file-change cleanup handler out of `usePlaythroughImportExport` so its `try`/`finally` is not lowered by React Compiler.
+- [x] Harden package installation with a one-day minimum release age and a no-downgrade trust policy.
+- [x] Scope Vercel preview credentials to the validation, pull, build, and deploy steps so dependency installation runs without secrets. Build steps still receive credentials because the Vercel CLI requires them.
 
 Acceptance criteria:
 

--- a/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
+++ b/docs/REACT_DOCTOR_REMEDIATION_PLAN.md
@@ -59,9 +59,10 @@ Acceptance criteria:
 
 Purpose: determine whether snapshot reads in callbacks are stale-state risks before changing state access patterns.
 
-- [ ] Audit the remaining 8 `valtio-no-snapshot-in-callback` findings individually or by shared callback pattern.
+- [ ] Audit the remaining 3 `valtio-no-snapshot-in-callback` findings individually or by shared callback pattern.
 - [x] Fix `src/components/LocationTable/FusionToggleButton.tsx`: its drop handlers now capture current drag state at event time and preserve the source across the asynchronous fusion operation; its render snapshot remains limited to the drop affordance.
-- [ ] Prioritize `src/components/PokemonCombobox/useComboboxDragAndDrop.ts`, which contains the highest remaining concentration.
+- [x] Fix `src/components/PokemonCombobox/useComboboxDragAndDrop.ts`: capture a drop's drag value before async lookup, check current drag data before publishing previews, and preserve the name that scheduled each preview lookup.
+- [ ] Audit the remaining findings in `src/components/PokemonCombobox/DraggableComboboxSprite.tsx` and `src/stores/playthroughs/hooks.ts`.
 - [ ] For each finding, decide whether the callback needs render-time snapshot data or current store state.
 - [ ] Add regression coverage for callbacks whose state source changes.
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - .
 
+minimumReleaseAge: 1440
+trustPolicy: no-downgrade
+
 onlyBuiltDependencies:
   - "@tailwindcss/oxide"
   - "@vercel/speed-insights"

--- a/scripts/generate-react-doctor-badge.js
+++ b/scripts/generate-react-doctor-badge.js
@@ -30,7 +30,7 @@ function getBadgeColor(score) {
 function readReactDoctorScore() {
   const result = spawnSync(
     "pnpm",
-    ["exec", "react-doctor", "--score", "--yes"],
+    ["exec", "react-doctor", ".", "--score", "--yes"],
     {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],

--- a/src/app/api/encounters/encounters-processor.ts
+++ b/src/app/api/encounters/encounters-processor.ts
@@ -264,17 +264,16 @@ export function processGameModeData(gameMode: "classic" | "remix") {
   const legendaryData =
     LegendaryRouteEncountersArraySchema.parse(legendaryEncounters);
 
-  // Create maps of route names for egg locations by source type
-  const eggGiftRoutes = new Map(
-    eggLocationsData.locations
-      .filter((location) => location.source === "gift")
-      .map((location) => [location.routeName, location]),
-  );
-  const eggNestRoutes = new Map(
-    eggLocationsData.locations
-      .filter((location) => location.source === "nest")
-      .map((location) => [location.routeName, location]),
-  );
+  // Create maps of route names for egg locations by source type.
+  const eggGiftRoutes = new Map();
+  const eggNestRoutes = new Map();
+  for (const location of eggLocationsData.locations) {
+    if (location.source === "gift") {
+      eggGiftRoutes.set(location.routeName, location);
+    } else if (location.source === "nest") {
+      eggNestRoutes.set(location.routeName, location);
+    }
+  }
 
   // Merge the data by route name
   const allRouteNames = new Set([

--- a/src/app/api/pokemon/route.ts
+++ b/src/app/api/pokemon/route.ts
@@ -45,10 +45,8 @@ const getFilteredPokemon = ({
   >[];
 
   if (ids) {
-    const idList = ids.split(",").map((id) => parseInt(id, 10));
-    filteredData = filteredData.filter((pokemon) =>
-      idList.includes(pokemon.id),
-    );
+    const idSet = new Set(ids.split(",").map((id) => parseInt(id, 10)));
+    filteredData = filteredData.filter((pokemon) => idSet.has(pokemon.id));
   }
 
   if (search) {

--- a/src/app/api/sprite/artists/route.ts
+++ b/src/app/api/sprite/artists/route.ts
@@ -14,9 +14,15 @@ const extractArtists = (html: string): string[] => {
     return [];
   }
 
-  return artistLinks
-    .map((link) => link.match(/<a[^>]*>([^<]+)<\/a>/)?.[1] || "")
-    .filter((name) => name.trim());
+  const artists: string[] = [];
+  for (const link of artistLinks) {
+    const name = link.match(/<a[^>]*>([^<]+)<\/a>/)?.[1] || "";
+    if (name.trim()) {
+      artists.push(name);
+    }
+  }
+
+  return artists;
 };
 
 // Parsing base and gallery credits together preserves the route's single response contract.

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -16,8 +16,8 @@ import type React from "react";
 import {
   cloneElement,
   isValidElement,
-  useCallback,
   useEffect,
+  useEffectEvent,
   useId,
   useLayoutEffect,
   useRef,
@@ -195,25 +195,25 @@ function useContextMenuState() {
   const [isVisible, setIsVisible] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
 
-  const openMenu = useCallback((position: { x: number; y: number }) => {
+  const openMenu = (position: { x: number; y: number }) => {
     startTransition(() => {
       setMenuPosition(position);
       setIsOpen(true);
       setIsVisible(true);
     });
-  }, []);
+  };
 
-  const closeMenu = useCallback(() => {
+  const closeMenu = () => {
     startTransition(() => {
       setIsOpen(false);
     });
-  }, []);
+  };
 
-  const hideMenu = useCallback(() => {
+  const hideMenu = () => {
     startTransition(() => {
       setIsVisible(false);
     });
-  }, []);
+  };
 
   return {
     menuPosition,
@@ -285,7 +285,7 @@ export function ContextMenu({
   const submenuItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const isOpenRef = useRef(isOpen);
 
-  const handleClose = useCallback(() => {
+  const handleClose = () => {
     if (isOpenRef.current) {
       window.dispatchEvent(new Event("context-menu-close"));
     }
@@ -300,7 +300,7 @@ export function ContextMenu({
         hideMenu();
       }, 50);
     }
-  }, [closeMenu, hideMenu]);
+  };
 
   useEffect(() => {
     isOpenRef.current = isOpen;
@@ -328,6 +328,37 @@ export function ContextMenu({
     }
   }, [isVisible, menuPosition, setMenuPosition]);
 
+  const handleVisibilityChange = useEffectEvent(() => {
+    const isVisible = document.visibilityState === "visible";
+    const isFocused = document.hasFocus();
+
+    if ((!isVisible || !isFocused) && isOpen) {
+      handleClose();
+    }
+  });
+
+  const handleScroll = useEffectEvent(() => {
+    if (isOpen) {
+      handleClose();
+    }
+  });
+
+  const handleActiveContextMenu = useEffectEvent((event: MouseEvent) => {
+    const target = event.target;
+    const contextMenuTrigger =
+      target instanceof Element &&
+      target.closest<HTMLElement>("[data-context-menu-trigger]");
+
+    if (!contextMenuTrigger) {
+      event.preventDefault();
+    } else if (contextMenuTrigger.dataset.contextMenuTrigger === triggerId) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    handleClose();
+  });
+
   // Floating UI setup for keyboard navigation
   const { refs, context } = useFloating({
     open: isOpen,
@@ -354,22 +385,6 @@ export function ContextMenu({
 
   // Close menu when window becomes hidden, loses focus, or scrolls
   useEffect(() => {
-    const handleVisibilityChange = () => {
-      const isVisible = document.visibilityState === "visible";
-      const isFocused = document.hasFocus();
-      const shouldClose = !isVisible || !isFocused;
-
-      if (shouldClose && isOpen) {
-        handleClose();
-      }
-    };
-
-    const handleScroll = () => {
-      if (isOpen) {
-        handleClose();
-      }
-    };
-
     // Add event listeners
     document.addEventListener("visibilitychange", handleVisibilityChange);
     window.addEventListener("focus", handleVisibilityChange);
@@ -383,26 +398,10 @@ export function ContextMenu({
       window.removeEventListener("blur", handleVisibilityChange);
       window.removeEventListener("scroll", handleScroll, true);
     };
-  }, [isOpen, handleClose]);
+  }, []);
 
   useEffect(() => {
     if (!isVisible) return;
-
-    const handleActiveContextMenu = (event: MouseEvent) => {
-      const target = event.target;
-      const contextMenuTrigger =
-        target instanceof Element &&
-        target.closest<HTMLElement>("[data-context-menu-trigger]");
-
-      if (!contextMenuTrigger) {
-        event.preventDefault();
-      } else if (contextMenuTrigger.dataset.contextMenuTrigger === triggerId) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-
-      handleClose();
-    };
 
     document.addEventListener("contextmenu", handleActiveContextMenu, true);
     return () => {
@@ -412,9 +411,9 @@ export function ContextMenu({
         true,
       );
     };
-  }, [isVisible, handleClose, triggerId]);
+  }, [isVisible]);
 
-  const openSubmenuForIndex = useCallback((validIndex: number) => {
+  const openSubmenuForIndex = (validIndex: number) => {
     const trigger = listRef.current[validIndex];
     if (trigger) {
       const { bottom, right, top } = trigger.getBoundingClientRect();
@@ -425,11 +424,11 @@ export function ContextMenu({
     }
     setActiveSubmenuIndex(0);
     setOpenSubmenuIndex(validIndex);
-  }, []);
+  };
 
-  const closeSubmenu = useCallback(() => {
+  const closeSubmenu = () => {
     setOpenSubmenuIndex(null);
-  }, []);
+  };
 
   const handleContextMenu = (event: React.MouseEvent) => {
     if (disabled) return;

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -253,7 +253,6 @@ export interface ContextMenuProps {
   items: ContextMenuItem[];
   className?: string;
   disabled?: boolean;
-  onOpenChange?: (open: boolean) => void;
   portalRootId?: string;
 }
 
@@ -263,7 +262,6 @@ export function ContextMenu({
   className,
   disabled = false,
   portalRootId = "context-menu-root",
-  onOpenChange,
 }: ContextMenuProps) {
   const triggerId = useId();
   const {
@@ -329,10 +327,6 @@ export function ContextMenu({
       setMenuPosition(nextPosition);
     }
   }, [isVisible, menuPosition, setMenuPosition]);
-
-  useEffect(() => {
-    onOpenChange?.(isOpen);
-  }, [isOpen, onOpenChange]);
 
   // Floating UI setup for keyboard navigation
   const { refs, context } = useFloating({

--- a/src/components/LocationTable/EncounterCell.tsx
+++ b/src/components/LocationTable/EncounterCell.tsx
@@ -552,7 +552,7 @@ export function EncounterCell({
                 <button
                   type="button"
                   onClick={handleFlip}
-                  className="group size-6 flex items-center justify-center p-1 rounded-md border border-gray-300 dark:border-gray-600 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 hover:bg-blue-500 hover:border-blue-600 bg-white dark:bg-gray-800"
+                  className="group size-6 flex items-center justify-center p-1 rounded-md border border-gray-300 dark:border-gray-600 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 hover:bg-blue-500 hover:border-blue-600 bg-white dark:bg-gray-800"
                   aria-label="Flip head and body"
                 >
                   <ArrowLeftRight className="size-4 text-gray-600 dark:text-gray-300 group-hover:text-white" />

--- a/src/components/LocationTable/EncounterCell.tsx
+++ b/src/components/LocationTable/EncounterCell.tsx
@@ -198,7 +198,7 @@ export function EncounterCell({
   const getConfirmationMessage = (pokemon: PokemonOptionType): string => {
     const dataText = getPokemonDataText(pokemon);
 
-    return `This will permanently remove ${`${pokemon.nickname} `}the ${pokemon.name}${dataText ? ` ${dataText}` : ""}.`;
+    return `This will permanently remove ${pokemon.nickname ? `${pokemon.nickname} ` : ""}the ${pokemon.name}${dataText ? ` ${dataText}` : ""}.`;
   };
 
   // Generate overwrite confirmation message

--- a/src/components/LocationTable/EncounterCell.tsx
+++ b/src/components/LocationTable/EncounterCell.tsx
@@ -3,7 +3,7 @@
 import clsx from "clsx";
 import { ArrowLeftRight } from "lucide-react";
 import Image from "next/image";
-import { useCallback, useReducer, useRef } from "react";
+import { useReducer, useRef } from "react";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
 import { CursorTooltip } from "@/components/CursorTooltip";
 import { PokemonCombobox } from "@/components/PokemonCombobox/PokemonCombobox";
@@ -163,13 +163,10 @@ export function EncounterCell({
   });
 
   // Function to get Pokemon source information
-  const getPokemonSource = useCallback(
-    (pokemonId: number): EncounterSource | null => {
-      const pokemonData = routeEncounterData.find((p) => p.id === pokemonId);
-      return pokemonData?.sources?.[0] || null;
-    },
-    [routeEncounterData],
-  );
+  const getPokemonSource = (pokemonId: number): EncounterSource | null => {
+    const pokemonData = routeEncounterData.find((p) => p.id === pokemonId);
+    return pokemonData?.sources?.[0] || null;
+  };
   const isFusion = encounterData.isFusion;
 
   // Use reducer for confirmation dialog state
@@ -192,130 +189,108 @@ export function EncounterCell({
   );
 
   // Check if a pokemon has valuable data that would be lost when clearing
-  const hasValuableData = useCallback(
-    (pokemon: PokemonOptionType | null): boolean => {
-      if (!pokemon) return false;
-      return !!(pokemon.nickname || pokemon.status);
-    },
-    [],
-  );
+  const hasValuableData = (pokemon: PokemonOptionType | null): boolean => {
+    if (!pokemon) return false;
+    return !!(pokemon.nickname || pokemon.status);
+  };
 
   // Generate confirmation message based on what data would be lost
-  const getConfirmationMessage = useCallback(
-    (pokemon: PokemonOptionType): string => {
-      const dataText = getPokemonDataText(pokemon);
+  const getConfirmationMessage = (pokemon: PokemonOptionType): string => {
+    const dataText = getPokemonDataText(pokemon);
 
-      return `This will permanently remove ${`${pokemon.nickname} `}the ${pokemon.name}${dataText ? ` ${dataText}` : ""}.`;
-    },
-    [],
-  );
+    return `This will permanently remove ${`${pokemon.nickname} `}the ${pokemon.name}${dataText ? ` ${dataText}` : ""}.`;
+  };
 
   // Generate overwrite confirmation message
-  const getOverwriteConfirmationMessage = useCallback(
-    (
-      currentPokemon: PokemonOptionType,
-      newPokemon: PokemonOptionType,
-    ): string => {
-      const currentDataText = getPokemonDataText(currentPokemon);
+  const getOverwriteConfirmationMessage = (
+    currentPokemon: PokemonOptionType,
+    newPokemon: PokemonOptionType,
+  ): string => {
+    const currentDataText = getPokemonDataText(currentPokemon);
 
-      return `This will replace ${currentPokemon.nickname ? `${currentPokemon.nickname} the ` : ""}${currentPokemon.name}${currentDataText ? ` ${currentDataText}` : ""} with ${newPokemon.name}?`;
-    },
-    [],
-  );
+    return `This will replace ${currentPokemon.nickname ? `${currentPokemon.nickname} the ` : ""}${currentPokemon.name}${currentDataText ? ` ${currentDataText}` : ""} with ${newPokemon.name}?`;
+  };
 
-  const getFusionOverwriteConfirmationMessage = useCallback(
-    (
-      currentPokemon: PokemonOptionType[],
-      head: PokemonOptionType,
-      body: PokemonOptionType,
-    ): string => {
-      const replacedPokemon = currentPokemon
-        .map((pokemon) => {
-          const name = pokemon.nickname
-            ? `${pokemon.nickname} the ${pokemon.name}`
-            : pokemon.name;
-          const dataText = getPokemonDataText(pokemon);
-          return `${name}${dataText ? ` ${dataText}` : ""}`;
-        })
-        .join(" and ");
-      return `This will replace ${replacedPokemon} with the fusion ${head.name}/${body.name}?`;
-    },
-    [],
-  );
+  const getFusionOverwriteConfirmationMessage = (
+    currentPokemon: PokemonOptionType[],
+    head: PokemonOptionType,
+    body: PokemonOptionType,
+  ): string => {
+    const replacedPokemon = currentPokemon
+      .map((pokemon) => {
+        const name = pokemon.nickname
+          ? `${pokemon.nickname} the ${pokemon.name}`
+          : pokemon.name;
+        const dataText = getPokemonDataText(pokemon);
+        return `${name}${dataText ? ` ${dataText}` : ""}`;
+      })
+      .join(" and ");
+    return `This will replace ${replacedPokemon} with the fusion ${head.name}/${body.name}?`;
+  };
 
   // Handle encounter selection with confirmation for clearing valuable data
-  const handleEncounterSelect = useCallback(
-    (pokemon: PokemonOptionType | null, field: "head" | "body" = "head") => {
-      // If we're clearing a pokemon (setting to null)
-      if (pokemon === null) {
-        const currentPokemon = field === "head" ? headPokemon : bodyPokemon;
+  const handleEncounterSelect = (
+    pokemon: PokemonOptionType | null,
+    field: "head" | "body" = "head",
+  ) => {
+    // If we're clearing a pokemon (setting to null)
+    if (pokemon === null) {
+      const currentPokemon = field === "head" ? headPokemon : bodyPokemon;
 
-        // Check if the current pokemon has valuable data
-        if (hasValuableData(currentPokemon)) {
-          // Show confirmation dialog
-          dispatch({
-            type: "SHOW_CLEAR_CONFIRMATION",
-            payload: { field, pokemon: currentPokemon! },
-          });
-          return;
-        }
-      }
-
-      // If no confirmation needed, proceed with the change
-      playthroughActions.updateEncounter(locationId, pokemon, field, false);
-    },
-    [locationId, headPokemon, bodyPokemon, hasValuableData],
-  );
-
-  // Create separate memoized handlers to avoid creating new functions on every render
-  const handleHeadChange = useCallback(
-    (pokemon: PokemonOptionType | null) => {
-      handleEncounterSelect(pokemon, "head");
-    },
-    [handleEncounterSelect],
-  );
-
-  const handleBodyChange = useCallback(
-    (pokemon: PokemonOptionType | null) => {
-      handleEncounterSelect(pokemon, "body");
-    },
-    [handleEncounterSelect],
-  );
-
-  const handleSingleChange = useCallback(
-    (pokemon: PokemonOptionType | null) => {
-      handleEncounterSelect(pokemon);
-    },
-    [handleEncounterSelect],
-  );
-
-  const handleSingleFusionChange = useCallback(
-    (head: PokemonOptionType, body: PokemonOptionType) => {
-      const existingPokemon = [headPokemon, bodyPokemon].filter(
-        (pokemon): pokemon is PokemonOptionType => pokemon !== null,
-      );
-      const valuablePokemon = existingPokemon.filter(hasValuableData);
-
-      if (valuablePokemon.length > 0) {
+      // Check if the current pokemon has valuable data
+      if (hasValuableData(currentPokemon)) {
+        // Show confirmation dialog
         dispatch({
-          type: "SHOW_OVERWRITE_CONFIRMATION",
-          payload: {
-            kind: "fusion",
-            currentPokemon: existingPokemon,
-            head,
-            body,
-          },
+          type: "SHOW_CLEAR_CONFIRMATION",
+          payload: { field, pokemon: currentPokemon! },
         });
         return;
       }
+    }
 
-      playthroughActions.createFusion(locationId, head, body);
-    },
-    [locationId, headPokemon, bodyPokemon, hasValuableData],
-  );
+    // If no confirmation needed, proceed with the change
+    playthroughActions.updateEncounter(locationId, pokemon, field, false);
+  };
+
+  const handleHeadChange = (pokemon: PokemonOptionType | null) => {
+    handleEncounterSelect(pokemon, "head");
+  };
+
+  const handleBodyChange = (pokemon: PokemonOptionType | null) => {
+    handleEncounterSelect(pokemon, "body");
+  };
+
+  const handleSingleChange = (pokemon: PokemonOptionType | null) => {
+    handleEncounterSelect(pokemon);
+  };
+
+  const handleSingleFusionChange = (
+    head: PokemonOptionType,
+    body: PokemonOptionType,
+  ) => {
+    const existingPokemon = [headPokemon, bodyPokemon].filter(
+      (pokemon): pokemon is PokemonOptionType => pokemon !== null,
+    );
+    const valuablePokemon = existingPokemon.filter(hasValuableData);
+
+    if (valuablePokemon.length > 0) {
+      dispatch({
+        type: "SHOW_OVERWRITE_CONFIRMATION",
+        payload: {
+          kind: "fusion",
+          currentPokemon: existingPokemon,
+          head,
+          body,
+        },
+      });
+      return;
+    }
+
+    playthroughActions.createFusion(locationId, head, body);
+  };
 
   // Handle confirmation dialog confirm action
-  const handleConfirmClear = useCallback(() => {
+  const handleConfirmClear = () => {
     if (confirmationState.pendingClear) {
       playthroughActions.updateEncounter(
         locationId,
@@ -327,10 +302,10 @@ export function EncounterCell({
 
     // Mark that the user confirmed the action
     dispatch({ type: "CONFIRM_CLEAR" });
-  }, [locationId, confirmationState.pendingClear]);
+  };
 
   // Handle confirmation dialog cancel/close action
-  const handleDialogClose = useCallback(() => {
+  const handleDialogClose = () => {
     // Resolve the pending promise based on whether it was confirmed or cancelled
     if (pendingClearResolveRef.current) {
       pendingClearResolveRef.current(confirmationState.wasConfirmed);
@@ -339,10 +314,10 @@ export function EncounterCell({
 
     // Reset all state when dialog closes
     dispatch({ type: "CLOSE_DIALOGS" });
-  }, [confirmationState.wasConfirmed]);
+  };
 
   // Handle overwrite confirmation dialog confirm action
-  const handleConfirmOverwrite = useCallback(() => {
+  const handleConfirmOverwrite = () => {
     if (confirmationState.pendingOverwrite) {
       if (confirmationState.pendingOverwrite.kind === "fusion") {
         playthroughActions.createFusion(
@@ -385,10 +360,10 @@ export function EncounterCell({
 
     // Mark that the user confirmed the action
     dispatch({ type: "CONFIRM_OVERWRITE" });
-  }, [locationId, confirmationState.pendingOverwrite, getPokemonSource]);
+  };
 
   // Handle overwrite confirmation dialog cancel/close action
-  const handleOverwriteDialogClose = useCallback(() => {
+  const handleOverwriteDialogClose = () => {
     // Resolve the pending promise based on whether it was confirmed or cancelled
     if (pendingOverwriteResolveRef.current) {
       pendingOverwriteResolveRef.current(
@@ -399,89 +374,74 @@ export function EncounterCell({
 
     // Reset all state when dialog closes
     dispatch({ type: "CLOSE_DIALOGS" });
-  }, [confirmationState.wasOverwriteConfirmed]);
+  };
 
-  const requestClearConfirmation = useCallback(
-    (field: "head" | "body", currentValue: PokemonOptionType) => {
-      return new Promise<boolean>((resolve) => {
-        if (hasValuableData(currentValue)) {
-          dispatch({
-            type: "SHOW_CLEAR_CONFIRMATION",
-            payload: { field, pokemon: currentValue },
-          });
-          pendingClearResolveRef.current = resolve;
-        } else {
-          resolve(true);
-        }
-      });
-    },
-    [hasValuableData],
-  );
+  const requestClearConfirmation = (
+    field: "head" | "body",
+    currentValue: PokemonOptionType,
+  ) => {
+    return new Promise<boolean>((resolve) => {
+      if (hasValuableData(currentValue)) {
+        dispatch({
+          type: "SHOW_CLEAR_CONFIRMATION",
+          payload: { field, pokemon: currentValue },
+        });
+        pendingClearResolveRef.current = resolve;
+      } else {
+        resolve(true);
+      }
+    });
+  };
 
-  const requestOverwriteConfirmation = useCallback(
-    (
-      field: "head" | "body",
-      currentValue: PokemonOptionType,
-      newValue: PokemonOptionType,
-    ) => {
-      return new Promise<boolean>((resolve) => {
-        if (hasValuableData(currentValue)) {
-          dispatch({
-            type: "SHOW_OVERWRITE_CONFIRMATION",
-            payload: {
-              kind: "pokemon",
-              field,
-              currentPokemon: currentValue,
-              newPokemon: newValue,
-            },
-          });
-          pendingOverwriteResolveRef.current = resolve;
-        } else {
-          resolve(true);
-        }
-      });
-    },
-    [hasValuableData],
-  );
+  const requestOverwriteConfirmation = (
+    field: "head" | "body",
+    currentValue: PokemonOptionType,
+    newValue: PokemonOptionType,
+  ) => {
+    return new Promise<boolean>((resolve) => {
+      if (hasValuableData(currentValue)) {
+        dispatch({
+          type: "SHOW_OVERWRITE_CONFIRMATION",
+          payload: {
+            kind: "pokemon",
+            field,
+            currentPokemon: currentValue,
+            newPokemon: newValue,
+          },
+        });
+        pendingOverwriteResolveRef.current = resolve;
+      } else {
+        resolve(true);
+      }
+    });
+  };
 
-  const handleBeforeClearHead = useCallback(
-    (currentValue: PokemonOptionType) =>
-      requestClearConfirmation("head", currentValue),
-    [requestClearConfirmation],
-  );
+  const handleBeforeClearHead = (currentValue: PokemonOptionType) =>
+    requestClearConfirmation("head", currentValue);
 
-  const handleBeforeClearBody = useCallback(
-    (currentValue: PokemonOptionType) =>
-      requestClearConfirmation("body", currentValue),
-    [requestClearConfirmation],
-  );
+  const handleBeforeClearBody = (currentValue: PokemonOptionType) =>
+    requestClearConfirmation("body", currentValue);
 
-  const handleBeforeClearSingle = useCallback(
-    (currentValue: PokemonOptionType) =>
-      requestClearConfirmation("head", currentValue),
-    [requestClearConfirmation],
-  );
+  const handleBeforeClearSingle = (currentValue: PokemonOptionType) =>
+    requestClearConfirmation("head", currentValue);
 
-  const handleBeforeOverwriteHead = useCallback(
-    (currentValue: PokemonOptionType, newValue: PokemonOptionType) =>
-      requestOverwriteConfirmation("head", currentValue, newValue),
-    [requestOverwriteConfirmation],
-  );
+  const handleBeforeOverwriteHead = (
+    currentValue: PokemonOptionType,
+    newValue: PokemonOptionType,
+  ) => requestOverwriteConfirmation("head", currentValue, newValue);
 
-  const handleBeforeOverwriteBody = useCallback(
-    (currentValue: PokemonOptionType, newValue: PokemonOptionType) =>
-      requestOverwriteConfirmation("body", currentValue, newValue),
-    [requestOverwriteConfirmation],
-  );
+  const handleBeforeOverwriteBody = (
+    currentValue: PokemonOptionType,
+    newValue: PokemonOptionType,
+  ) => requestOverwriteConfirmation("body", currentValue, newValue);
 
-  const handleBeforeOverwriteSingle = useCallback(
-    (currentValue: PokemonOptionType, newValue: PokemonOptionType) =>
-      requestOverwriteConfirmation("head", currentValue, newValue),
-    [requestOverwriteConfirmation],
-  );
+  const handleBeforeOverwriteSingle = (
+    currentValue: PokemonOptionType,
+    newValue: PokemonOptionType,
+  ) => requestOverwriteConfirmation("head", currentValue, newValue);
 
   // Handle fusion toggle
-  const handleFusionToggle = useCallback(() => {
+  const handleFusionToggle = () => {
     playthroughActions.toggleEncounterFusion(locationId);
 
     // Focus body combobox when toggling to fusion mode if head pokemon exists but body doesn't
@@ -491,15 +451,15 @@ export function EncounterCell({
         bodyComboboxRef.current?.focus();
       }, 0);
     }
-  }, [locationId, isFusion, headPokemon, bodyPokemon]);
+  };
 
   // Handle flip button click
-  const handleFlip = useCallback(() => {
+  const handleFlip = () => {
     if (!isFusion) return;
 
     // Use the atomic flip function to avoid duplicate preferred variant lookups
     playthroughActions.flipEncounterFusion(locationId);
-  }, [isFusion, locationId]);
+  };
 
   return (
     <td

--- a/src/components/LocationTable/FusionToggleButton.tsx
+++ b/src/components/LocationTable/FusionToggleButton.tsx
@@ -39,12 +39,17 @@ export function FusionToggleButton({
       const pokemonName = e.dataTransfer.getData("text/plain");
       if (!pokemonName) return;
 
+      // Event handlers must use the drag state that is current for this drop.
+      // Keep it after the async fusion completes because global drop handlers clear it.
+      const dragSource = dragStore.currentDragSource;
+      const dragValue = dragStore.currentDragValue;
+
       // Check if this drop is from a different combobox
       const isFromDifferentCombobox =
-        dragSnapshot.currentDragSource &&
-        dragSnapshot.currentDragSource !== `${locationId}-single` &&
-        dragSnapshot.currentDragSource !== `${locationId}-head` &&
-        dragSnapshot.currentDragSource !== `${locationId}-body`;
+        dragSource &&
+        dragSource !== `${locationId}-single` &&
+        dragSource !== `${locationId}-head` &&
+        dragSource !== `${locationId}-body`;
 
       if (!isFromDifferentCombobox) return;
 
@@ -64,24 +69,21 @@ export function FusionToggleButton({
         id: foundPokemon.id,
         name: pokemonName,
         nationalDexId: foundPokemon.nationalDexId,
-        originalLocation:
-          dragSnapshot.currentDragValue?.originalLocation || locationId,
-        ...(dragSnapshot.currentDragValue && {
-          nickname: dragSnapshot.currentDragValue.nickname,
-          status: dragSnapshot.currentDragValue.status,
-          uid: dragSnapshot.currentDragValue.uid,
+        originalLocation: dragValue?.originalLocation || locationId,
+        ...(dragValue && {
+          nickname: dragValue.nickname,
+          status: dragValue.status,
+          uid: dragValue.uid,
         }),
       };
 
       await playthroughActions
         .createFusion(locationId, selectedPokemon, pokemonOption)
         .then(async () => {
-          if (!dragSnapshot.currentDragSource) return;
+          if (!dragSource) return;
 
           const { locationId: sourceLocationId, field: sourceField } =
-            playthroughActions.getLocationFromComboboxId(
-              dragSnapshot.currentDragSource,
-            );
+            playthroughActions.getLocationFromComboboxId(dragSource);
           await playthroughActions.clearEncounterFromLocation(
             sourceLocationId,
             sourceField,
@@ -92,15 +94,7 @@ export function FusionToggleButton({
           console.error("Error finding Pokemon by name:", err);
         });
     },
-    [
-      isFusion,
-      selectedPokemon,
-      dragSnapshot.currentDragSource,
-      dragSnapshot.currentDragValue,
-      locationId,
-      allPokemon,
-      nameMap,
-    ],
+    [isFusion, selectedPokemon, locationId, allPokemon, nameMap],
   );
 
   // Handle drag over
@@ -122,11 +116,12 @@ export function FusionToggleButton({
       }
 
       // Check if drag is from a different combobox
+      const dragSource = dragStore.currentDragSource;
       const isFromDifferentCombobox =
-        dragSnapshot.currentDragSource &&
-        dragSnapshot.currentDragSource !== `${locationId}-single` &&
-        dragSnapshot.currentDragSource !== `${locationId}-head` &&
-        dragSnapshot.currentDragSource !== `${locationId}-body`;
+        dragSource &&
+        dragSource !== `${locationId}-single` &&
+        dragSource !== `${locationId}-head` &&
+        dragSource !== `${locationId}-body`;
 
       if (isFromDifferentCombobox) {
         e.dataTransfer.dropEffect = "copy";
@@ -134,7 +129,7 @@ export function FusionToggleButton({
         e.dataTransfer.dropEffect = "none";
       }
     },
-    [isFusion, selectedPokemon, dragSnapshot.currentDragSource, locationId],
+    [isFusion, selectedPokemon, locationId],
   );
 
   // Handle drag end

--- a/src/components/LocationTable/FusionToggleButton.tsx
+++ b/src/components/LocationTable/FusionToggleButton.tsx
@@ -4,7 +4,6 @@ import clsx from "clsx";
 import { Dna, DnaOff } from "lucide-react";
 import Image from "next/image";
 import type React from "react";
-import { useCallback } from "react";
 import { useSnapshot } from "valtio";
 import { DNA_SPLICER_ICON } from "@/constants/items";
 import type { PokemonOptionType } from "@/loaders/pokemon";
@@ -31,111 +30,105 @@ export function FusionToggleButton({
   const nameMap = usePokemonNameMap();
 
   // Handle drop on fusion button
-  const handleFusionDrop = useCallback(
-    async (e: React.DragEvent<HTMLButtonElement>) => {
-      e.preventDefault();
-      e.stopPropagation();
+  const handleFusionDrop = async (e: React.DragEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
 
-      const pokemonName = e.dataTransfer.getData("text/plain");
-      if (!pokemonName) return;
+    const pokemonName = e.dataTransfer.getData("text/plain");
+    if (!pokemonName) return;
 
-      // Event handlers must use the drag state that is current for this drop.
-      // Keep it after the async fusion completes because global drop handlers clear it.
-      const dragSource = dragStore.currentDragSource;
-      const dragValue = dragStore.currentDragValue;
+    // Event handlers must use the drag state that is current for this drop.
+    // Keep it after the async fusion completes because global drop handlers clear it.
+    const dragSource = dragStore.currentDragSource;
+    const dragValue = dragStore.currentDragValue;
 
-      // Check if this drop is from a different combobox
-      const isFromDifferentCombobox =
-        dragSource &&
-        dragSource !== `${locationId}-single` &&
-        dragSource !== `${locationId}-head` &&
-        dragSource !== `${locationId}-body`;
+    // Check if this drop is from a different combobox
+    const isFromDifferentCombobox =
+      dragSource &&
+      dragSource !== `${locationId}-single` &&
+      dragSource !== `${locationId}-head` &&
+      dragSource !== `${locationId}-body`;
 
-      if (!isFromDifferentCombobox) return;
+    if (!isFromDifferentCombobox) return;
 
-      // Only allow dropping if this row is not already a fusion and has an existing encounter
-      if (isFusion || !selectedPokemon) return;
+    // Only allow dropping if this row is not already a fusion and has an existing encounter
+    if (isFusion || !selectedPokemon) return;
 
-      // Prevent dropping if the button is disabled (Egg in non-fusion mode)
-      if (!isFusion && selectedPokemon && isEgg(selectedPokemon)) return;
+    // Prevent dropping if the button is disabled (Egg in non-fusion mode)
+    if (!isFusion && selectedPokemon && isEgg(selectedPokemon)) return;
 
-      const foundPokemon = allPokemon.find(
-        (p) => nameMap?.get(p.id)?.toLowerCase() === pokemonName.toLowerCase(),
-      );
+    const foundPokemon = allPokemon.find(
+      (p) => nameMap?.get(p.id)?.toLowerCase() === pokemonName.toLowerCase(),
+    );
 
-      if (!foundPokemon) return;
+    if (!foundPokemon) return;
 
-      const pokemonOption: PokemonOptionType = {
-        id: foundPokemon.id,
-        name: pokemonName,
-        nationalDexId: foundPokemon.nationalDexId,
-        originalLocation: dragValue?.originalLocation || locationId,
-        ...(dragValue && {
-          nickname: dragValue.nickname,
-          status: dragValue.status,
-          uid: dragValue.uid,
-        }),
-      };
+    const pokemonOption: PokemonOptionType = {
+      id: foundPokemon.id,
+      name: pokemonName,
+      nationalDexId: foundPokemon.nationalDexId,
+      originalLocation: dragValue?.originalLocation || locationId,
+      ...(dragValue && {
+        nickname: dragValue.nickname,
+        status: dragValue.status,
+        uid: dragValue.uid,
+      }),
+    };
 
-      await playthroughActions
-        .createFusion(locationId, selectedPokemon, pokemonOption)
-        .then(async () => {
-          if (!dragSource) return;
+    await playthroughActions
+      .createFusion(locationId, selectedPokemon, pokemonOption)
+      .then(async () => {
+        if (!dragSource) return;
 
-          const { locationId: sourceLocationId, field: sourceField } =
-            playthroughActions.getLocationFromComboboxId(dragSource);
-          await playthroughActions.clearEncounterFromLocation(
-            sourceLocationId,
-            sourceField,
-            { preserveTeamMembership: true },
-          );
-        })
-        .catch((err) => {
-          console.error("Error finding Pokemon by name:", err);
-        });
-    },
-    [isFusion, selectedPokemon, locationId, allPokemon, nameMap],
-  );
+        const { locationId: sourceLocationId, field: sourceField } =
+          playthroughActions.getLocationFromComboboxId(dragSource);
+        await playthroughActions.clearEncounterFromLocation(
+          sourceLocationId,
+          sourceField,
+          { preserveTeamMembership: true },
+        );
+      })
+      .catch((err) => {
+        console.error("Error finding Pokemon by name:", err);
+      });
+  };
 
   // Handle drag over
-  const handleFusionDragOver = useCallback(
-    (e: React.DragEvent<HTMLButtonElement>) => {
-      // Always prevent default to allow drop events to fire
-      e.preventDefault();
+  const handleFusionDragOver = (e: React.DragEvent<HTMLButtonElement>) => {
+    // Always prevent default to allow drop events to fire
+    e.preventDefault();
 
-      // Only allow drop if this row is not already a fusion and has an existing encounter
-      if (isFusion || !selectedPokemon) {
-        e.dataTransfer.dropEffect = "none";
-        return;
-      }
+    // Only allow drop if this row is not already a fusion and has an existing encounter
+    if (isFusion || !selectedPokemon) {
+      e.dataTransfer.dropEffect = "none";
+      return;
+    }
 
-      // Prevent drop if the button is disabled (Egg in non-fusion mode)
-      if (!isFusion && selectedPokemon && isEgg(selectedPokemon)) {
-        e.dataTransfer.dropEffect = "none";
-        return;
-      }
+    // Prevent drop if the button is disabled (Egg in non-fusion mode)
+    if (!isFusion && selectedPokemon && isEgg(selectedPokemon)) {
+      e.dataTransfer.dropEffect = "none";
+      return;
+    }
 
-      // Check if drag is from a different combobox
-      const dragSource = dragStore.currentDragSource;
-      const isFromDifferentCombobox =
-        dragSource &&
-        dragSource !== `${locationId}-single` &&
-        dragSource !== `${locationId}-head` &&
-        dragSource !== `${locationId}-body`;
+    // Check if drag is from a different combobox
+    const dragSource = dragStore.currentDragSource;
+    const isFromDifferentCombobox =
+      dragSource &&
+      dragSource !== `${locationId}-single` &&
+      dragSource !== `${locationId}-head` &&
+      dragSource !== `${locationId}-body`;
 
-      if (isFromDifferentCombobox) {
-        e.dataTransfer.dropEffect = "copy";
-      } else {
-        e.dataTransfer.dropEffect = "none";
-      }
-    },
-    [isFusion, selectedPokemon, locationId],
-  );
+    if (isFromDifferentCombobox) {
+      e.dataTransfer.dropEffect = "copy";
+    } else {
+      e.dataTransfer.dropEffect = "none";
+    }
+  };
 
   // Handle drag end
-  const handleFusionDragEnd = useCallback(() => {
+  const handleFusionDragEnd = () => {
     dragActions.clearDrag();
-  }, []);
+  };
 
   const isDropAllowed =
     !isFusion &&

--- a/src/components/LocationTable/LocationCell.tsx
+++ b/src/components/LocationTable/LocationCell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CheckCircle, Info } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useSnapshot } from "valtio";
 import type { z } from "zod";
 import { PokemonSprite } from "@/components/PokemonSprite";
@@ -38,7 +38,7 @@ export default function LocationCell({
   const [isTooltipHovered, setIsTooltipHovered] = useState(false);
 
   // Find all pokemon that originated from this location
-  const locationPokemon = useMemo(() => {
+  const locationPokemon = (() => {
     if (!encounters) return [];
 
     const pokemon: Pokemon[] = [];
@@ -54,7 +54,7 @@ export default function LocationCell({
     }
 
     return pokemon;
-  }, [encounters, location.id]);
+  })();
 
   const shouldShowOriginalEncounter = settings.moveEncountersBetweenLocations;
 
@@ -89,7 +89,7 @@ export default function LocationCell({
     });
   }, [isTooltipHovered, encounterUids, shouldShowOriginalEncounter]);
 
-  const getTooltipContent = useMemo(() => {
+  const getTooltipContent = (() => {
     if (locationPokemon.length > 0 && shouldShowOriginalEncounter) {
       return (
         <div className="max-w-xs">
@@ -128,7 +128,7 @@ export default function LocationCell({
     return isCustomLocation(location)
       ? `Custom Location`
       : location.description;
-  }, [locationPokemon, location, shouldShowOriginalEncounter]);
+  })();
 
   return (
     <div className="text-gray-900 dark:text-white flex gap-x-2 items-center">

--- a/src/components/LocationTable/LocationCell.tsx
+++ b/src/components/LocationTable/LocationCell.tsx
@@ -58,9 +58,9 @@ export default function LocationCell({
 
   const shouldShowOriginalEncounter = settings.moveEncountersBetweenLocations;
 
-  const encounterUids = locationPokemon
-    .map((p) => p.uid)
-    .filter(Boolean) as string[];
+  const encounterUids = locationPokemon.flatMap((pokemon) =>
+    pokemon.uid ? [pokemon.uid] : [],
+  );
   const hasEncounter = locationPokemon.length > 0;
 
   // Handle hover effect on encounter Pokémon elements - only when moving is relevant

--- a/src/components/LocationTable/LocationTableRow.tsx
+++ b/src/components/LocationTable/LocationTableRow.tsx
@@ -56,6 +56,7 @@ export default function LocationTableRow({
 
   // Get encounter data directly - only this row will rerender when this encounter changes
   const encounterData = useEncounter(locationId) || EMPTY_ENCOUNTER;
+  const effectiveFusionId = getEffectiveFusionId(encounterData);
 
   useEffect(() => {
     previousFusionId.current = null;
@@ -95,19 +96,17 @@ export default function LocationTableRow({
 
   // Play evolution animation only when the effective fusion ID changes after initialization.
   useEffect(() => {
-    const currentFusionId = getEffectiveFusionId(encounterData);
-
     if (!hasInitializedFusionId.current) {
-      previousFusionId.current = currentFusionId;
+      previousFusionId.current = effectiveFusionId;
       hasInitializedFusionId.current = true;
       return;
     }
 
-    if (currentFusionId && currentFusionId !== previousFusionId.current) {
+    if (effectiveFusionId && effectiveFusionId !== previousFusionId.current) {
       spriteRef.current?.playEvolution();
     }
-    previousFusionId.current = currentFusionId;
-  }, [encounterData.isFusion, encounterData.head, encounterData.body]);
+    previousFusionId.current = effectiveFusionId;
+  }, [effectiveFusionId]);
 
   return (
     <tr

--- a/src/components/LocationTable/ResetEncounterButton.tsx
+++ b/src/components/LocationTable/ResetEncounterButton.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { Eraser } from "lucide-react";
-import { Fragment, useCallback, useState } from "react";
+import { Fragment, useState } from "react";
 import { playthroughActions } from "@/stores/playthroughs";
 import ConfirmationDialog from "../ConfirmationDialog";
 import { CursorTooltip } from "../CursorTooltip";
@@ -18,18 +18,18 @@ export default function ResetEncounterButton({
 }: ResetEncounterButtonProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-  const handleButtonClick = useCallback(() => {
+  const handleButtonClick = () => {
     setIsDialogOpen(true);
-  }, []);
+  };
 
-  const handleConfirm = useCallback(() => {
+  const handleConfirm = () => {
     playthroughActions.resetEncounter(locationId);
     setIsDialogOpen(false);
-  }, [locationId]);
+  };
 
-  const handleCancel = useCallback(() => {
+  const handleCancel = () => {
     setIsDialogOpen(false);
-  }, []);
+  };
 
   return (
     <Fragment>

--- a/src/components/LocationTable/__tests__/EncounterCell.test.tsx
+++ b/src/components/LocationTable/__tests__/EncounterCell.test.tsx
@@ -264,6 +264,41 @@ describe("EncounterCell", () => {
     );
   });
 
+  it("omits a missing nickname from the clear confirmation", () => {
+    useEncounterMock.mockReturnValue({
+      head: {
+        id: 25,
+        name: "Pikachu",
+        uid: "pikachu-1",
+        nationalDexId: 25,
+        status: "captured",
+      },
+      body: null,
+      isFusion: false,
+      updatedAt: Date.now(),
+    });
+
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <EncounterCell locationId="route-1" />
+          </tr>
+        </tbody>
+      </table>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "clear-route-1-single" }),
+    );
+
+    expect(
+      screen.getByText(
+        'This will permanently remove the Pikachu with the status "Captured".',
+      ),
+    ).toBeDefined();
+  });
+
   it("toggles fusion mode from the fusion toggle button", () => {
     useEncounterMock.mockReturnValue({
       head: {

--- a/src/components/LocationTable/__tests__/FusionToggleButton.test.tsx
+++ b/src/components/LocationTable/__tests__/FusionToggleButton.test.tsx
@@ -1,0 +1,116 @@
+/** @vitest-environment jsdom */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dragActions } from "@/stores/dragStore";
+import { FusionToggleButton } from "../FusionToggleButton";
+
+const {
+  clearEncounterFromLocationMock,
+  createFusionMock,
+  getLocationFromComboboxIdMock,
+} = vi.hoisted(() => ({
+  clearEncounterFromLocationMock: vi.fn(),
+  createFusionMock: vi.fn(),
+  getLocationFromComboboxIdMock: vi.fn(),
+}));
+
+vi.mock("next/image", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/CursorTooltip", () => ({
+  CursorTooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/loaders/pokemon", () => ({
+  isEgg: () => false,
+  useAllPokemon: () => ({
+    data: [{ id: 25, nationalDexId: 25 }],
+  }),
+  usePokemonNameMap: () => new Map([[25, "pikachu"]]),
+}));
+
+vi.mock("@/stores/playthroughs/index", () => ({
+  playthroughActions: {
+    clearEncounterFromLocation: clearEncounterFromLocationMock,
+    createFusion: createFusionMock,
+    getLocationFromComboboxId: getLocationFromComboboxIdMock,
+  },
+}));
+
+describe("FusionToggleButton", () => {
+  afterEach(() => {
+    cleanup();
+    dragActions.clearDrag();
+    vi.clearAllMocks();
+  });
+
+  it("uses the active drag state and preserves its source through async fusion", async () => {
+    let resolveFusion: () => void;
+    createFusionMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFusion = resolve;
+        }),
+    );
+    getLocationFromComboboxIdMock.mockReturnValue({
+      locationId: "route-2",
+      field: "single",
+    });
+    clearEncounterFromLocationMock.mockResolvedValue(undefined);
+    dragActions.startDrag("Pikachu", "route-2-single", {
+      id: 25,
+      name: "Pikachu",
+      nationalDexId: 25,
+      originalLocation: "Route 2",
+      nickname: "Sparky",
+      status: "captured",
+      uid: "pikachu-1",
+    });
+
+    render(
+      <FusionToggleButton
+        locationId="route-1"
+        isFusion={false}
+        selectedPokemon={{ id: 1, name: "Bulbasaur", nationalDexId: 1 }}
+        onToggleFusion={vi.fn()}
+      />,
+    );
+
+    fireEvent.drop(screen.getByRole("button"), {
+      dataTransfer: { getData: () => "Pikachu" },
+    });
+
+    expect(createFusionMock).toHaveBeenCalledWith(
+      "route-1",
+      { id: 1, name: "Bulbasaur", nationalDexId: 1 },
+      expect.objectContaining({
+        originalLocation: "Route 2",
+        nickname: "Sparky",
+        status: "captured",
+        uid: "pikachu-1",
+      }),
+    );
+
+    dragActions.clearDrag();
+    resolveFusion!();
+
+    await waitFor(() => {
+      expect(getLocationFromComboboxIdMock).toHaveBeenCalledWith(
+        "route-2-single",
+      );
+      expect(clearEncounterFromLocationMock).toHaveBeenCalledWith(
+        "route-2",
+        "single",
+        { preserveTeamMembership: true },
+      );
+    });
+  });
+});

--- a/src/components/LocationTable/customLocations/AddCustomLocationModal.tsx
+++ b/src/components/LocationTable/customLocations/AddCustomLocationModal.tsx
@@ -8,7 +8,7 @@ import {
 } from "@headlessui/react";
 import clsx from "clsx";
 import { Loader2, Plus, X } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import { getLocationsSortedWithCustom } from "@/loaders";
 import { useCustomLocations } from "@/stores/playthroughs/hooks";
 import { playthroughActions } from "@/stores/playthroughs/index";
@@ -26,17 +26,17 @@ export default function AddCustomLocationModal({
   const [selectedAfterLocationId, setSelectedAfterLocationId] = useState("");
   const customLocations = useCustomLocations();
 
-  const handleClose = useCallback(() => {
+  const handleClose = () => {
     setLocationName("");
     setSelectedAfterLocationId("");
     onClose();
-  }, [onClose]);
+  };
 
   // Only process locations when modal is open to improve performance
-  const allLocations = useMemo(() => {
+  const allLocations = (() => {
     if (!isOpen) return [];
     return getLocationsSortedWithCustom(customLocations);
-  }, [isOpen, customLocations]);
+  })();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/LocationTable/customLocations/RemoveLocationButton.tsx
+++ b/src/components/LocationTable/customLocations/RemoveLocationButton.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { TrashIcon } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
 import { playthroughActions } from "@/stores/playthroughs";
 import { CursorTooltip } from "../../CursorTooltip";
@@ -16,18 +16,18 @@ export default function RemoveLocationButton({
 }: RemoveLocationButtonProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-  const handleButtonClick = useCallback(() => {
+  const handleButtonClick = () => {
     setIsDialogOpen(true);
-  }, []);
+  };
 
-  const handleConfirm = useCallback(async () => {
+  const handleConfirm = async () => {
     await playthroughActions.removeCustomLocation(locationId);
     setIsDialogOpen(false);
-  }, [locationId]);
+  };
 
-  const handleCancel = useCallback(() => {
+  const handleCancel = () => {
     setIsDialogOpen(false);
-  }, []);
+  };
 
   return (
     <>

--- a/src/components/LocationTable/useLocationTableVirtualization.ts
+++ b/src/components/LocationTable/useLocationTableVirtualization.ts
@@ -2,7 +2,6 @@ import type { Table } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   type RefObject,
-  useCallback,
   useEffect,
   useLayoutEffect,
   useState,
@@ -21,28 +20,23 @@ const LOCATION_ROW_OVERSCAN_COUNT = 4;
 function useContainerLayoutSnapshot(
   tableContainerElement: HTMLDivElement | null,
 ) {
-  const subscribe = useCallback(
-    (notify: () => void) => {
-      if (!tableContainerElement) return () => {};
+  const subscribe = (notify: () => void) => {
+    if (!tableContainerElement) return () => {};
 
-      const resizeObserver =
-        typeof ResizeObserver === "undefined"
-          ? null
-          : new ResizeObserver(notify);
-      resizeObserver?.observe(tableContainerElement);
-      document.fonts?.addEventListener("loadingdone", notify);
+    const resizeObserver =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(notify);
+    resizeObserver?.observe(tableContainerElement);
+    document.fonts?.addEventListener("loadingdone", notify);
 
-      return () => {
-        resizeObserver?.disconnect();
-        document.fonts?.removeEventListener("loadingdone", notify);
-      };
-    },
-    [tableContainerElement],
-  );
-  const getSnapshot = useCallback(() => {
+    return () => {
+      resizeObserver?.disconnect();
+      document.fonts?.removeEventListener("loadingdone", notify);
+    };
+  };
+  const getSnapshot = () => {
     const width = tableContainerElement?.clientWidth ?? 0;
     return `${width}:${document.fonts?.status ?? "unavailable"}`;
-  }, [tableContainerElement]);
+  };
 
   return useSyncExternalStore(subscribe, getSnapshot, () => "0:unavailable");
 }

--- a/src/components/LocationTable/useLocationTableVirtualization.ts
+++ b/src/components/LocationTable/useLocationTableVirtualization.ts
@@ -112,10 +112,12 @@ export function useLocationTableVirtualization({
       return;
     }
 
+    // react-doctor-disable-next-line react-doctor/no-self-updating-effect -- A changed snapshot clears this cache; the following layout pass measures and converges.
     setMeasuredTableLayout({ columnWidths, snapshot: layoutSnapshot, width });
   }, [
     layoutSnapshot,
     measuredTableLayout,
+    tableRef,
     virtualRows.length,
     visibleColumns.length,
   ]);
@@ -149,7 +151,7 @@ export function useLocationTableVirtualization({
       offScroll();
       offFlash();
     };
-  }, [rowVirtualizer, tableRows]);
+  }, [rowVirtualizer, tableContainerRef, tableRows]);
 
   return {
     measuredTableLayout,

--- a/src/components/PokemonCombobox/DraggableComboboxSprite.tsx
+++ b/src/components/PokemonCombobox/DraggableComboboxSprite.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import { ArrowDownToDot, ArrowUpRight, Atom, Home, Undo2 } from "lucide-react";
 import dynamic from "next/dynamic";
 import type React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import { useSnapshot } from "valtio";
 import spritesheetMetadata from "@/assets/pokemon-gen8-spritesheet-metadata.json";
 import { emitEvolutionEvent } from "@/lib/events";
@@ -71,9 +71,8 @@ export function DraggableComboboxSprite({
     : [];
 
   // Check if moving to original location would create egg fusion
-  const wouldCreateEggFusionAtOriginal = useMemo(() => {
-    if (!value?.originalLocation || !locationId) return false;
-
+  let wouldCreateEggFusionAtOriginal = false;
+  if (value?.originalLocation && locationId) {
     // Check if the Pokemon is an egg
     const isPokemonEgg = isEggId(value.id);
 
@@ -83,48 +82,44 @@ export function DraggableComboboxSprite({
       | Record<string, EncounterData>
       | undefined;
     const originalEncounter = encounters?.[value.originalLocation];
-    if (!originalEncounter) return false;
+    if (originalEncounter) {
+      // If the original location encounter is not a fusion (isFusion = false),
+      // then no fusion will be created regardless of what's in the body slot
+      // UNLESS we're moving an egg or there's an egg in the target location
+      if (!originalEncounter.isFusion) {
+        // For non-fusion encounters, only prevent if there's an egg involved
+        const headPokemon = originalEncounter.head;
+        const bodyPokemon = originalEncounter.body;
 
-    // If the original location encounter is not a fusion (isFusion = false),
-    // then no fusion will be created regardless of what's in the body slot
-    // UNLESS we're moving an egg or there's an egg in the target location
-    if (!originalEncounter.isFusion) {
-      // For non-fusion encounters, only prevent if there's an egg involved
-      const headPokemon = originalEncounter.head;
-      const bodyPokemon = originalEncounter.body;
+        // If moving an egg and there's any Pokemon in the target location
+        if (isPokemonEgg && (headPokemon || bodyPokemon)) {
+          wouldCreateEggFusionAtOriginal = true;
+        }
 
-      // If moving an egg and there's any Pokemon in the target location
-      if (isPokemonEgg && (headPokemon || bodyPokemon)) {
-        return true;
+        // If there's an egg in the target location and we're moving a Pokemon
+        if (
+          (headPokemon && isEggId(headPokemon.id)) ||
+          (bodyPokemon && isEggId(bodyPokemon.id))
+        ) {
+          wouldCreateEggFusionAtOriginal = true;
+        }
+      } else {
+        // For fusion encounters, check the opposite slot
+        const oppositeField = field === "head" ? "body" : "head";
+        const oppositePokemon = originalEncounter[oppositeField];
+
+        // If moving Pokemon is an egg and there's a Pokemon in the opposite slot, it would create egg fusion
+        if (isPokemonEgg && oppositePokemon) {
+          wouldCreateEggFusionAtOriginal = true;
+        }
+
+        // If there's an egg in the opposite slot and we're moving a Pokemon, it would create egg fusion
+        if (oppositePokemon && isEggId(oppositePokemon.id)) {
+          wouldCreateEggFusionAtOriginal = true;
+        }
       }
-
-      // If there's an egg in the target location and we're moving a Pokemon
-      if (
-        (headPokemon && isEggId(headPokemon.id)) ||
-        (bodyPokemon && isEggId(bodyPokemon.id))
-      ) {
-        return true;
-      }
-
-      return false;
     }
-
-    // For fusion encounters, check the opposite slot
-    const oppositeField = field === "head" ? "body" : "head";
-    const oppositePokemon = originalEncounter[oppositeField];
-
-    // If moving Pokemon is an egg and there's a Pokemon in the opposite slot, it would create egg fusion
-    if (isPokemonEgg && oppositePokemon) {
-      return true;
-    }
-
-    // If there's an egg in the opposite slot and we're moving a Pokemon, it would create egg fusion
-    if (oppositePokemon && isEggId(oppositePokemon.id)) {
-      return true;
-    }
-
-    return false;
-  }, [value, locationId, field]);
+  }
 
   // Handle move to location
   const handleMoveToLocation = async (
@@ -142,115 +137,147 @@ export function DraggableComboboxSprite({
   };
 
   // Handle move to original location
-  const handleMoveToOriginalLocation = useCallback(async () => {
+  const handleMoveToOriginalLocation = async () => {
     if (!value || !locationId) return;
 
     await playthroughActions.moveToOriginalLocation(locationId, field, value);
-  }, [value, locationId, field]);
+  };
 
-  const menuOptions = useMemo(() => {
-    const options: ContextMenuItem[] = [];
+  const menuOptions: ContextMenuItem[] = [];
 
-    // Add move to original location option if Pokemon has an original location and isn't already there
-    if (
-      value &&
-      locationId &&
-      value.originalLocation &&
-      value.originalLocation !== locationId &&
-      settings.moveEncountersBetweenLocations
-    ) {
-      const originalLocation = getLocationByIdFromMerged(
-        value.originalLocation,
-        customLocations,
-      );
-      if (originalLocation) {
-        const isDisabled = wouldCreateEggFusionAtOriginal;
-        options.push({
-          id: "move-to-original",
-          label: "Move to Original Location",
-          tooltip: isDisabled
-            ? "Cannot move to original location - would create egg fusion"
-            : originalLocation.name,
-          icon: Home,
-          onClick: handleMoveToOriginalLocation,
-          disabled: isDisabled,
-        });
-      }
-    }
-
-    // Add move option if we have a Pokemon and location with available destinations
-    if (
-      value &&
-      locationId &&
-      availableLocations.length > 0 &&
-      settings.moveEncountersBetweenLocations
-    ) {
-      options.push({
-        id: "move",
-        label: "Move to Location",
-        icon: ArrowDownToDot,
-        onClick: () => setIsMoveModalOpen(true),
+  // Add move to original location option if Pokemon has an original location and isn't already there
+  if (
+    value &&
+    locationId &&
+    value.originalLocation &&
+    value.originalLocation !== locationId &&
+    settings.moveEncountersBetweenLocations
+  ) {
+    const originalLocation = getLocationByIdFromMerged(
+      value.originalLocation,
+      customLocations,
+    );
+    if (originalLocation) {
+      const isDisabled = wouldCreateEggFusionAtOriginal;
+      menuOptions.push({
+        id: "move-to-original",
+        label: "Move to Original Location",
+        tooltip: isDisabled
+          ? "Cannot move to original location - would create egg fusion"
+          : originalLocation.name,
+        icon: Home,
+        onClick: handleMoveToOriginalLocation,
+        disabled: isDisabled,
       });
     }
+  }
 
-    if (
-      value &&
-      locationId &&
-      (preEvolution || evolutions?.length) &&
-      settings.moveEncountersBetweenLocations
-    ) {
-      options.push({
-        id: "evolve-separator",
-        separator: true,
-      });
-    }
+  // Add move option if we have a Pokemon and location with available destinations
+  if (
+    value &&
+    locationId &&
+    availableLocations.length > 0 &&
+    settings.moveEncountersBetweenLocations
+  ) {
+    menuOptions.push({
+      id: "move",
+      label: "Move to Location",
+      icon: ArrowDownToDot,
+      onClick: () => setIsMoveModalOpen(true),
+    });
+  }
 
-    // Add devolve option if pre-evolution exists
-    if (value && locationId && preEvolution) {
-      options.push({
-        id: "devolve",
+  if (
+    value &&
+    locationId &&
+    (preEvolution || evolutions?.length) &&
+    settings.moveEncountersBetweenLocations
+  ) {
+    menuOptions.push({
+      id: "evolve-separator",
+      separator: true,
+    });
+  }
+
+  // Add devolve option if pre-evolution exists
+  if (value && locationId && preEvolution) {
+    menuOptions.push({
+      id: "devolve",
+      label: (
+        <div className="flex items-center gap-x-2 w-full">
+          <div className="flex items-center justify-center size-6 flex-shrink-0">
+            <PokemonSprite pokemonId={preEvolution.id} generation="gen7" />
+          </div>
+          <span className="truncate">Devolve to {preEvolution.name}</span>
+        </div>
+      ),
+      icon: Undo2,
+      onClick: async () => {
+        if (!value || !locationId || !preEvolution) return;
+        const devolved: PokemonOptionType = {
+          ...value,
+          id: preEvolution.id,
+          name: preEvolution.name,
+          nationalDexId: preEvolution.nationalDexId,
+        };
+        await playthroughActions.updateEncounter(
+          locationId,
+          devolved,
+          field,
+          false,
+        );
+      },
+    });
+  }
+
+  // Add evolve option(s)
+  if (value && locationId && evolutions && evolutions.length > 0) {
+    if (evolutions.length === 1) {
+      const evo = evolutions[0]!;
+      menuOptions.push({
+        id: `evolve-${evo.id}`,
         label: (
           <div className="flex items-center gap-x-2 w-full">
             <div className="flex items-center justify-center size-6 flex-shrink-0">
-              <PokemonSprite pokemonId={preEvolution.id} generation="gen7" />
+              <PokemonSprite pokemonId={evo.id} generation="gen7" />
             </div>
-            <span className="truncate">Devolve to {preEvolution.name}</span>
+            <span className="truncate">Evolve to {evo.name}</span>
           </div>
         ),
-        icon: Undo2,
+        icon: Atom,
         onClick: async () => {
-          if (!value || !locationId || !preEvolution) return;
-          const devolved: PokemonOptionType = {
+          if (!value || !locationId) return;
+          const evolved: PokemonOptionType = {
             ...value,
-            id: preEvolution.id,
-            name: preEvolution.name,
-            nationalDexId: preEvolution.nationalDexId,
+            id: evo.id,
+            name: evo.name,
+            nationalDexId: evo.nationalDexId,
           };
           await playthroughActions.updateEncounter(
             locationId,
-            devolved,
+            evolved,
             field,
             false,
           );
+          const id = locationId ?? value?.originalLocation ?? null;
+          if (id) emitEvolutionEvent(id);
         },
       });
-    }
-
-    // Add evolve option(s)
-    if (value && locationId && evolutions && evolutions.length > 0) {
-      if (evolutions.length === 1) {
-        const evo = evolutions[0]!;
-        options.push({
+    } else {
+      menuOptions.push({
+        id: "evolve",
+        label: "Evolve to…",
+        icon: Atom,
+        children: evolutions.map((evo) => ({
           id: `evolve-${evo.id}`,
           label: (
             <div className="flex items-center gap-x-2 w-full">
               <div className="flex items-center justify-center size-6 flex-shrink-0">
                 <PokemonSprite pokemonId={evo.id} generation="gen7" />
               </div>
-              <span className="truncate">Evolve to {evo.name}</span>
+              <span className="truncate">{evo.name}</span>
             </div>
           ),
-          icon: Atom,
           onClick: async () => {
             if (!value || !locationId) return;
             const evolved: PokemonOptionType = {
@@ -268,83 +295,37 @@ export function DraggableComboboxSprite({
             const id = locationId ?? value?.originalLocation ?? null;
             if (id) emitEvolutionEvent(id);
           },
-        });
-      } else {
-        options.push({
-          id: "evolve",
-          label: "Evolve to…",
-          icon: Atom,
-          children: evolutions.map((evo) => ({
-            id: `evolve-${evo.id}`,
-            label: (
-              <div className="flex items-center gap-x-2 w-full">
-                <div className="flex items-center justify-center size-6 flex-shrink-0">
-                  <PokemonSprite pokemonId={evo.id} generation="gen7" />
-                </div>
-                <span className="truncate">{evo.name}</span>
-              </div>
-            ),
-            onClick: async () => {
-              if (!value || !locationId) return;
-              const evolved: PokemonOptionType = {
-                ...value,
-                id: evo.id,
-                name: evo.name,
-                nationalDexId: evo.nationalDexId,
-              };
-              await playthroughActions.updateEncounter(
-                locationId,
-                evolved,
-                field,
-                false,
-              );
-              const id = locationId ?? value?.originalLocation ?? null;
-              if (id) emitEvolutionEvent(id);
-            },
-          })),
-        });
-      }
+        })),
+      });
     }
-    const infinitefusiondexLink = `https://infinitefusiondex.com/details/${value?.id}`;
-    const fusiondexLink = `https://fusiondex.org/sprite/pif/${value?.id}/`;
+  }
+  const infinitefusiondexLink = `https://infinitefusiondex.com/details/${value?.id}`;
+  const fusiondexLink = `https://fusiondex.org/sprite/pif/${value?.id}/`;
 
-    options.push(
-      {
-        id: "separator",
-        separator: true,
-      },
-      {
-        id: "infinitefusiondex",
-        label: "Open InfiniteDex entry",
-        href: infinitefusiondexLink,
-        target: "_blank",
-        favicon: "https://infinitefusiondex.com/images/favicon.ico",
-        icon: ArrowUpRight,
-        iconClassName: "dark:text-blue-300 text-blue-400",
-      },
-      {
-        id: "fusiondex",
-        label: "Open FusionDex entry",
-        href: fusiondexLink,
-        target: "_blank",
-        favicon: "https://www.fusiondex.org/favicon.ico",
-        icon: ArrowUpRight,
-        iconClassName: "dark:text-blue-300 text-blue-400",
-      },
-    );
-    return options;
-  }, [
-    value,
-    locationId,
-    customLocations,
-    availableLocations.length,
-    settings.moveEncountersBetweenLocations,
-    handleMoveToOriginalLocation,
-    wouldCreateEggFusionAtOriginal,
-    preEvolution,
-    evolutions,
-    field,
-  ]);
+  menuOptions.push(
+    {
+      id: "separator",
+      separator: true,
+    },
+    {
+      id: "infinitefusiondex",
+      label: "Open InfiniteDex entry",
+      href: infinitefusiondexLink,
+      target: "_blank",
+      favicon: "https://infinitefusiondex.com/images/favicon.ico",
+      icon: ArrowUpRight,
+      iconClassName: "dark:text-blue-300 text-blue-400",
+    },
+    {
+      id: "fusiondex",
+      label: "Open FusionDex entry",
+      href: fusiondexLink,
+      target: "_blank",
+      favicon: "https://www.fusiondex.org/favicon.ico",
+      icon: ArrowUpRight,
+      iconClassName: "dark:text-blue-300 text-blue-400",
+    },
+  );
 
   const originalLocationName =
     !pokemon?.originalLocation || pokemon.originalLocation === locationId

--- a/src/components/PokemonCombobox/DraggableComboboxSprite.tsx
+++ b/src/components/PokemonCombobox/DraggableComboboxSprite.tsx
@@ -355,7 +355,7 @@ export function DraggableComboboxSprite({
   if (!pokemon) return null;
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
-    if (disabled || !settings.moveEncountersBetweenLocations) {
+    if (disabled || !settingsStore.moveEncountersBetweenLocations) {
       e.preventDefault();
       return;
     }

--- a/src/components/PokemonCombobox/DraggableComboboxSprite.tsx
+++ b/src/components/PokemonCombobox/DraggableComboboxSprite.tsx
@@ -1,39 +1,33 @@
 "use client";
 
 import clsx from "clsx";
-import { ArrowDownToDot, ArrowUpRight, Atom, Home, Undo2 } from "lucide-react";
 import dynamic from "next/dynamic";
 import type React from "react";
 import { useState } from "react";
 import { useSnapshot } from "valtio";
 import spritesheetMetadata from "@/assets/pokemon-gen8-spritesheet-metadata.json";
-import { emitEvolutionEvent } from "@/lib/events";
-import { getLocationByIdFromMerged, getLocations } from "@/loaders/locations";
+import { getLocationByIdFromMerged } from "@/loaders/locations";
 import {
-  isEggId,
   type PokemonOptionType,
   usePokemonEvolutionData,
 } from "@/loaders/pokemon";
 import { dragActions } from "@/stores/dragStore";
+import { playthroughActions } from "@/stores/playthroughs";
 import { useCustomLocations } from "@/stores/playthroughs/hooks";
-import { playthroughActions } from "@/stores/playthroughs/index";
-import { getActivePlaythrough } from "@/stores/playthroughs/store";
-import type { EncounterData } from "@/stores/playthroughs/types";
 import { settingsStore } from "@/stores/settings";
 import usePokemonTypes from "../../hooks/usePokemonTypes";
-import ContextMenu, { type ContextMenuItem } from "../ContextMenu";
+import ContextMenu from "../ContextMenu";
 import { CursorTooltip } from "../CursorTooltip";
 import { PokemonSprite } from "../PokemonSprite";
 import { DraggableSpriteTooltipContent } from "./DraggableSpriteTooltipContent";
+import { getDraggableComboboxSpriteMenuOptions } from "./draggableComboboxSpriteMenu";
 
 const LocationSelector = dynamic(
   () =>
     import("../PokemonSummaryCard/LocationSelector").then(
       (mod) => mod.LocationSelector,
     ),
-  {
-    ssr: false,
-  },
+  { ssr: false },
 );
 
 interface DraggableComboboxSpriteProps {
@@ -55,277 +49,23 @@ export function DraggableComboboxSprite({
   const [isMoveModalOpen, setIsMoveModalOpen] = useState(false);
   const customLocations = useCustomLocations();
   const settings = useSnapshot(settingsStore);
-
   const { primary, secondary } = usePokemonTypes({ id: pokemon?.id });
   const { evolutions, preEvolution } = usePokemonEvolutionData(
     pokemon?.id,
     true,
   );
-
-  // Extract field from comboboxId
   const field = comboboxId?.includes("-body") ? "body" : "head";
 
-  // Get available locations (excluding current one)
-  const availableLocations = locationId
-    ? getLocations().filter((location) => location.id !== locationId)
-    : [];
-
-  // Check if moving to original location would create egg fusion
-  let wouldCreateEggFusionAtOriginal = false;
-  if (value?.originalLocation && locationId) {
-    // Check if the Pokemon is an egg
-    const isPokemonEgg = isEggId(value.id);
-
-    // Check if there's a Pokemon in the opposite slot at the original location
-    const activePlaythrough = getActivePlaythrough();
-    const encounters = activePlaythrough?.encounters as
-      | Record<string, EncounterData>
-      | undefined;
-    const originalEncounter = encounters?.[value.originalLocation];
-    if (originalEncounter) {
-      // If the original location encounter is not a fusion (isFusion = false),
-      // then no fusion will be created regardless of what's in the body slot
-      // UNLESS we're moving an egg or there's an egg in the target location
-      if (!originalEncounter.isFusion) {
-        // For non-fusion encounters, only prevent if there's an egg involved
-        const headPokemon = originalEncounter.head;
-        const bodyPokemon = originalEncounter.body;
-
-        // If moving an egg and there's any Pokemon in the target location
-        if (isPokemonEgg && (headPokemon || bodyPokemon)) {
-          wouldCreateEggFusionAtOriginal = true;
-        }
-
-        // If there's an egg in the target location and we're moving a Pokemon
-        if (
-          (headPokemon && isEggId(headPokemon.id)) ||
-          (bodyPokemon && isEggId(bodyPokemon.id))
-        ) {
-          wouldCreateEggFusionAtOriginal = true;
-        }
-      } else {
-        // For fusion encounters, check the opposite slot
-        const oppositeField = field === "head" ? "body" : "head";
-        const oppositePokemon = originalEncounter[oppositeField];
-
-        // If moving Pokemon is an egg and there's a Pokemon in the opposite slot, it would create egg fusion
-        if (isPokemonEgg && oppositePokemon) {
-          wouldCreateEggFusionAtOriginal = true;
-        }
-
-        // If there's an egg in the opposite slot and we're moving a Pokemon, it would create egg fusion
-        if (oppositePokemon && isEggId(oppositePokemon.id)) {
-          wouldCreateEggFusionAtOriginal = true;
-        }
-      }
-    }
-  }
-
-  // Handle move to location
-  const handleMoveToLocation = async (
-    targetLocationId: string,
-    targetField: "head" | "body",
-  ) => {
-    if (!value || !locationId) return;
-
-    await playthroughActions.relocateEncounterSlot({
-      sourceLocationId: locationId,
-      sourceField: field,
-      targetLocationId,
-      targetField,
-    });
-  };
-
-  // Handle move to original location
-  const handleMoveToOriginalLocation = async () => {
-    if (!value || !locationId) return;
-
-    await playthroughActions.moveToOriginalLocation(locationId, field, value);
-  };
-
-  const menuOptions: ContextMenuItem[] = [];
-
-  // Add move to original location option if Pokemon has an original location and isn't already there
-  if (
-    value &&
-    locationId &&
-    value.originalLocation &&
-    value.originalLocation !== locationId &&
-    settings.moveEncountersBetweenLocations
-  ) {
-    const originalLocation = getLocationByIdFromMerged(
-      value.originalLocation,
-      customLocations,
-    );
-    if (originalLocation) {
-      const isDisabled = wouldCreateEggFusionAtOriginal;
-      menuOptions.push({
-        id: "move-to-original",
-        label: "Move to Original Location",
-        tooltip: isDisabled
-          ? "Cannot move to original location - would create egg fusion"
-          : originalLocation.name,
-        icon: Home,
-        onClick: handleMoveToOriginalLocation,
-        disabled: isDisabled,
-      });
-    }
-  }
-
-  // Add move option if we have a Pokemon and location with available destinations
-  if (
-    value &&
-    locationId &&
-    availableLocations.length > 0 &&
-    settings.moveEncountersBetweenLocations
-  ) {
-    menuOptions.push({
-      id: "move",
-      label: "Move to Location",
-      icon: ArrowDownToDot,
-      onClick: () => setIsMoveModalOpen(true),
-    });
-  }
-
-  if (
-    value &&
-    locationId &&
-    (preEvolution || evolutions?.length) &&
-    settings.moveEncountersBetweenLocations
-  ) {
-    menuOptions.push({
-      id: "evolve-separator",
-      separator: true,
-    });
-  }
-
-  // Add devolve option if pre-evolution exists
-  if (value && locationId && preEvolution) {
-    menuOptions.push({
-      id: "devolve",
-      label: (
-        <div className="flex items-center gap-x-2 w-full">
-          <div className="flex items-center justify-center size-6 flex-shrink-0">
-            <PokemonSprite pokemonId={preEvolution.id} generation="gen7" />
-          </div>
-          <span className="truncate">Devolve to {preEvolution.name}</span>
-        </div>
-      ),
-      icon: Undo2,
-      onClick: async () => {
-        if (!value || !locationId || !preEvolution) return;
-        const devolved: PokemonOptionType = {
-          ...value,
-          id: preEvolution.id,
-          name: preEvolution.name,
-          nationalDexId: preEvolution.nationalDexId,
-        };
-        await playthroughActions.updateEncounter(
-          locationId,
-          devolved,
-          field,
-          false,
-        );
-      },
-    });
-  }
-
-  // Add evolve option(s)
-  if (value && locationId && evolutions && evolutions.length > 0) {
-    if (evolutions.length === 1) {
-      const evo = evolutions[0]!;
-      menuOptions.push({
-        id: `evolve-${evo.id}`,
-        label: (
-          <div className="flex items-center gap-x-2 w-full">
-            <div className="flex items-center justify-center size-6 flex-shrink-0">
-              <PokemonSprite pokemonId={evo.id} generation="gen7" />
-            </div>
-            <span className="truncate">Evolve to {evo.name}</span>
-          </div>
-        ),
-        icon: Atom,
-        onClick: async () => {
-          if (!value || !locationId) return;
-          const evolved: PokemonOptionType = {
-            ...value,
-            id: evo.id,
-            name: evo.name,
-            nationalDexId: evo.nationalDexId,
-          };
-          await playthroughActions.updateEncounter(
-            locationId,
-            evolved,
-            field,
-            false,
-          );
-          const id = locationId ?? value?.originalLocation ?? null;
-          if (id) emitEvolutionEvent(id);
-        },
-      });
-    } else {
-      menuOptions.push({
-        id: "evolve",
-        label: "Evolve to…",
-        icon: Atom,
-        children: evolutions.map((evo) => ({
-          id: `evolve-${evo.id}`,
-          label: (
-            <div className="flex items-center gap-x-2 w-full">
-              <div className="flex items-center justify-center size-6 flex-shrink-0">
-                <PokemonSprite pokemonId={evo.id} generation="gen7" />
-              </div>
-              <span className="truncate">{evo.name}</span>
-            </div>
-          ),
-          onClick: async () => {
-            if (!value || !locationId) return;
-            const evolved: PokemonOptionType = {
-              ...value,
-              id: evo.id,
-              name: evo.name,
-              nationalDexId: evo.nationalDexId,
-            };
-            await playthroughActions.updateEncounter(
-              locationId,
-              evolved,
-              field,
-              false,
-            );
-            const id = locationId ?? value?.originalLocation ?? null;
-            if (id) emitEvolutionEvent(id);
-          },
-        })),
-      });
-    }
-  }
-  const infinitefusiondexLink = `https://infinitefusiondex.com/details/${value?.id}`;
-  const fusiondexLink = `https://fusiondex.org/sprite/pif/${value?.id}/`;
-
-  menuOptions.push(
-    {
-      id: "separator",
-      separator: true,
-    },
-    {
-      id: "infinitefusiondex",
-      label: "Open InfiniteDex entry",
-      href: infinitefusiondexLink,
-      target: "_blank",
-      favicon: "https://infinitefusiondex.com/images/favicon.ico",
-      icon: ArrowUpRight,
-      iconClassName: "dark:text-blue-300 text-blue-400",
-    },
-    {
-      id: "fusiondex",
-      label: "Open FusionDex entry",
-      href: fusiondexLink,
-      target: "_blank",
-      favicon: "https://www.fusiondex.org/favicon.ico",
-      icon: ArrowUpRight,
-      iconClassName: "dark:text-blue-300 text-blue-400",
-    },
-  );
+  const menuOptions = getDraggableComboboxSpriteMenuOptions({
+    value,
+    locationId,
+    field,
+    customLocations,
+    moveEncountersBetweenLocations: settings.moveEncountersBetweenLocations,
+    preEvolution,
+    evolutions,
+    onOpenMoveModal: () => setIsMoveModalOpen(true),
+  });
 
   const originalLocationName =
     !pokemon?.originalLocation || pokemon.originalLocation === locationId
@@ -335,38 +75,38 @@ export function DraggableComboboxSprite({
 
   if (!pokemon) return null;
 
-  const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
+  const handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
     if (disabled || !settingsStore.moveEncountersBetweenLocations) {
-      e.preventDefault();
+      event.preventDefault();
       return;
     }
-    const sprite = e.currentTarget.querySelector("img") as HTMLImageElement;
-    if (sprite && pokemon) {
-      const spriteMetadata = spritesheetMetadata.sprites.find(
-        (s) => s.id === pokemon.id,
+
+    const sprite = event.currentTarget.querySelector("img") as HTMLImageElement;
+    const spriteMetadata = spritesheetMetadata.sprites.find(
+      (metadata) => metadata.id === pokemon.id,
+    );
+    if (sprite && spriteMetadata) {
+      const dragElement = document.createElement("div");
+      dragElement.style.cssText = `
+        width: ${spriteMetadata.width}px;
+        height: ${spriteMetadata.height}px;
+        background-image: url(${sprite.src});
+        background-position: -${spriteMetadata.x}px -${spriteMetadata.y}px;
+        background-repeat: no-repeat;
+        position: absolute;
+        top: -1000px;
+        image-rendering: pixelated;
+      `;
+      document.body.appendChild(dragElement);
+      event.dataTransfer.setDragImage(
+        dragElement,
+        spriteMetadata.width / 2,
+        spriteMetadata.height / 2,
       );
-      if (spriteMetadata) {
-        const dragElement = document.createElement("div");
-        dragElement.style.cssText = `
-          width: ${spriteMetadata.width}px;
-          height: ${spriteMetadata.height}px;
-          background-image: url(${sprite.src});
-          background-position: -${spriteMetadata.x}px -${spriteMetadata.y}px;
-          background-repeat: no-repeat;
-          position: absolute;
-          top: -1000px;
-          image-rendering: pixelated;
-        `;
-        document.body.appendChild(dragElement);
-        e.dataTransfer.setDragImage(
-          dragElement,
-          spriteMetadata.width / 2,
-          spriteMetadata.height / 2,
-        );
-        setTimeout(() => document.body.removeChild(dragElement), 0);
-      }
+      setTimeout(() => document.body.removeChild(dragElement), 0);
     }
-    e.dataTransfer.setData("text/plain", pokemon.name);
+
+    event.dataTransfer.setData("text/plain", pokemon.name);
     dragActions.startDrag(pokemon.name, comboboxId || "", pokemon);
   };
 
@@ -377,10 +117,7 @@ export function DraggableComboboxSprite({
           <CursorTooltip
             disabled={!!dragPreview || disabled}
             delay={500}
-            offset={{
-              mainAxis: 8,
-              crossAxis: 8,
-            }}
+            offset={{ mainAxis: 8, crossAxis: 8 }}
             placement="bottom-start"
             content={
               <DraggableSpriteTooltipContent
@@ -409,7 +146,7 @@ export function DraggableComboboxSprite({
               <PokemonSprite
                 pokemonId={pokemon.id}
                 className={clsx(
-                  dragPreview && "opacity-60 pointer-events-none", // Make preview sprite opaque
+                  dragPreview && "opacity-60 pointer-events-none",
                 )}
                 draggable={false}
               />
@@ -418,16 +155,19 @@ export function DraggableComboboxSprite({
         </div>
       </ContextMenu>
 
-      {/* Location Selector Modal */}
       <LocationSelector
         isOpen={isMoveModalOpen}
         onClose={() => setIsMoveModalOpen(false)}
         currentLocationId={locationId || ""}
-        onSelectLocation={(
-          targetLocationId: string,
-          targetField: "head" | "body",
-        ) => {
-          handleMoveToLocation(targetLocationId, targetField);
+        onSelectLocation={(targetLocationId, targetField) => {
+          if (value && locationId) {
+            void playthroughActions.relocateEncounterSlot({
+              sourceLocationId: locationId,
+              sourceField: field,
+              targetLocationId,
+              targetField,
+            });
+          }
           setIsMoveModalOpen(false);
         }}
         encounterData={value ? { [field]: value } : null}

--- a/src/components/PokemonCombobox/PokemonCombobox.tsx
+++ b/src/components/PokemonCombobox/PokemonCombobox.tsx
@@ -201,13 +201,15 @@ export const PokemonCombobox = ({
         if (isAllPokemonLoading) {
           return [];
         }
-        return allPokemon
-          .map((p) => ({
-            id: p.id,
-            name: p.name,
-            nationalDexId: p.nationalDexId,
-          }))
-          .filter((pokemon) => !isFusion || !isEgg(pokemon));
+        return allPokemon.flatMap((pokemon) => {
+          const option = {
+            id: pokemon.id,
+            name: pokemon.name,
+            nationalDexId: pokemon.nationalDexId,
+          };
+
+          return !isFusion || !isEgg(option) ? [option] : [];
+        });
       }
       return routeEncounterData.filter(
         (pokemon) => !isFusion || !isEgg(pokemon),

--- a/src/components/PokemonCombobox/PokemonNicknameInput.tsx
+++ b/src/components/PokemonCombobox/PokemonNicknameInput.tsx
@@ -2,7 +2,7 @@
 
 import clsx from "clsx";
 import type React from "react";
-import { startTransition, useCallback, useRef } from "react";
+import { startTransition, useRef } from "react";
 import type { PokemonOptionType } from "@/loaders/pokemon";
 
 interface PokemonNicknameInputProps {
@@ -24,7 +24,7 @@ export const PokemonNicknameInput = ({
   const inputKey = `${value?.id ?? "none"}:${value?.nickname ?? ""}`;
 
   // Helper function to commit changes to parent
-  const commitChanges = useCallback(() => {
+  const commitChanges = () => {
     const nextNickname = inputRef.current?.value ?? "";
 
     if (value && nextNickname !== value.nickname) {
@@ -36,26 +36,23 @@ export const PokemonNicknameInput = ({
         onChange(updatedPokemon);
       });
     }
-  }, [value, onChange]);
+  };
 
   // Handle Enter key - commit changes immediately and blur
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (event.key === "Enter") {
-        commitChanges();
-        event.currentTarget.blur();
-      } else if (event.key === "Escape") {
-        event.currentTarget.value = value?.nickname || "";
-        event.currentTarget.blur();
-      }
-    },
-    [commitChanges, value],
-  );
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      commitChanges();
+      event.currentTarget.blur();
+    } else if (event.key === "Escape") {
+      event.currentTarget.value = value?.nickname || "";
+      event.currentTarget.blur();
+    }
+  };
 
   // Handle blur - commit changes immediately
-  const handleBlur = useCallback(() => {
+  const handleBlur = () => {
     commitChanges();
-  }, [commitChanges]);
+  };
 
   if (dragPreview) {
     return (

--- a/src/components/PokemonCombobox/SourceTag.tsx
+++ b/src/components/PokemonCombobox/SourceTag.tsx
@@ -35,14 +35,12 @@ export function SourceTag({ sources, locationId }: SourceTagProps) {
       <span
         className={clsx(
           "text-xs px-1.5 py-0.5 rounded-sm font-medium leading-none flex items-center gap-1",
-          "transition-all duration-200 text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/20 border border-blue-200/60 dark:border-blue-700/40 hover:bg-blue-100 dark:hover:bg-blue-900/70",
+          "transition-[padding,gap,color,background-color,border-color] duration-200 text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/20 border border-blue-200/60 dark:border-blue-700/40 hover:bg-blue-100 dark:hover:bg-blue-900/70",
           "group-hover:px-2 group-hover:gap-2 font-medium",
         )}
         title="Starter"
       >
-        <span className="hidden group-hover:inline transition-all duration-200">
-          Starter
-        </span>
+        <span className="hidden group-hover:inline">Starter</span>
         <PokeballIcon className="size-3" />
       </span>
     );
@@ -55,15 +53,13 @@ export function SourceTag({ sources, locationId }: SourceTagProps) {
       <span
         className={clsx(
           "text-xs px-1.5 py-0.5 rounded-sm font-medium leading-none flex items-center gap-1",
-          "transition-all duration-200",
+          "transition-[padding,gap,color,background-color,border-color] duration-200",
           config.className,
           "group-hover:px-2 group-hover:gap-2",
         )}
         title={config.text}
       >
-        <span className="hidden group-hover:inline transition-all duration-200">
-          {config.text}
-        </span>
+        <span className="hidden group-hover:inline">{config.text}</span>
         {config.icon}
       </span>
     );
@@ -79,15 +75,13 @@ export function SourceTag({ sources, locationId }: SourceTagProps) {
             key={source}
             className={clsx(
               "text-xs px-1.5 py-0.5 rounded-sm font-medium leading-none flex items-center gap-1",
-              "transition-all duration-200",
+              "transition-[padding,gap,color,background-color,border-color] duration-200",
               config.className,
               "group-hover:px-2 group-hover:gap-2",
             )}
             title={config.text}
           >
-            <span className="hidden group-hover:inline transition-all duration-200">
-              {config.text}
-            </span>
+            <span className="hidden group-hover:inline">{config.text}</span>
             {config.icon}
           </span>
         );

--- a/src/components/PokemonCombobox/__tests__/DraggableComboboxSprite.test.tsx
+++ b/src/components/PokemonCombobox/__tests__/DraggableComboboxSprite.test.tsx
@@ -1,0 +1,103 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DraggableComboboxSprite } from "../DraggableComboboxSprite";
+
+const { startDragMock } = vi.hoisted(() => ({
+  startDragMock: vi.fn(),
+}));
+
+vi.mock("next/dynamic", () => ({ default: () => () => null }));
+
+vi.mock("@/components/ContextMenu", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/components/CursorTooltip", () => ({
+  CursorTooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/components/PokemonSprite", () => ({
+  PokemonSprite: () => <img alt="Pokemon" />,
+}));
+
+vi.mock("@/components/PokemonCombobox/DraggableSpriteTooltipContent", () => ({
+  DraggableSpriteTooltipContent: () => null,
+}));
+
+vi.mock("@/hooks/usePokemonTypes", () => ({
+  default: () => ({ primary: null, secondary: null }),
+}));
+
+vi.mock("@/loaders/locations", () => ({
+  getLocationByIdFromMerged: () => null,
+  getLocations: () => [],
+}));
+
+vi.mock("@/loaders/pokemon", () => ({
+  isEggId: () => false,
+  usePokemonEvolutionData: () => ({ evolutions: [], preEvolution: null }),
+}));
+
+vi.mock("@/stores/dragStore", () => ({
+  dragActions: { startDrag: startDragMock },
+}));
+
+vi.mock("@/stores/playthroughs/hooks", () => ({
+  useCustomLocations: () => [],
+}));
+
+vi.mock("@/stores/playthroughs/index", () => ({
+  playthroughActions: {},
+}));
+
+vi.mock("@/stores/playthroughs/store", () => ({
+  getActivePlaythrough: () => null,
+}));
+
+vi.mock("@/stores/settings", async () => {
+  const { proxy } = await import("valtio");
+  return {
+    settingsStore: proxy({
+      moveEncountersBetweenLocations: true,
+      version: "1.0.0",
+    }),
+  };
+});
+
+describe("DraggableComboboxSprite", () => {
+  beforeEach(async () => {
+    const { settingsStore } = await import("@/stores/settings");
+    settingsStore.moveEncountersBetweenLocations = true;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not start a drag after moves are disabled", async () => {
+    const { settingsStore } = await import("@/stores/settings");
+    const { container } = render(
+      <DraggableComboboxSprite
+        value={{ id: 25, name: "Pikachu", nationalDexId: 25 }}
+        dragPreview={null}
+        comboboxId="route-1-single"
+        locationId="route-1"
+      />,
+    );
+    const sprite = container.querySelector('[draggable="true"]');
+    expect(sprite).not.toBeNull();
+
+    settingsStore.moveEncountersBetweenLocations = false;
+    const dispatched = fireEvent.dragStart(sprite!, {
+      dataTransfer: {
+        setData: vi.fn(),
+        setDragImage: vi.fn(),
+      },
+    });
+
+    expect(dispatched).toBe(false);
+    expect(startDragMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/PokemonCombobox/__tests__/DraggableComboboxSprite.test.tsx
+++ b/src/components/PokemonCombobox/__tests__/DraggableComboboxSprite.test.tsx
@@ -3,6 +3,7 @@
 import { fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DraggableComboboxSprite } from "../DraggableComboboxSprite";
+import { getDraggableComboboxSpriteMenuOptions } from "../draggableComboboxSpriteMenu";
 
 const { startDragMock } = vi.hoisted(() => ({
   startDragMock: vi.fn(),
@@ -99,5 +100,20 @@ describe("DraggableComboboxSprite", () => {
 
     expect(dispatched).toBe(false);
     expect(startDragMock).not.toHaveBeenCalled();
+  });
+
+  it("omits Dex links when no Pokemon is selected", () => {
+    expect(
+      getDraggableComboboxSpriteMenuOptions({
+        value: undefined,
+        locationId: "route-1",
+        field: "head",
+        customLocations: [],
+        moveEncountersBetweenLocations: true,
+        preEvolution: null,
+        evolutions: [],
+        onOpenMoveModal: vi.fn(),
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/components/PokemonCombobox/__tests__/useComboboxDragAndDrop.test.tsx
+++ b/src/components/PokemonCombobox/__tests__/useComboboxDragAndDrop.test.tsx
@@ -1,0 +1,92 @@
+/** @vitest-environment jsdom */
+
+import { act, renderHook } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { dragActions } from "@/stores/dragStore";
+import { useComboboxDragAndDrop } from "../useComboboxDragAndDrop";
+
+const { getPokemonMock, getPokemonNameMapMock } = vi.hoisted(() => ({
+  getPokemonMock: vi.fn(),
+  getPokemonNameMapMock: vi.fn(),
+}));
+
+vi.mock("@/loaders", () => ({
+  getPokemon: getPokemonMock,
+  getPokemonNameMap: getPokemonNameMapMock,
+}));
+
+vi.mock("@/stores/playthroughs", () => ({
+  playthroughActions: {
+    getLocationFromComboboxId: vi.fn(),
+    relocateEncounterSlot: vi.fn(),
+  },
+}));
+
+vi.mock("@/stores/settings", async () => {
+  const { proxy } = await import("valtio");
+  return {
+    settingsStore: proxy({
+      moveEncountersBetweenLocations: false,
+      version: "1.0.0",
+    }),
+  };
+});
+
+describe("useComboboxDragAndDrop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    dragActions.cleanup();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("does not publish a preview after its drag data is cleared during lookup", async () => {
+    let resolvePokemon: (
+      value: { id: number; nationalDexId: number }[],
+    ) => void;
+    let resolveNameMap: (value: Map<number, string>) => void;
+    getPokemonMock.mockReturnValue(
+      new Promise<{ id: number; nationalDexId: number }[]>((resolve) => {
+        resolvePokemon = resolve;
+      }),
+    );
+    getPokemonNameMapMock.mockReturnValue(
+      new Promise<Map<number, string>>((resolve) => {
+        resolveNameMap = resolve;
+      }),
+    );
+    dragActions.startDrag("Pikachu", "route-2-single", null);
+    const { result } = renderHook(() =>
+      useComboboxDragAndDrop({
+        comboboxId: "route-1-single",
+        locationId: "route-1",
+        value: null,
+        onChange: vi.fn(),
+      }),
+    );
+    const event = {
+      dataTransfer: { dropEffect: "none" },
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as React.DragEvent<HTMLDivElement>;
+
+    act(() => {
+      result.current.handleDragOver(event);
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(getPokemonMock).toHaveBeenCalledOnce();
+
+    dragActions.clearDrag();
+    await act(async () => {
+      resolvePokemon!([{ id: 25, nationalDexId: 25 }]);
+      resolveNameMap!(new Map([[25, "pikachu"]]));
+    });
+
+    expect(result.current.dragPreview).toBeNull();
+  });
+});

--- a/src/components/PokemonCombobox/draggableComboboxSpriteMenu.tsx
+++ b/src/components/PokemonCombobox/draggableComboboxSpriteMenu.tsx
@@ -5,7 +5,7 @@ import { isEggId, type PokemonOptionType } from "@/loaders/pokemon";
 import { playthroughActions } from "@/stores/playthroughs";
 import { getActivePlaythrough } from "@/stores/playthroughs/store";
 import type { EncounterData } from "@/stores/playthroughs/types";
-import ContextMenu, { type ContextMenuItem } from "../ContextMenu";
+import type { ContextMenuItem } from "../ContextMenu";
 import { PokemonSprite } from "../PokemonSprite";
 
 type EncounterField = "head" | "body";
@@ -266,12 +266,14 @@ export function getDraggableComboboxSpriteMenuOptions({
     }),
   );
 
+  if (!value) return menuOptions;
+
   menuOptions.push(
     { id: "separator", separator: true },
     {
       id: "infinitefusiondex",
       label: "Open InfiniteDex entry",
-      href: `https://infinitefusiondex.com/details/${value?.id}`,
+      href: `https://infinitefusiondex.com/details/${value.id}`,
       target: "_blank",
       favicon: "https://infinitefusiondex.com/images/favicon.ico",
       icon: ArrowUpRight,
@@ -280,7 +282,7 @@ export function getDraggableComboboxSpriteMenuOptions({
     {
       id: "fusiondex",
       label: "Open FusionDex entry",
-      href: `https://fusiondex.org/sprite/pif/${value?.id}/`,
+      href: `https://fusiondex.org/sprite/pif/${value.id}/`,
       target: "_blank",
       favicon: "https://www.fusiondex.org/favicon.ico",
       icon: ArrowUpRight,

--- a/src/components/PokemonCombobox/draggableComboboxSpriteMenu.tsx
+++ b/src/components/PokemonCombobox/draggableComboboxSpriteMenu.tsx
@@ -1,0 +1,292 @@
+import { ArrowDownToDot, ArrowUpRight, Atom, Home, Undo2 } from "lucide-react";
+import { emitEvolutionEvent } from "@/lib/events";
+import { getLocationByIdFromMerged, getLocations } from "@/loaders/locations";
+import { isEggId, type PokemonOptionType } from "@/loaders/pokemon";
+import { playthroughActions } from "@/stores/playthroughs";
+import { getActivePlaythrough } from "@/stores/playthroughs/store";
+import type { EncounterData } from "@/stores/playthroughs/types";
+import ContextMenu, { type ContextMenuItem } from "../ContextMenu";
+import { PokemonSprite } from "../PokemonSprite";
+
+type EncounterField = "head" | "body";
+
+interface DraggableComboboxSpriteMenuOptions {
+  value: PokemonOptionType | null | undefined;
+  locationId?: string;
+  field: EncounterField;
+  customLocations: Parameters<typeof getLocationByIdFromMerged>[1];
+  moveEncountersBetweenLocations: boolean;
+  preEvolution: PokemonOptionType | null;
+  evolutions: PokemonOptionType[];
+  onOpenMoveModal: () => void;
+}
+
+function wouldCreateEggFusionAtOriginalLocation(
+  value: PokemonOptionType | null | undefined,
+  locationId: string | undefined,
+  field: EncounterField,
+) {
+  if (!value?.originalLocation || !locationId) return false;
+
+  const encounters = getActivePlaythrough()?.encounters as
+    | Record<string, EncounterData>
+    | undefined;
+  const originalEncounter = encounters?.[value.originalLocation];
+  if (!originalEncounter) return false;
+
+  return originalEncounter.isFusion
+    ? wouldCreateEggFusionInFusion(originalEncounter, value.id, field)
+    : wouldCreateEggFusionInSingleEncounter(originalEncounter, value.id);
+}
+
+function wouldCreateEggFusionInFusion(
+  encounter: EncounterData,
+  pokemonId: number,
+  field: EncounterField,
+) {
+  const oppositeField = field === "head" ? "body" : "head";
+  const oppositePokemon = encounter[oppositeField];
+  return Boolean(
+    (isEggId(pokemonId) && oppositePokemon) ||
+      (oppositePokemon && isEggId(oppositePokemon.id)),
+  );
+}
+
+function wouldCreateEggFusionInSingleEncounter(
+  encounter: EncounterData,
+  pokemonId: number,
+) {
+  const { head: headPokemon, body: bodyPokemon } = encounter;
+  return Boolean(
+    (isEggId(pokemonId) && (headPokemon || bodyPokemon)) ||
+      (headPokemon && isEggId(headPokemon.id)) ||
+      (bodyPokemon && isEggId(bodyPokemon.id)),
+  );
+}
+
+function getEvolutionLabel(pokemon: PokemonOptionType, action: string) {
+  return (
+    <div className="flex items-center gap-x-2 w-full">
+      <div className="flex items-center justify-center size-6 flex-shrink-0">
+        <PokemonSprite pokemonId={pokemon.id} generation="gen7" />
+      </div>
+      <span className="truncate">
+        {action && `${action} `}
+        {pokemon.name}
+      </span>
+    </div>
+  );
+}
+
+async function updateEvolution(
+  value: PokemonOptionType,
+  locationId: string,
+  field: EncounterField,
+  evolution: PokemonOptionType,
+  emitEvent: boolean,
+) {
+  await playthroughActions.updateEncounter(
+    locationId,
+    {
+      ...value,
+      id: evolution.id,
+      name: evolution.name,
+      nationalDexId: evolution.nationalDexId,
+    },
+    field,
+    false,
+  );
+
+  if (emitEvent) emitEvolutionEvent(locationId);
+}
+
+function getEvolutionMenuItem(
+  evolution: PokemonOptionType,
+  value: PokemonOptionType,
+  locationId: string,
+  field: EncounterField,
+  action: "Devolve to" | "Evolve to",
+  emitEvent: boolean,
+  icon?: typeof Atom | typeof Undo2,
+): ContextMenuItem {
+  return {
+    id: `${action === "Devolve to" ? "devolve" : "evolve"}-${evolution.id}`,
+    label: getEvolutionLabel(evolution, action),
+    ...(icon ? { icon } : {}),
+    onClick: () =>
+      updateEvolution(value, locationId, field, evolution, emitEvent),
+  };
+}
+
+function getMoveMenuOptions({
+  value,
+  locationId,
+  field,
+  customLocations,
+  onOpenMoveModal,
+}: Pick<
+  DraggableComboboxSpriteMenuOptions,
+  "value" | "locationId" | "field" | "customLocations" | "onOpenMoveModal"
+>) {
+  if (!value || !locationId) return [];
+
+  const menuOptions: ContextMenuItem[] = [];
+  if (value.originalLocation && value.originalLocation !== locationId) {
+    const originalLocation = getLocationByIdFromMerged(
+      value.originalLocation,
+      customLocations,
+    );
+    if (originalLocation) {
+      const disabled = wouldCreateEggFusionAtOriginalLocation(
+        value,
+        locationId,
+        field,
+      );
+      menuOptions.push({
+        id: "move-to-original",
+        label: "Move to Original Location",
+        tooltip: disabled
+          ? "Cannot move to original location - would create egg fusion"
+          : originalLocation.name,
+        icon: Home,
+        onClick: () =>
+          playthroughActions.moveToOriginalLocation(locationId, field, value),
+        disabled,
+      });
+    }
+  }
+
+  if (getLocations().some((location) => location.id !== locationId)) {
+    menuOptions.push({
+      id: "move",
+      label: "Move to Location",
+      icon: ArrowDownToDot,
+      onClick: onOpenMoveModal,
+    });
+  }
+  return menuOptions;
+}
+
+function getEvolutionMenuOptions({
+  value,
+  locationId,
+  field,
+  preEvolution,
+  evolutions,
+  includeSeparator,
+}: Pick<
+  DraggableComboboxSpriteMenuOptions,
+  "value" | "locationId" | "field" | "preEvolution" | "evolutions"
+> & { includeSeparator: boolean }) {
+  if (!value || !locationId) return [];
+
+  const menuOptions: ContextMenuItem[] = [];
+  if (includeSeparator && (preEvolution || evolutions.length > 0)) {
+    menuOptions.push({ id: "evolve-separator", separator: true });
+  }
+  if (preEvolution) {
+    menuOptions.push(
+      getEvolutionMenuItem(
+        preEvolution,
+        value,
+        locationId,
+        field,
+        "Devolve to",
+        false,
+        Undo2,
+      ),
+    );
+  }
+  if (evolutions.length === 0) return menuOptions;
+
+  const evolutionItems = evolutions.map((evolution) =>
+    getEvolutionMenuItem(
+      evolution,
+      value,
+      locationId,
+      field,
+      "Evolve to",
+      true,
+    ),
+  );
+  menuOptions.push(
+    evolutions.length === 1
+      ? getEvolutionMenuItem(
+          evolutions[0]!,
+          value,
+          locationId,
+          field,
+          "Evolve to",
+          true,
+          Atom,
+        )
+      : {
+          id: "evolve",
+          label: "Evolve to…",
+          icon: Atom,
+          children: evolutionItems.map((item, index) => ({
+            ...item,
+            label: getEvolutionLabel(evolutions[index]!, ""),
+          })),
+        },
+  );
+  return menuOptions;
+}
+
+export function getDraggableComboboxSpriteMenuOptions({
+  value,
+  locationId,
+  field,
+  customLocations,
+  moveEncountersBetweenLocations,
+  preEvolution,
+  evolutions,
+  onOpenMoveModal,
+}: DraggableComboboxSpriteMenuOptions) {
+  const menuOptions: ContextMenuItem[] = [];
+  if (moveEncountersBetweenLocations) {
+    menuOptions.push(
+      ...getMoveMenuOptions({
+        value,
+        locationId,
+        field,
+        customLocations,
+        onOpenMoveModal,
+      }),
+    );
+  }
+  menuOptions.push(
+    ...getEvolutionMenuOptions({
+      value,
+      locationId,
+      field,
+      preEvolution,
+      evolutions,
+      includeSeparator: moveEncountersBetweenLocations,
+    }),
+  );
+
+  menuOptions.push(
+    { id: "separator", separator: true },
+    {
+      id: "infinitefusiondex",
+      label: "Open InfiniteDex entry",
+      href: `https://infinitefusiondex.com/details/${value?.id}`,
+      target: "_blank",
+      favicon: "https://infinitefusiondex.com/images/favicon.ico",
+      icon: ArrowUpRight,
+      iconClassName: "dark:text-blue-300 text-blue-400",
+    },
+    {
+      id: "fusiondex",
+      label: "Open FusionDex entry",
+      href: `https://fusiondex.org/sprite/pif/${value?.id}/`,
+      target: "_blank",
+      favicon: "https://www.fusiondex.org/favicon.ico",
+      icon: ArrowUpRight,
+      iconClassName: "dark:text-blue-300 text-blue-400",
+    },
+  );
+
+  return menuOptions;
+}

--- a/src/components/PokemonCombobox/useComboboxDragAndDrop.ts
+++ b/src/components/PokemonCombobox/useComboboxDragAndDrop.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSnapshot } from "valtio";
 import { getPokemon, getPokemonNameMap } from "@/loaders";
 import type { PokemonOptionType } from "@/loaders/pokemon";
@@ -33,67 +33,61 @@ export function useComboboxDragAndDrop({
   const dragLeaveAnimationRef = useRef<number | null>(null);
 
   // Helper function to get location info from combobox ID
-  const getLocationInfo = useCallback((id: string) => {
+  const getLocationInfo = (id: string) => {
     return playthroughActions.getLocationFromComboboxId(id);
-  }, []);
+  };
 
   // Helper function to find Pokemon by name
-  const findPokemonByName = useCallback(
-    async (
-      pokemonName: string,
-      dragValue?: PokemonOptionType | null,
-    ): Promise<PokemonOptionType | null> => {
-      try {
-        const allPokemon = await getPokemon();
-        const nameMap = await getPokemonNameMap();
+  const findPokemonByName = async (
+    pokemonName: string,
+    dragValue?: PokemonOptionType | null,
+  ): Promise<PokemonOptionType | null> => {
+    try {
+      const allPokemon = await getPokemon();
+      const nameMap = await getPokemonNameMap();
 
-        const foundPokemon = allPokemon.find(
-          (p) => nameMap.get(p.id)?.toLowerCase() === pokemonName.toLowerCase(),
-        );
+      const foundPokemon = allPokemon.find(
+        (p) => nameMap.get(p.id)?.toLowerCase() === pokemonName.toLowerCase(),
+      );
 
-        if (!foundPokemon) return null;
+      if (!foundPokemon) return null;
 
-        return {
-          id: foundPokemon.id,
-          name: pokemonName,
-          nationalDexId: foundPokemon.nationalDexId,
-          originalLocation: locationId,
-          ...(dragValue && {
-            nickname: dragValue.nickname,
-            status: dragValue.status,
-          }),
-        };
-      } catch (err) {
-        console.error("Error finding Pokemon by name:", err);
-        return null;
-      }
-    },
-    [locationId],
-  );
+      return {
+        id: foundPokemon.id,
+        name: pokemonName,
+        nationalDexId: foundPokemon.nationalDexId,
+        originalLocation: locationId,
+        ...(dragValue && {
+          nickname: dragValue.nickname,
+          status: dragValue.status,
+        }),
+      };
+    } catch (err) {
+      console.error("Error finding Pokemon by name:", err);
+      return null;
+    }
+  };
 
   // Helper function to perform move operations
-  const performMoveOperation = useCallback(
-    (pokemon: PokemonOptionType) => {
-      if (!dragSnapshot.currentDragSource || !comboboxId) {
-        onChange(pokemon);
-        return;
-      }
+  const performMoveOperation = (pokemon: PokemonOptionType) => {
+    if (!dragSnapshot.currentDragSource || !comboboxId) {
+      onChange(pokemon);
+      return;
+    }
 
-      const sourceLocation = getLocationInfo(dragSnapshot.currentDragSource);
-      const targetLocation = getLocationInfo(comboboxId);
+    const sourceLocation = getLocationInfo(dragSnapshot.currentDragSource);
+    const targetLocation = getLocationInfo(comboboxId);
 
-      playthroughActions.relocateEncounterSlot({
-        sourceLocationId: sourceLocation.locationId,
-        sourceField: sourceLocation.field,
-        targetLocationId: targetLocation.locationId,
-        targetField: targetLocation.field,
-      });
-    },
-    [dragSnapshot.currentDragSource, comboboxId, onChange, getLocationInfo],
-  );
+    playthroughActions.relocateEncounterSlot({
+      sourceLocationId: sourceLocation.locationId,
+      sourceField: sourceLocation.field,
+      targetLocationId: targetLocation.locationId,
+      targetField: targetLocation.field,
+    });
+  };
 
   // Helper function to perform swap operations
-  const performSwapOperation = useCallback(() => {
+  const performSwapOperation = () => {
     if (!dragSnapshot.currentDragSource || !comboboxId) return;
 
     const sourceLocation = getLocationInfo(dragSnapshot.currentDragSource);
@@ -105,190 +99,145 @@ export function useComboboxDragAndDrop({
       targetLocationId: targetLocation.locationId,
       targetField: targetLocation.field,
     });
-  }, [dragSnapshot.currentDragSource, comboboxId, getLocationInfo]);
+  };
 
-  // Memoize drag state calculations
-  const dragState = useMemo(() => {
-    if (!comboboxId || !dragSnapshot.currentDragSource) {
-      return { isFromDifferentCombobox: false, canSwitch: false };
-    }
-
-    const isFromDifferentCombobox =
-      dragSnapshot.currentDragSource !== comboboxId;
-    const canSwitch =
-      isFromDifferentCombobox &&
-      dragSnapshot.currentDragValue &&
-      value &&
-      dragSnapshot.currentDragValue.uid !== value.uid;
-
-    return { isFromDifferentCombobox, canSwitch };
-  }, [
-    comboboxId,
-    dragSnapshot.currentDragSource,
-    dragSnapshot.currentDragValue,
-    value,
-  ]);
+  const isFromDifferentCombobox = Boolean(
+    comboboxId &&
+      dragSnapshot.currentDragSource &&
+      dragSnapshot.currentDragSource !== comboboxId,
+  );
+  const canSwitch =
+    isFromDifferentCombobox &&
+    dragSnapshot.currentDragValue &&
+    value &&
+    dragSnapshot.currentDragValue.uid !== value.uid;
 
   // Debounced drag preview setter
-  const setDragPreviewDebounced = useCallback(
-    (preview: PokemonOptionType | null) => {
-      if (dragPreviewTimeout) {
-        clearTimeout(dragPreviewTimeout);
-      }
+  const setDragPreviewDebounced = (preview: PokemonOptionType | null) => {
+    if (dragPreviewTimeout) {
+      clearTimeout(dragPreviewTimeout);
+    }
 
-      dragPreviewTimeout = window.setTimeout(() => {
-        setDragPreview(preview);
-        dragPreviewTimeout = null;
-      }, DRAG_PREVIEW_DEBOUNCE);
-    },
-    [],
-  );
+    dragPreviewTimeout = window.setTimeout(() => {
+      setDragPreview(preview);
+      dragPreviewTimeout = null;
+    }, DRAG_PREVIEW_DEBOUNCE);
+  };
 
   // Handle drop events on the input
-  const handleDrop = useCallback(
-    async (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      e.stopPropagation();
+  const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
 
-      // Clear debounced preview immediately
-      if (dragPreviewTimeout) {
-        clearTimeout(dragPreviewTimeout);
-        dragPreviewTimeout = null;
-      }
-      setDragPreview(null);
+    // Clear debounced preview immediately
+    if (dragPreviewTimeout) {
+      clearTimeout(dragPreviewTimeout);
+      dragPreviewTimeout = null;
+    }
+    setDragPreview(null);
 
-      const pokemonName = e.dataTransfer.getData("text/plain");
-      if (!pokemonName) return;
+    const pokemonName = e.dataTransfer.getData("text/plain");
+    if (!pokemonName) return;
 
-      // Preserve the drag value that initiated this drop while async lookup runs.
-      const dragValue = dragStore.currentDragValue;
+    // Preserve the drag value that initiated this drop while async lookup runs.
+    const dragValue = dragStore.currentDragValue;
 
-      // Check if move operations are allowed
-      if (
-        dragState.isFromDifferentCombobox &&
-        !settings.moveEncountersBetweenLocations
-      ) {
-        // If trying to move between different locations but setting is disabled, just set the Pokemon
-        let pokemon = dragValue;
-        if (!pokemon) {
-          pokemon = await findPokemonByName(pokemonName, dragValue);
-          if (!pokemon) return;
-        }
-        onChange(pokemon);
-        return;
-      }
-
-      // Handle swap operation if conditions are met
-      if (dragState.canSwitch && settings.moveEncountersBetweenLocations) {
-        performSwapOperation();
-        return;
-      }
-
-      // Determine the Pokemon to use (existing drag value or lookup by name)
+    // Check if move operations are allowed
+    if (isFromDifferentCombobox && !settings.moveEncountersBetweenLocations) {
+      // If trying to move between different locations but setting is disabled, just set the Pokemon
       let pokemon = dragValue;
       if (!pokemon) {
         pokemon = await findPokemonByName(pokemonName, dragValue);
         if (!pokemon) return;
       }
+      onChange(pokemon);
+      return;
+    }
 
-      // Perform move or set operation
-      if (
-        dragState.isFromDifferentCombobox &&
-        settings.moveEncountersBetweenLocations
-      ) {
-        performMoveOperation(pokemon);
-      } else {
-        onChange(pokemon);
-      }
-    },
-    [
-      dragState.canSwitch,
-      dragState.isFromDifferentCombobox,
-      settings.moveEncountersBetweenLocations,
-      performSwapOperation,
-      performMoveOperation,
-      findPokemonByName,
-      onChange,
-    ],
-  );
+    // Handle swap operation if conditions are met
+    if (canSwitch && settings.moveEncountersBetweenLocations) {
+      performSwapOperation();
+      return;
+    }
+
+    // Determine the Pokemon to use (existing drag value or lookup by name)
+    let pokemon = dragValue;
+    if (!pokemon) {
+      pokemon = await findPokemonByName(pokemonName, dragValue);
+      if (!pokemon) return;
+    }
+
+    // Perform move or set operation
+    if (isFromDifferentCombobox && settings.moveEncountersBetweenLocations) {
+      performMoveOperation(pokemon);
+    } else {
+      onChange(pokemon);
+    }
+  };
 
   // Helper function to update preview for drag data
-  const updatePreviewForDragData = useCallback(
-    async (pokemonName: string) => {
-      const pokemon = await findPokemonByName(pokemonName);
-      if (pokemon && dragStore.currentDragData === pokemonName) {
-        setDragPreview(pokemon);
+  const updatePreviewForDragData = async (pokemonName: string) => {
+    const pokemon = await findPokemonByName(pokemonName);
+    if (pokemon && dragStore.currentDragData === pokemonName) {
+      setDragPreview(pokemon);
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // If move operations are disabled, show appropriate drop effect
+    if (!settings.moveEncountersBetweenLocations) {
+      e.dataTransfer.dropEffect = "copy";
+    } else {
+      e.dataTransfer.dropEffect = "copy";
+    }
+
+    // Cancel pending drag leave timeout
+    if (dragLeaveAnimationRef.current !== null) {
+      clearTimeout(dragLeaveAnimationRef.current);
+      dragLeaveAnimationRef.current = null;
+    }
+
+    // Early exit if no drag data
+    if (!dragSnapshot.currentDragValue && !dragSnapshot.currentDragData) {
+      return;
+    }
+
+    // Handle existing Pokemon drag value
+    if (dragSnapshot.currentDragValue) {
+      const shouldUpdate =
+        !dragPreview || dragPreview.name !== dragSnapshot.currentDragValue.name;
+
+      if (shouldUpdate) {
+        setDragPreviewDebounced(dragSnapshot.currentDragValue);
       }
-    },
-    [findPokemonByName],
-  );
+      return;
+    }
 
-  const handleDragOver = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      e.stopPropagation();
+    // Handle Pokemon name drag data
+    if (dragSnapshot.currentDragData) {
+      const dragData = dragSnapshot.currentDragData;
+      const shouldUpdate = !dragPreview || dragPreview.name !== dragData;
 
-      // If move operations are disabled, show appropriate drop effect
-      if (!settings.moveEncountersBetweenLocations) {
-        e.dataTransfer.dropEffect = "copy";
-      } else {
-        e.dataTransfer.dropEffect = "copy";
-      }
+      if (shouldUpdate) {
+        setDragPreviewDebounced(null); // Clear current preview immediately
 
-      // Cancel pending drag leave timeout
-      if (dragLeaveAnimationRef.current !== null) {
-        clearTimeout(dragLeaveAnimationRef.current);
-        dragLeaveAnimationRef.current = null;
-      }
-
-      // Early exit if no drag data
-      if (!dragSnapshot.currentDragValue && !dragSnapshot.currentDragData) {
-        return;
-      }
-
-      // Handle existing Pokemon drag value
-      if (dragSnapshot.currentDragValue) {
-        const shouldUpdate =
-          !dragPreview ||
-          dragPreview.name !== dragSnapshot.currentDragValue.name;
-
-        if (shouldUpdate) {
-          setDragPreviewDebounced(dragSnapshot.currentDragValue);
+        // Debounce the expensive async operation
+        if (dragPreviewTimeout) {
+          clearTimeout(dragPreviewTimeout);
         }
-        return;
+
+        dragPreviewTimeout = window.setTimeout(() => {
+          updatePreviewForDragData(dragData);
+          dragPreviewTimeout = null;
+        }, DRAG_PREVIEW_DEBOUNCE);
       }
+    }
+  };
 
-      // Handle Pokemon name drag data
-      if (dragSnapshot.currentDragData) {
-        const dragData = dragSnapshot.currentDragData;
-        const shouldUpdate = !dragPreview || dragPreview.name !== dragData;
-
-        if (shouldUpdate) {
-          setDragPreviewDebounced(null); // Clear current preview immediately
-
-          // Debounce the expensive async operation
-          if (dragPreviewTimeout) {
-            clearTimeout(dragPreviewTimeout);
-          }
-
-          dragPreviewTimeout = window.setTimeout(() => {
-            updatePreviewForDragData(dragData);
-            dragPreviewTimeout = null;
-          }, DRAG_PREVIEW_DEBOUNCE);
-        }
-      }
-    },
-    [
-      dragPreview,
-      dragSnapshot.currentDragValue,
-      dragSnapshot.currentDragData,
-      setDragPreviewDebounced,
-      updatePreviewForDragData,
-      settings.moveEncountersBetweenLocations,
-    ],
-  );
-
-  const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
     e.stopPropagation(); // Prevent event bubbling
 
     // Cancel any pending timeout
@@ -302,14 +251,14 @@ export function useComboboxDragAndDrop({
       setDragPreview(null);
       dragLeaveAnimationRef.current = null;
     }, 50); // Short delay to allow for dragEnter on new targets
-  }, []);
+  };
 
-  const handleDragEnd = useCallback(() => {
+  const handleDragEnd = () => {
     // Clear global drag data when drag ends
     dragActions.clearDrag();
     // Also clear any lingering drag preview
     setDragPreview(null);
-  }, []);
+  };
 
   // Clean up timeouts on unmount
   useEffect(() => {

--- a/src/components/PokemonCombobox/useComboboxDragAndDrop.ts
+++ b/src/components/PokemonCombobox/useComboboxDragAndDrop.ts
@@ -39,7 +39,10 @@ export function useComboboxDragAndDrop({
 
   // Helper function to find Pokemon by name
   const findPokemonByName = useCallback(
-    async (pokemonName: string): Promise<PokemonOptionType | null> => {
+    async (
+      pokemonName: string,
+      dragValue?: PokemonOptionType | null,
+    ): Promise<PokemonOptionType | null> => {
       try {
         const allPokemon = await getPokemon();
         const nameMap = await getPokemonNameMap();
@@ -55,9 +58,9 @@ export function useComboboxDragAndDrop({
           name: pokemonName,
           nationalDexId: foundPokemon.nationalDexId,
           originalLocation: locationId,
-          ...(dragSnapshot.currentDragValue && {
-            nickname: dragSnapshot.currentDragValue.nickname,
-            status: dragSnapshot.currentDragValue.status,
+          ...(dragValue && {
+            nickname: dragValue.nickname,
+            status: dragValue.status,
           }),
         };
       } catch (err) {
@@ -65,7 +68,7 @@ export function useComboboxDragAndDrop({
         return null;
       }
     },
-    [locationId, dragSnapshot.currentDragValue],
+    [locationId],
   );
 
   // Helper function to perform move operations
@@ -157,15 +160,18 @@ export function useComboboxDragAndDrop({
       const pokemonName = e.dataTransfer.getData("text/plain");
       if (!pokemonName) return;
 
+      // Preserve the drag value that initiated this drop while async lookup runs.
+      const dragValue = dragStore.currentDragValue;
+
       // Check if move operations are allowed
       if (
         dragState.isFromDifferentCombobox &&
         !settings.moveEncountersBetweenLocations
       ) {
         // If trying to move between different locations but setting is disabled, just set the Pokemon
-        let pokemon = dragSnapshot.currentDragValue;
+        let pokemon = dragValue;
         if (!pokemon) {
-          pokemon = await findPokemonByName(pokemonName);
+          pokemon = await findPokemonByName(pokemonName, dragValue);
           if (!pokemon) return;
         }
         onChange(pokemon);
@@ -179,9 +185,9 @@ export function useComboboxDragAndDrop({
       }
 
       // Determine the Pokemon to use (existing drag value or lookup by name)
-      let pokemon = dragSnapshot.currentDragValue;
+      let pokemon = dragValue;
       if (!pokemon) {
-        pokemon = await findPokemonByName(pokemonName);
+        pokemon = await findPokemonByName(pokemonName, dragValue);
         if (!pokemon) return;
       }
 
@@ -198,7 +204,6 @@ export function useComboboxDragAndDrop({
     [
       dragState.canSwitch,
       dragState.isFromDifferentCombobox,
-      dragSnapshot.currentDragValue,
       settings.moveEncountersBetweenLocations,
       performSwapOperation,
       performMoveOperation,
@@ -211,11 +216,11 @@ export function useComboboxDragAndDrop({
   const updatePreviewForDragData = useCallback(
     async (pokemonName: string) => {
       const pokemon = await findPokemonByName(pokemonName);
-      if (pokemon && dragSnapshot.currentDragData === pokemonName) {
+      if (pokemon && dragStore.currentDragData === pokemonName) {
         setDragPreview(pokemon);
       }
     },
-    [findPokemonByName, dragSnapshot.currentDragData],
+    [findPokemonByName],
   );
 
   const handleDragOver = useCallback(
@@ -255,8 +260,8 @@ export function useComboboxDragAndDrop({
 
       // Handle Pokemon name drag data
       if (dragSnapshot.currentDragData) {
-        const shouldUpdate =
-          !dragPreview || dragPreview.name !== dragSnapshot.currentDragData;
+        const dragData = dragSnapshot.currentDragData;
+        const shouldUpdate = !dragPreview || dragPreview.name !== dragData;
 
         if (shouldUpdate) {
           setDragPreviewDebounced(null); // Clear current preview immediately
@@ -267,7 +272,7 @@ export function useComboboxDragAndDrop({
           }
 
           dragPreviewTimeout = window.setTimeout(() => {
-            updatePreviewForDragData(dragSnapshot.currentDragData!);
+            updatePreviewForDragData(dragData);
             dragPreviewTimeout = null;
           }, DRAG_PREVIEW_DEBOUNCE);
         }

--- a/src/components/PokemonSummaryCard/ArtworkVariantButton.tsx
+++ b/src/components/PokemonSummaryCard/ArtworkVariantButton.tsx
@@ -17,6 +17,27 @@ interface ArtworkVariantButtonProps {
   shouldLoad?: boolean;
 }
 
+function ArtworkVariantIcon({
+  hasVariants,
+  isLoading,
+  isShiftPressed,
+}: {
+  hasVariants: boolean;
+  isLoading: boolean;
+  isShiftPressed: boolean;
+}) {
+  if (isLoading) {
+    return <Loader2 className="animate-spin size-3" />;
+  }
+  if (!hasVariants) {
+    return <RefreshCwOff className="size-3" />;
+  }
+  if (isShiftPressed) {
+    return <RefreshCcw className="size-3" />;
+  }
+  return <RefreshCw className="size-3" />;
+}
+
 export function ArtworkVariantButton({
   headId,
   bodyId,
@@ -48,7 +69,7 @@ export function ArtworkVariantButton({
   );
 
   // Determine if variants are available
-  const hasVariants = variants && variants.length > 1;
+  const hasVariants = (variants?.length ?? 0) > 1;
 
   const handleCycleVariant = React.useCallback(
     async (event: React.MouseEvent) => {
@@ -77,19 +98,6 @@ export function ArtworkVariantButton({
       updateVariant,
     ],
   );
-
-  const buttonIcon = useMemo(() => {
-    if (isLoading) {
-      return <Loader2 className="animate-spin size-3" />;
-    }
-    if (!hasVariants) {
-      return <RefreshCwOff className="size-3" />;
-    }
-    if (isShiftPressed) {
-      return <RefreshCcw className="size-3" />;
-    }
-    return <RefreshCw className="size-3" />;
-  }, [hasVariants, isLoading, isShiftPressed]);
 
   const label = useMemo(() => {
     if (isLoading) {
@@ -143,7 +151,13 @@ export function ArtworkVariantButton({
         )}
         aria-label={label}
       >
-        <div className="">{buttonIcon}</div>
+        <div className="">
+          <ArtworkVariantIcon
+            hasVariants={hasVariants}
+            isLoading={isLoading}
+            isShiftPressed={isShiftPressed}
+          />
+        </div>
       </button>
     </CursorTooltip>
   );

--- a/src/components/PokemonSummaryCard/ArtworkVariantButton.tsx
+++ b/src/components/PokemonSummaryCard/ArtworkVariantButton.tsx
@@ -2,7 +2,7 @@
 
 import clsx from "clsx";
 import { Loader2, RefreshCcw, RefreshCw, RefreshCwOff } from "lucide-react";
-import React, { useMemo } from "react";
+import type React from "react";
 import { twMerge } from "tailwind-merge";
 import { useShiftKey } from "@/hooks/useKeyPressed";
 import { usePreferredVariantState, useSpriteVariants } from "@/hooks/useSprite";
@@ -71,35 +71,25 @@ export function ArtworkVariantButton({
   // Determine if variants are available
   const hasVariants = (variants?.length ?? 0) > 1;
 
-  const handleCycleVariant = React.useCallback(
-    async (event: React.MouseEvent) => {
-      // Prevent event bubbling to avoid triggering parent click handlers
-      event.stopPropagation();
+  const handleCycleVariant = async (event: React.MouseEvent) => {
+    // Prevent event bubbling to avoid triggering parent click handlers
+    event.stopPropagation();
 
-      if (disabled || !hasVariants || !variants) return;
+    if (disabled || !hasVariants || !variants) return;
 
-      const currentIndex = variants.indexOf(currentVariant);
-      const nextIndex = isShiftPressed
-        ? (currentIndex - 1 + variants.length) % variants.length
-        : (currentIndex + 1) % variants.length;
+    const currentIndex = variants.indexOf(currentVariant);
+    const nextIndex = isShiftPressed
+      ? (currentIndex - 1 + variants.length) % variants.length
+      : (currentIndex + 1) % variants.length;
 
-      const newVariant = variants[nextIndex] || "";
+    const newVariant = variants[nextIndex] || "";
 
-      await updateVariant(newVariant).catch((error) => {
-        console.error("Failed to cycle artwork variant:", error);
-      });
-    },
-    [
-      disabled,
-      hasVariants,
-      variants,
-      currentVariant,
-      isShiftPressed,
-      updateVariant,
-    ],
-  );
+    await updateVariant(newVariant).catch((error) => {
+      console.error("Failed to cycle artwork variant:", error);
+    });
+  };
 
-  const label = useMemo(() => {
+  const label = (() => {
     if (isLoading) {
       return "Checking for artwork variants...";
     }
@@ -107,7 +97,7 @@ export function ArtworkVariantButton({
       return "No artwork variants available";
     }
     return "Cycle artwork variants (hold Shift to reverse)";
-  }, [hasVariants, isLoading]);
+  })();
 
   // Don't render the button if there are no variants (unless still loading)
   if (!isLoading && !hasVariants) {

--- a/src/components/PokemonSummaryCard/ArtworkVariantModal.tsx
+++ b/src/components/PokemonSummaryCard/ArtworkVariantModal.tsx
@@ -12,7 +12,7 @@ import {
 import clsx from "clsx";
 import { ArrowUpRight, Check, X } from "lucide-react";
 import Image from "next/image";
-import React, { useMemo } from "react";
+import React from "react";
 import {
   usePreferredVariantState,
   useSpriteCredits,
@@ -84,32 +84,29 @@ export function ArtworkVariantModal({
 
   const isLoading = creditsLoading || variantsLoading;
 
-  const availableVariants = useMemo(() => {
+  const availableVariants = (() => {
     if (!variants || variants.length <= 1) return [];
     return variants;
-  }, [variants]);
+  })();
 
   const selectedVariant = localVariant ?? globalPreferredVariant ?? "";
 
-  const handleClose = React.useCallback(() => {
+  const handleClose = () => {
     setLocalVariant(null);
     onClose();
-  }, [onClose]);
+  };
 
-  const handleSelectVariant = React.useCallback(
-    async (variant: string) => {
-      // Immediately update the local state for instant UI feedback
-      setLocalVariant(variant);
-      await updateVariant(variant);
-    },
-    [updateVariant],
-  );
+  const handleSelectVariant = async (variant: string) => {
+    // Immediately update the local state for instant UI feedback
+    setLocalVariant(variant);
+    await updateVariant(variant);
+  };
 
-  const handleClearVariant = React.useCallback(async () => {
+  const handleClearVariant = async () => {
     setLocalVariant("");
     await updateVariant("");
     handleClose();
-  }, [updateVariant, handleClose]);
+  };
 
   // No cleanup needed
 

--- a/src/components/PokemonSummaryCard/FusionSprite.tsx
+++ b/src/components/PokemonSummaryCard/FusionSprite.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import type React from "react";
-import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { forwardRef, useImperativeHandle, useRef } from "react";
 
 import { twMerge } from "tailwind-merge";
 import Rays from "@/assets/images/rays.svg";
@@ -60,27 +60,26 @@ export const FusionSprite = forwardRef<FusionSpriteHandle, FusionSpriteProps>(
       variantBodyId,
     );
 
-    const handleImageError = useCallback(
-      async (e: React.SyntheticEvent<HTMLImageElement>) => {
-        const target = e.target as HTMLImageElement;
-        target.style.visibility = "hidden";
-        const failingUrl = target.src;
-        target.src = TRANSPARENT_PIXEL;
-        const newUrl = await getNextFallbackUrl(
-          failingUrl,
-          head,
-          body,
-          preferredVariant,
-        );
-        if (newUrl) {
-          target.src = newUrl;
-        }
-        window.requestAnimationFrame(() => {
-          target.style.visibility = "visible";
-        });
-      },
-      [head, body, preferredVariant],
-    );
+    const handleImageError = async (
+      e: React.SyntheticEvent<HTMLImageElement>,
+    ) => {
+      const target = e.target as HTMLImageElement;
+      target.style.visibility = "hidden";
+      const failingUrl = target.src;
+      target.src = TRANSPARENT_PIXEL;
+      const newUrl = await getNextFallbackUrl(
+        failingUrl,
+        head,
+        body,
+        preferredVariant,
+      );
+      if (newUrl) {
+        target.src = newUrl;
+      }
+      window.requestAnimationFrame(() => {
+        target.style.visibility = "visible";
+      });
+    };
 
     const statusState = getStatusState(head, body);
     const {

--- a/src/components/PokemonSummaryCard/LocationSelector.tsx
+++ b/src/components/PokemonSummaryCard/LocationSelector.tsx
@@ -8,7 +8,7 @@ import {
 } from "@headlessui/react";
 import { clsx } from "clsx";
 import { ArrowUpDown, Dna, MapPin, Search, X } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import BodyIcon from "@/assets/images/body.svg";
 import HeadIcon from "@/assets/images/head.svg";
 import { TypePills } from "@/components/TypePills";
@@ -123,21 +123,21 @@ function ActionPreview({
   sourceMoveTargetField,
 }: ActionPreviewProps) {
   // Compute target and source post-move states for typing previews
-  const { targetHeadAfter, targetBodyAfter } = useMemo(() => {
+  const { targetHeadAfter, targetBodyAfter } = (() => {
     const headAfter =
       selectedTargetField === "head" ? movingPokemon : otherFieldPokemon;
     const bodyAfter =
       selectedTargetField === "body" ? movingPokemon : otherFieldPokemon;
     return { targetHeadAfter: headAfter, targetBodyAfter: bodyAfter };
-  }, [selectedTargetField, movingPokemon, otherFieldPokemon]);
+  })();
 
-  const { sourceHeadAfter, sourceBodyAfter } = useMemo(() => {
+  const { sourceHeadAfter, sourceBodyAfter } = (() => {
     const headAfter =
       sourceMoveTargetField === "head" ? existingPokemon : remainingPokemon;
     const bodyAfter =
       sourceMoveTargetField === "body" ? existingPokemon : remainingPokemon;
     return { sourceHeadAfter: headAfter, sourceBodyAfter: bodyAfter };
-  }, [existingPokemon, remainingPokemon, sourceMoveTargetField]);
+  })();
 
   // Resolve typings with fusion hook (falls back to single when one side is missing)
   const existingTypes = useFusionTypesFromPokemon(existingPokemon, null, false);
@@ -226,25 +226,18 @@ function LocationItem({
   onSelect,
   movingPokemon,
 }: LocationItemProps) {
-  const handleSelect = useCallback(() => {
+  const handleSelect = () => {
     onSelect(location);
-  }, [location, onSelect]);
+  };
 
-  const existingPokemon = useMemo(
-    () => getSlotPokemon(location.id, selectedTargetField),
-    [location.id, selectedTargetField],
+  const existingPokemon = getSlotPokemon(location.id, selectedTargetField);
+
+  const otherFieldPokemon = getSlotPokemon(
+    location.id,
+    selectedTargetField === "head" ? "body" : "head",
   );
 
-  const otherFieldPokemon = useMemo(
-    () =>
-      getSlotPokemon(
-        location.id,
-        selectedTargetField === "head" ? "body" : "head",
-      ),
-    [location.id, selectedTargetField],
-  );
-
-  const remainingPokemon = useMemo(() => {
+  const remainingPokemon = (() => {
     if (!existingPokemon) return null;
     const activePlaythrough = getActivePlaythrough();
     const sourceEncounter = activePlaythrough?.encounters?.[currentLocationId];
@@ -253,10 +246,10 @@ function LocationItem({
         ? sourceEncounter.body
         : sourceEncounter.head
       : null;
-  }, [existingPokemon, currentLocationId, moveTargetField]);
+  })();
 
   // Check if this move would result in egg fusion
-  const wouldCreateEggFusion = useMemo(() => {
+  const wouldCreateEggFusion = (() => {
     if (!movingPokemon) return false;
 
     // Check if the Pokemon being moved is an egg
@@ -307,7 +300,7 @@ function LocationItem({
     }
 
     return false;
-  }, [movingPokemon, location.id, selectedTargetField]);
+  })();
 
   return (
     <li
@@ -456,21 +449,21 @@ function useLocationSelector({
     useState<"head" | "body" | null>(null);
   const selectedTargetField = selectedTargetFieldOverride ?? moveTargetField;
 
-  const setSelectedTargetField = useCallback((field: "head" | "body") => {
+  const setSelectedTargetField = (field: "head" | "body") => {
     setSelectedTargetFieldOverride(field);
-  }, []);
+  };
 
   // Get custom locations and create merged locations
   const customLocations = useCustomLocations();
 
   // Get all locations except the current one
-  const availableLocations = useMemo(() => {
+  const availableLocations = (() => {
     const allLocations = getLocationsSortedWithCustom(customLocations);
     return allLocations.filter((location) => location.id !== currentLocationId);
-  }, [customLocations, currentLocationId]);
+  })();
 
   // Filter locations based on search query (including Pokemon names)
-  const filteredLocations = useMemo(() => {
+  const filteredLocations = (() => {
     if (!searchQuery.trim()) {
       return availableLocations;
     }
@@ -504,10 +497,10 @@ function useLocationSelector({
 
       return false;
     });
-  }, [availableLocations, searchQuery]);
+  })();
 
   // Determine what Pokemon is being moved
-  const movingPokemon = useMemo(() => {
+  const movingPokemon = (() => {
     if (!encounterData) return null;
 
     if (moveTargetField === "head" && encounterData.head) {
@@ -517,16 +510,14 @@ function useLocationSelector({
       return encounterData.body;
     }
     return encounterData.head ?? encounterData.body ?? null;
-  }, [encounterData, moveTargetField]);
+  })();
 
   // Check if the Pokemon being moved is an egg
-  const isMovingPokemonEgg = useMemo(() => {
-    return movingPokemon ? isEggId(movingPokemon.id) : false;
-  }, [movingPokemon]);
+  const isMovingPokemonEgg = movingPokemon ? isEggId(movingPokemon.id) : false;
 
   // Determine if this should be treated as a fusion
   // Disable fusion mode when moving an egg to the head slot
-  const isFusion = useMemo(() => {
+  const isFusion = (() => {
     if (!encounterData?.head || !encounterData?.body) return false;
 
     // If moving an egg to head slot, disable fusion mode
@@ -535,17 +526,12 @@ function useLocationSelector({
     }
 
     return true;
-  }, [
-    encounterData?.head,
-    encounterData?.body,
-    moveTargetField,
-    isMovingPokemonEgg,
-  ]);
+  })();
 
-  const resetState = useCallback(() => {
+  const resetState = () => {
     setSearchQuery("");
     setSelectedTargetFieldOverride(null);
-  }, []);
+  };
 
   return {
     searchQuery,
@@ -583,19 +569,16 @@ function LocationSelector({
     encounterData,
   });
 
-  const handleLocationSelect = useCallback(
-    (location: CombinedLocation) => {
-      onSelectLocation(location.id, selectedTargetField);
-      resetState();
-      onClose();
-    },
-    [onSelectLocation, selectedTargetField, resetState, onClose],
-  );
-
-  const handleClose = useCallback(() => {
+  const handleLocationSelect = (location: CombinedLocation) => {
+    onSelectLocation(location.id, selectedTargetField);
     resetState();
     onClose();
-  }, [resetState, onClose]);
+  };
+
+  const handleClose = () => {
+    resetState();
+    onClose();
+  };
 
   return (
     <Dialog

--- a/src/components/PokemonSummaryCard/PokemonContextMenu.tsx
+++ b/src/components/PokemonSummaryCard/PokemonContextMenu.tsx
@@ -191,8 +191,6 @@ export function PokemonContextMenu({
     displayPokemon.body?.id ?? null,
   );
 
-  const [hasContextMenuBeenOpened, setHasContextMenuBeenOpened] =
-    useState(false);
   const [isVariantModalOpen, setIsVariantModalOpen] = useState(false);
   const [isMoveHeadModalOpen, setIsMoveHeadModalOpen] = useState(false);
   const [isMoveBodyModalOpen, setIsMoveBodyModalOpen] = useState(false);
@@ -361,11 +359,6 @@ export function PokemonContextMenu({
         disabled={eitherPokemonIsEgg}
         items={contextItems}
         portalRootId="location-table"
-        onOpenChange={
-          hasContextMenuBeenOpened
-            ? undefined
-            : () => setHasContextMenuBeenOpened(true)
-        }
       >
         {children}
       </ContextMenu>

--- a/src/components/PokemonSummaryCard/PokemonContextMenu.tsx
+++ b/src/components/PokemonSummaryCard/PokemonContextMenu.tsx
@@ -7,7 +7,7 @@ import {
   Skull,
 } from "lucide-react";
 import dynamic from "next/dynamic";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import { useSnapshot } from "valtio";
 import BodyIcon from "@/assets/images/body.svg";
 import EscapeIcon from "@/assets/images/escape-cloud.svg";
@@ -196,57 +196,57 @@ export function PokemonContextMenu({
   const [isMoveBodyModalOpen, setIsMoveBodyModalOpen] = useState(false);
 
   // Handler to mark both Pokemon in the fusion as deceased
-  const handleMarkAsDeceased = useCallback(async () => {
+  const handleMarkAsDeceased = async () => {
     await playthroughActions.markEncounterAsDeceased(locationId);
-  }, [locationId]);
+  };
 
   // Handler to move both Pokemon in the fusion to box (stored status)
-  const handleMoveToBox = useCallback(async () => {
+  const handleMoveToBox = async () => {
     await playthroughActions.moveEncounterToBox(locationId);
-  }, [locationId]);
+  };
 
   // Handler to mark both Pokemon in the fusion as captured
-  const handleMarkAsCaptured = useCallback(async () => {
+  const handleMarkAsCaptured = async () => {
     await playthroughActions.markEncounterAsCaptured(locationId);
-  }, [locationId]);
+  };
 
   // Handler to mark both Pokemon in the fusion as missed
-  const handleMarkAsMissed = useCallback(async () => {
+  const handleMarkAsMissed = async () => {
     await playthroughActions.markEncounterAsMissed(locationId);
-  }, [locationId]);
+  };
 
   // Handler to mark both Pokemon in the fusion as received
-  const handleMarkAsReceived = useCallback(async () => {
+  const handleMarkAsReceived = async () => {
     await playthroughActions.markEncounterAsReceived(locationId);
-  }, [locationId]);
+  };
 
   // Handler for moving head Pokemon
-  const handleMoveHead = useCallback(
-    async (targetLocationId: string, targetField: "head" | "body") => {
-      await playthroughActions.relocateEncounterSlot({
-        sourceLocationId: locationId,
-        sourceField: "head",
-        targetLocationId,
-        targetField,
-      });
-    },
-    [locationId],
-  );
+  const handleMoveHead = async (
+    targetLocationId: string,
+    targetField: "head" | "body",
+  ) => {
+    await playthroughActions.relocateEncounterSlot({
+      sourceLocationId: locationId,
+      sourceField: "head",
+      targetLocationId,
+      targetField,
+    });
+  };
 
   // Handler for moving body Pokemon
-  const handleMoveBody = useCallback(
-    async (targetLocationId: string, targetField: "head" | "body") => {
-      await playthroughActions.relocateEncounterSlot({
-        sourceLocationId: locationId,
-        sourceField: "body",
-        targetLocationId,
-        targetField,
-      });
-    },
-    [locationId],
-  );
+  const handleMoveBody = async (
+    targetLocationId: string,
+    targetField: "head" | "body",
+  ) => {
+    await playthroughActions.relocateEncounterSlot({
+      sourceLocationId: locationId,
+      sourceField: "body",
+      targetLocationId,
+      targetField,
+    });
+  };
 
-  const contextItems = useMemo<ContextMenuItem[]>(() => {
+  const contextItems: ContextMenuItem[] = (() => {
     // Use display Pokemon for links instead of raw encounter data
     const id = getSpriteId(displayPokemon.head?.id, displayPokemon.body?.id);
 
@@ -337,21 +337,7 @@ export function PokemonContextMenu({
     items.push(...createExternalDexItems(id, preferredVariant));
 
     return items;
-  }, [
-    preferredVariant,
-    encounterData,
-    displayPokemon,
-    eitherPokemonIsEgg,
-    hasArtVariants,
-    isLoadingVariants,
-    settings.moveEncountersBetweenLocations,
-    showStatusActions,
-    handleMarkAsDeceased,
-    handleMoveToBox,
-    handleMarkAsCaptured,
-    handleMarkAsMissed,
-    handleMarkAsReceived,
-  ]);
+  })();
 
   return (
     <>

--- a/src/components/PokemonSummaryCard/TeamMemberContextMenu.tsx
+++ b/src/components/PokemonSummaryCard/TeamMemberContextMenu.tsx
@@ -9,7 +9,7 @@ import {
   Undo2,
 } from "lucide-react";
 import dynamic from "next/dynamic";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import BodyIcon from "@/assets/images/body.svg";
 import HeadIcon from "@/assets/images/head.svg";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
@@ -457,53 +457,39 @@ export function TeamMemberContextMenu({
   const [isVariantModalOpen, setIsVariantModalOpen] = useState(false);
 
   // Handler to mark team member as deceased
-  const handleMarkAsDeceased = useCallback(async () => {
+  const handleMarkAsDeceased = async () => {
     await playthroughActions.markTeamMemberAsDeceased(position);
-  }, [position]);
+  };
 
   // Handler to move team member to box
-  const handleMoveToBox = useCallback(async () => {
+  const handleMoveToBox = async () => {
     await playthroughActions.moveTeamMemberToBox(position);
-  }, [position]);
+  };
 
-  const handleEvolveHead = useCallback(
-    (evolution: Pokemon) => evolvePokemon(headPokemon, evolution),
-    [headPokemon],
-  );
+  const handleEvolveHead = (evolution: Pokemon) =>
+    evolvePokemon(headPokemon, evolution);
 
-  const handleEvolveBody = useCallback(
-    (evolution: Pokemon) => evolvePokemon(bodyPokemon, evolution),
-    [bodyPokemon],
-  );
+  const handleEvolveBody = (evolution: Pokemon) =>
+    evolvePokemon(bodyPokemon, evolution);
 
-  const handleDevolveHead = useCallback(
-    () => devolvePokemon(headPokemon, headPreEvolution),
-    [headPokemon, headPreEvolution],
-  );
+  const handleDevolveHead = () => devolvePokemon(headPokemon, headPreEvolution);
 
-  const handleDevolveBody = useCallback(
-    () => devolvePokemon(bodyPokemon, bodyPreEvolution),
-    [bodyPokemon, bodyPreEvolution],
-  );
+  const handleDevolveBody = () => devolvePokemon(bodyPokemon, bodyPreEvolution);
 
   // Handler to flip fusion (swap head and body)
-  const handleFlipFusion = useCallback(async () => {
+  const handleFlipFusion = async () => {
     if (hasFusionPair === false) return;
 
     await playthroughActions.flipTeamMemberFusion(position);
-  }, [hasFusionPair, position]);
+  };
 
-  const handleGoToHeadEncounter = useCallback(
-    () => scrollToPokemonEncounter(headPokemon, onClose),
-    [headPokemon, onClose],
-  );
+  const handleGoToHeadEncounter = () =>
+    scrollToPokemonEncounter(headPokemon, onClose);
 
-  const handleGoToBodyEncounter = useCallback(
-    () => scrollToPokemonEncounter(bodyPokemon, onClose),
-    [bodyPokemon, onClose],
-  );
+  const handleGoToBodyEncounter = () =>
+    scrollToPokemonEncounter(bodyPokemon, onClose);
 
-  const contextItems = useMemo<ContextMenuItem[]>(() => {
+  const contextItems: ContextMenuItem[] = (() => {
     return createTeamMemberContextItems({
       headPokemon,
       bodyPokemon,
@@ -527,26 +513,7 @@ export function TeamMemberContextMenu({
         onGoToBodyEncounter: handleGoToBodyEncounter,
       },
     });
-  }, [
-    headPokemon,
-    bodyPokemon,
-    preferredVariant,
-    hasArtVariants,
-    isLoadingVariants,
-    handleMarkAsDeceased,
-    handleMoveToBox,
-    headEvolutions,
-    headPreEvolution,
-    bodyEvolutions,
-    bodyPreEvolution,
-    handleEvolveHead,
-    handleEvolveBody,
-    handleDevolveHead,
-    handleDevolveBody,
-    handleFlipFusion,
-    handleGoToHeadEncounter,
-    handleGoToBodyEncounter,
-  ]);
+  })();
 
   return (
     <>

--- a/src/components/PokemonSummaryCard/TeamMemberContextMenu.tsx
+++ b/src/components/PokemonSummaryCard/TeamMemberContextMenu.tsx
@@ -80,6 +80,17 @@ interface TeamMemberContextItemOptions {
   actions: TeamMemberContextActions;
 }
 
+interface TeamMemberContextActionOptions {
+  headPokemon: PokemonOptionType | null | undefined;
+  bodyPokemon: PokemonOptionType | null | undefined;
+  headPreEvolution: Pokemon | null;
+  bodyPreEvolution: Pokemon | null;
+  position: number;
+  hasFusionPair: boolean;
+  onClose: (() => void) | undefined;
+  onOpenVariantModal: () => void;
+}
+
 function createPokemonActionLabel(pokemon: Pokemon, action: string) {
   return (
     <div className="flex items-center gap-x-2 w-full">
@@ -359,35 +370,17 @@ function createTeamMemberContextItems({
   ];
 }
 
-async function evolvePokemon(
+async function updatePokemonToEvolution(
   pokemon: PokemonOptionType | null | undefined,
-  evolution: Pokemon,
+  evolution: Pokemon | null,
 ) {
-  if (!pokemon?.uid) return;
+  if (!pokemon?.uid || !evolution) return;
 
   await playthroughActions.updatePokemonByUID(pokemon.uid, {
     ...pokemon,
     id: evolution.id,
     name: evolution.name,
     nationalDexId: evolution.nationalDexId,
-  });
-
-  if (pokemon.originalLocation) {
-    emitEvolutionEvent(pokemon.originalLocation);
-  }
-}
-
-async function devolvePokemon(
-  pokemon: PokemonOptionType | null | undefined,
-  preEvolution: Pokemon | null,
-) {
-  if (!pokemon?.uid || !preEvolution) return;
-
-  await playthroughActions.updatePokemonByUID(pokemon.uid, {
-    ...pokemon,
-    id: preEvolution.id,
-    name: preEvolution.name,
-    nationalDexId: preEvolution.nationalDexId,
   });
 
   if (pokemon.originalLocation) {
@@ -407,6 +400,58 @@ function scrollToPokemonEncounter(
     durationMs: 1200,
   });
   onClose?.();
+}
+
+function createTeamMemberContextActions({
+  headPokemon,
+  bodyPokemon,
+  headPreEvolution,
+  bodyPreEvolution,
+  position,
+  hasFusionPair,
+  onClose,
+  onOpenVariantModal,
+}: TeamMemberContextActionOptions): TeamMemberContextActions {
+  return {
+    onOpenVariantModal,
+    onReverseFusion: async () => {
+      if (hasFusionPair === false) return;
+
+      await playthroughActions.flipTeamMemberFusion(position);
+    },
+    onMarkAsDeceased: () =>
+      playthroughActions.markTeamMemberAsDeceased(position),
+    onMoveToBox: () => playthroughActions.moveTeamMemberToBox(position),
+    onDevolveHead: () =>
+      updatePokemonToEvolution(headPokemon, headPreEvolution),
+    onEvolveHead: (evolution) =>
+      updatePokemonToEvolution(headPokemon, evolution),
+    onGoToHeadEncounter: () => scrollToPokemonEncounter(headPokemon, onClose),
+    onDevolveBody: () =>
+      updatePokemonToEvolution(bodyPokemon, bodyPreEvolution),
+    onEvolveBody: (evolution) =>
+      updatePokemonToEvolution(bodyPokemon, evolution),
+    onGoToBodyEncounter: () => scrollToPokemonEncounter(bodyPokemon, onClose),
+  };
+}
+
+function useTeamMemberArtworkVariants(
+  headPokemon: PokemonOptionType | null | undefined,
+  bodyPokemon: PokemonOptionType | null | undefined,
+  shouldLoad: boolean,
+): Pick<TeamMemberContextItemOptions, "hasArtVariants" | "isLoadingVariants"> {
+  const headId = headPokemon?.id;
+  const bodyId = bodyPokemon?.id;
+  const { data: variants, isLoading: isLoadingVariants } = useSpriteVariants(
+    headId,
+    bodyId,
+    shouldLoad && !isEggId(headId) && !isEggId(bodyId),
+  );
+
+  return {
+    hasArtVariants: variants && variants.length > 1,
+    isLoadingVariants,
+  };
 }
 
 interface TeamMemberContextMenuProps {
@@ -433,87 +478,41 @@ export function TeamMemberContextMenu({
     headPokemon != null &&
     bodyPokemon != null &&
     headPokemon.id !== bodyPokemon.id;
-
-  // Check for art variants using the team member's Pokémon
-  const { data: variants, isLoading: isLoadingVariants } = useSpriteVariants(
-    headPokemon?.id,
-    bodyPokemon?.id,
-    shouldLoad && !isEggId(headPokemon?.id) && !isEggId(bodyPokemon?.id),
+  const [isVariantModalOpen, setIsVariantModalOpen] = useState(false);
+  const { hasArtVariants, isLoadingVariants } = useTeamMemberArtworkVariants(
+    headPokemon,
+    bodyPokemon,
+    shouldLoad,
   );
-  const hasArtVariants = variants && variants.length > 1;
-
-  // Get current preferred variant for the team member
   const { variant: preferredVariant } = usePreferredVariantState(
     headPokemon?.id ?? null,
     bodyPokemon?.id ?? null,
   );
-
-  // Get evolution data for both Pokémon
   const { evolutions: headEvolutions, preEvolution: headPreEvolution } =
     usePokemonEvolutionData(headPokemon?.id, true);
   const { evolutions: bodyEvolutions, preEvolution: bodyPreEvolution } =
     usePokemonEvolutionData(bodyPokemon?.id, true);
-
-  const [isVariantModalOpen, setIsVariantModalOpen] = useState(false);
-
-  // Handler to mark team member as deceased
-  const handleMarkAsDeceased = async () => {
-    await playthroughActions.markTeamMemberAsDeceased(position);
-  };
-
-  // Handler to move team member to box
-  const handleMoveToBox = async () => {
-    await playthroughActions.moveTeamMemberToBox(position);
-  };
-
-  const handleEvolveHead = (evolution: Pokemon) =>
-    evolvePokemon(headPokemon, evolution);
-
-  const handleEvolveBody = (evolution: Pokemon) =>
-    evolvePokemon(bodyPokemon, evolution);
-
-  const handleDevolveHead = () => devolvePokemon(headPokemon, headPreEvolution);
-
-  const handleDevolveBody = () => devolvePokemon(bodyPokemon, bodyPreEvolution);
-
-  // Handler to flip fusion (swap head and body)
-  const handleFlipFusion = async () => {
-    if (hasFusionPair === false) return;
-
-    await playthroughActions.flipTeamMemberFusion(position);
-  };
-
-  const handleGoToHeadEncounter = () =>
-    scrollToPokemonEncounter(headPokemon, onClose);
-
-  const handleGoToBodyEncounter = () =>
-    scrollToPokemonEncounter(bodyPokemon, onClose);
-
-  const contextItems: ContextMenuItem[] = (() => {
-    return createTeamMemberContextItems({
+  const contextItems = createTeamMemberContextItems({
+    headPokemon,
+    bodyPokemon,
+    headEvolutions,
+    headPreEvolution,
+    bodyEvolutions,
+    bodyPreEvolution,
+    preferredVariant,
+    hasArtVariants,
+    isLoadingVariants,
+    actions: createTeamMemberContextActions({
       headPokemon,
       bodyPokemon,
-      headEvolutions,
       headPreEvolution,
-      bodyEvolutions,
       bodyPreEvolution,
-      preferredVariant,
-      hasArtVariants,
-      isLoadingVariants,
-      actions: {
-        onOpenVariantModal: () => setIsVariantModalOpen(true),
-        onReverseFusion: handleFlipFusion,
-        onMarkAsDeceased: handleMarkAsDeceased,
-        onMoveToBox: handleMoveToBox,
-        onDevolveHead: handleDevolveHead,
-        onEvolveHead: handleEvolveHead,
-        onGoToHeadEncounter: handleGoToHeadEncounter,
-        onDevolveBody: handleDevolveBody,
-        onEvolveBody: handleEvolveBody,
-        onGoToBodyEncounter: handleGoToBodyEncounter,
-      },
-    });
-  })();
+      position,
+      hasFusionPair,
+      onClose,
+      onOpenVariantModal: () => setIsVariantModalOpen(true),
+    }),
+  });
 
   return (
     <>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -2,7 +2,7 @@
 
 import clsx from "clsx";
 import { CircleIcon, SkullIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import EscapeIcon from "@/assets/images/escape-cloud.svg";
 import PokeballIcon from "@/assets/images/pokeball.svg";
 import { getLocationsSortedWithCustom } from "@/loaders";
@@ -25,54 +25,53 @@ export default function ProgressBar({ className }: ProgressBarProps) {
     null,
   );
 
-  const { capturedCount, deceasedCount, missedCount, totalCount } =
-    useMemo(() => {
-      const allLocations = getLocationsSortedWithCustom(customLocations);
-      const total = allLocations.length;
+  const { capturedCount, deceasedCount, missedCount, totalCount } = (() => {
+    const allLocations = getLocationsSortedWithCustom(customLocations);
+    const total = allLocations.length;
 
-      let captured = 0;
-      let deceased = 0;
-      let missed = 0;
+    let captured = 0;
+    let deceased = 0;
+    let missed = 0;
 
-      for (const location of allLocations) {
-        const encounter = encounters?.[location.id];
-        if (!encounter || (!encounter.head && !encounter.body)) {
-          continue;
-        }
-
-        const statuses = [encounter.head?.status, encounter.body?.status];
-        const hasMissed = statuses.includes(PokemonStatus.MISSED);
-        const hasDeceased = statuses.includes(PokemonStatus.DECEASED);
-        const hasSuccessfulEncounter = statuses.some(
-          (status) =>
-            status === PokemonStatus.CAPTURED ||
-            status === PokemonStatus.RECEIVED ||
-            status === PokemonStatus.TRADED ||
-            status === PokemonStatus.STORED,
-        );
-
-        if (hasMissed) {
-          missed += 1;
-          continue;
-        }
-
-        if (hasDeceased) {
-          deceased += 1;
-          continue;
-        }
-
-        if (hasSuccessfulEncounter) {
-          captured += 1;
-        }
+    for (const location of allLocations) {
+      const encounter = encounters?.[location.id];
+      if (!encounter || (!encounter.head && !encounter.body)) {
+        continue;
       }
 
-      return {
-        capturedCount: captured,
-        deceasedCount: deceased,
-        missedCount: missed,
-        totalCount: total,
-      };
-    }, [encounters, customLocations]);
+      const statuses = [encounter.head?.status, encounter.body?.status];
+      const hasMissed = statuses.includes(PokemonStatus.MISSED);
+      const hasDeceased = statuses.includes(PokemonStatus.DECEASED);
+      const hasSuccessfulEncounter = statuses.some(
+        (status) =>
+          status === PokemonStatus.CAPTURED ||
+          status === PokemonStatus.RECEIVED ||
+          status === PokemonStatus.TRADED ||
+          status === PokemonStatus.STORED,
+      );
+
+      if (hasMissed) {
+        missed += 1;
+        continue;
+      }
+
+      if (hasDeceased) {
+        deceased += 1;
+        continue;
+      }
+
+      if (hasSuccessfulEncounter) {
+        captured += 1;
+      }
+    }
+
+    return {
+      capturedCount: captured,
+      deceasedCount: deceased,
+      missedCount: missed,
+      totalCount: total,
+    };
+  })();
 
   const completedCount = capturedCount + deceasedCount + missedCount;
   const unencounteredCount = Math.max(totalCount - completedCount, 0);

--- a/src/components/TypePills.tsx
+++ b/src/components/TypePills.tsx
@@ -1,7 +1,6 @@
 import clsx from "clsx";
 import { getTypeWeaknesses } from "poke-types";
 import type React from "react";
-import { useMemo } from "react";
 import { twMerge } from "tailwind-merge";
 import type { TypeName } from "@/lib/typings";
 import { ALL_TYPES } from "@/lib/typings";
@@ -97,14 +96,11 @@ function TypeEffectivenessSummary({
 }) {
   // Keep computed groups available for future presentation tweaks (group chips)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const _groups = useMemo(
-    () => getDefensiveEffectGroups(primary, secondary),
-    [primary, secondary],
-  );
+  const _groups = getDefensiveEffectGroups(primary, secondary);
 
   const mainType = (primary ?? secondary) as string | undefined;
   const secondType = primary && secondary ? (secondary as string) : undefined;
-  const multiplierByType = useMemo(() => {
+  const multiplierByType = (() => {
     if (!mainType) return {} as Record<TypeName, number>;
     const map = getTypeWeaknesses(mainType, secondType);
     const result: Record<TypeName, number> = {} as Record<TypeName, number>;
@@ -113,7 +109,7 @@ function TypeEffectivenessSummary({
       result[t] = Number.isFinite(v) ? (v as number) : 1;
     });
     return result;
-  }, [mainType, secondType]);
+  })();
 
   const factorLabel = (v: number): string => {
     if (v === 4) return "4x";

--- a/src/components/analytics/AnalyticsDebugPanel.tsx
+++ b/src/components/analytics/AnalyticsDebugPanel.tsx
@@ -41,7 +41,7 @@ export function AnalyticsDebugPanel() {
   const [enabled, setEnabled] = useState(false);
   const [open, setOpen] = useState(true);
   const [counters, setCounters] = useState<AnalyticsDebugCounters>(
-    getAnalyticsDebugCounters(),
+    getAnalyticsDebugCounters,
   );
 
   useEffect(() => {

--- a/src/components/analytics/AnalyticsDebugPanel.tsx
+++ b/src/components/analytics/AnalyticsDebugPanel.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { Bug, RotateCcw, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-import { useMounted } from "@/hooks/useMounted";
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import {
   type AnalyticsDebugCounters,
   getAnalyticsDebugCounters,
@@ -12,20 +11,24 @@ import {
 const DEBUG_QUERY_KEY = "analytics_debug";
 const DEBUG_STORAGE_KEY = "analytics-debug-panel";
 
-function isPanelEnabled(): boolean {
+const subscribeToPanelEnabled = () => () => {};
+const getServerPanelEnabledSnapshot = () => false;
+
+function isDebugQueryEnabled(): boolean {
   if (typeof window === "undefined") {
     return false;
   }
 
   const params = new URLSearchParams(window.location.search);
-  const queryEnabled = params.get(DEBUG_QUERY_KEY) === "1";
-  if (queryEnabled) {
-    try {
-      localStorage.setItem(DEBUG_STORAGE_KEY, "1");
-    } catch {
-      // Ignore localStorage write failures.
-    }
+  return params.get(DEBUG_QUERY_KEY) === "1";
+}
 
+function isPanelEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  if (isDebugQueryEnabled()) {
     return true;
   }
 
@@ -37,20 +40,27 @@ function isPanelEnabled(): boolean {
 }
 
 export function AnalyticsDebugPanel() {
-  const mounted = useMounted();
-  const [enabled, setEnabled] = useState(false);
+  const enabled = useSyncExternalStore(
+    subscribeToPanelEnabled,
+    isPanelEnabled,
+    getServerPanelEnabledSnapshot,
+  );
   const [open, setOpen] = useState(true);
   const [counters, setCounters] = useState<AnalyticsDebugCounters>(
     getAnalyticsDebugCounters,
   );
 
   useEffect(() => {
-    if (!mounted) {
+    if (!isDebugQueryEnabled()) {
       return;
     }
 
-    setEnabled(isPanelEnabled());
-  }, [mounted]);
+    try {
+      localStorage.setItem(DEBUG_STORAGE_KEY, "1");
+    } catch {
+      // Ignore localStorage write failures.
+    }
+  }, []);
 
   useEffect(() => {
     if (!enabled) {
@@ -80,7 +90,7 @@ export function AnalyticsDebugPanel() {
     return hasConsentBlocks && !hasOtherBlockers;
   }, [counters]);
 
-  if (!mounted || !enabled) {
+  if (!enabled) {
     return null;
   }
 

--- a/src/components/pc/PokemonPCSheet.tsx
+++ b/src/components/pc/PokemonPCSheet.tsx
@@ -13,7 +13,6 @@ import {
 } from "@headlessui/react";
 import clsx from "clsx";
 import { Box, Boxes, Skull, Users, X } from "lucide-react";
-import { useCallback, useMemo } from "react";
 import { getLocationsSortedWithCustom } from "@/loaders/locations";
 import type { PokemonOptionType } from "@/loaders/pokemon";
 import {
@@ -63,39 +62,27 @@ export default function PokemonPCSheet({
     selectTeamMember,
   } = useTeamMemberPicker();
 
-  const mergedLocations = useMemo(
-    () => getLocationsSortedWithCustom(customLocations),
-    [customLocations],
-  );
+  const mergedLocations = getLocationsSortedWithCustom(customLocations);
 
-  const idToName = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const loc of mergedLocations) map.set(loc.id, loc.name);
-    return map;
-  }, [mergedLocations]);
+  const idToName = new Map<string, string>();
+  for (const loc of mergedLocations) idToName.set(loc.id, loc.name);
 
-  const pokemonByUid = useMemo(
-    () => buildPokemonUidIndex(encounters),
-    [encounters],
-  );
+  const pokemonByUid = buildPokemonUidIndex(encounters);
 
   // Handlers for team member picker modal
-  const handleTeamMemberClick = useCallback(
-    (
-      position: number,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      _existingTeamMember: {
-        position: number;
-        isEmpty: boolean;
-        headPokemon: PokemonOptionType | null;
-        bodyPokemon: PokemonOptionType | null;
-        isFusion: boolean;
-      },
-    ) => {
-      openPicker(position);
+  const handleTeamMemberClick = (
+    position: number,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _existingTeamMember: {
+      position: number;
+      isEmpty: boolean;
+      headPokemon: PokemonOptionType | null;
+      bodyPokemon: PokemonOptionType | null;
+      isFusion: boolean;
     },
-    [openPicker],
-  );
+  ) => {
+    openPicker(position);
+  };
 
   const team: Entry[] = activePlaythrough?.team
     ? getTeamSlots(
@@ -114,30 +101,19 @@ export default function PokemonPCSheet({
       )
     : [];
 
-  const deceased: Entry[] = useMemo(
-    () => getDeceasedEntries(encounters, idToName),
-    [encounters, idToName],
-  );
+  const deceased: Entry[] = getDeceasedEntries(encounters, idToName);
 
-  const stored: Entry[] = useMemo(
-    () => getStoredEntries(encounters, idToName),
-    [encounters, idToName],
-  );
+  const stored: Entry[] = getStoredEntries(encounters, idToName);
 
   const selectedIndex = getPCTabIndex(activeTab);
 
-  // Memoize the onClose handler to prevent unnecessary re-renders
-  const handleClose = useCallback(() => {
+  const handleClose = () => {
     onClose();
-  }, [onClose]);
+  };
 
-  // Memoize the onChangeTab handler
-  const handleChangeTab = useCallback(
-    (index: number) => {
-      onChangeTab(getPCTab(index));
-    },
-    [onChangeTab],
-  );
+  const handleChangeTab = (index: number) => {
+    onChangeTab(getPCTab(index));
+  };
 
   return (
     <Dialog

--- a/src/components/pc/PokemonPCSheet.tsx
+++ b/src/components/pc/PokemonPCSheet.tsx
@@ -5,35 +5,13 @@ import {
   DialogBackdrop,
   DialogPanel,
   DialogTitle,
-  Tab,
-  TabGroup,
-  TabList,
-  TabPanel,
-  TabPanels,
 } from "@headlessui/react";
 import clsx from "clsx";
-import { Box, Boxes, Skull, Users, X } from "lucide-react";
-import { getLocationsSortedWithCustom } from "@/loaders/locations";
-import type { PokemonOptionType } from "@/loaders/pokemon";
-import {
-  useActivePlaythrough,
-  useCustomLocations,
-  useEncounters,
-} from "@/stores/playthroughs/hooks";
-import { buildPokemonUidIndex } from "@/utils/encounter-utils";
-import { scrollToLocationById } from "@/utils/scrollToLocation";
+import { X } from "lucide-react";
 import TeamMemberPickerModal from "../team/TeamMemberPickerModal";
-import { getTeamSlots } from "../team/teamSlots";
 import { useTeamMemberPicker } from "../team/useTeamMemberPicker";
-import { GraveyardGridItem } from "./GraveyardGridItem";
-import PCEntryItem from "./PCEntryItem";
-import {
-  getDeceasedEntries,
-  getPCTab,
-  getPCTabIndex,
-  getStoredEntries,
-} from "./pcSheetDomain";
-import TeamEntryItem from "./TeamEntryItem";
+import { PokemonPCSheetContent } from "./PokemonPCSheetContent";
+import { usePokemonPCSheetData } from "./usePokemonPCSheetData";
 
 export interface PokemonPCSheetProps {
   isOpen: boolean;
@@ -42,18 +20,13 @@ export interface PokemonPCSheetProps {
   onChangeTab: (tab: "team" | "box" | "graveyard") => void;
 }
 
-import type { PCEntry as Entry } from "./types";
-
 export default function PokemonPCSheet({
   isOpen,
   onClose,
   activeTab,
   onChangeTab,
 }: PokemonPCSheetProps) {
-  const activePlaythrough = useActivePlaythrough();
-  const encounters = useEncounters();
-  const customLocations = useCustomLocations();
-
+  const { team, stored, deceased, idToName } = usePokemonPCSheetData();
   const {
     pickerModalOpen,
     selectedPosition,
@@ -62,65 +35,8 @@ export default function PokemonPCSheet({
     selectTeamMember,
   } = useTeamMemberPicker();
 
-  const mergedLocations = getLocationsSortedWithCustom(customLocations);
-
-  const idToName = new Map<string, string>();
-  for (const loc of mergedLocations) idToName.set(loc.id, loc.name);
-
-  const pokemonByUid = buildPokemonUidIndex(encounters);
-
-  // Handlers for team member picker modal
-  const handleTeamMemberClick = (
-    position: number,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _existingTeamMember: {
-      position: number;
-      isEmpty: boolean;
-      headPokemon: PokemonOptionType | null;
-      bodyPokemon: PokemonOptionType | null;
-      isFusion: boolean;
-    },
-  ) => {
-    openPicker(position);
-  };
-
-  const team: Entry[] = activePlaythrough?.team
-    ? getTeamSlots(
-        activePlaythrough.team.members,
-        encounters,
-        pokemonByUid,
-      ).map(
-        ({ position, locationName, headPokemon, bodyPokemon, isFusion }) => ({
-          locationId: `team-slot-${position}`,
-          locationName,
-          head: headPokemon,
-          body: bodyPokemon,
-          position,
-          isFusion,
-        }),
-      )
-    : [];
-
-  const deceased: Entry[] = getDeceasedEntries(encounters, idToName);
-
-  const stored: Entry[] = getStoredEntries(encounters, idToName);
-
-  const selectedIndex = getPCTabIndex(activeTab);
-
-  const handleClose = () => {
-    onClose();
-  };
-
-  const handleChangeTab = (index: number) => {
-    onChangeTab(getPCTab(index));
-  };
-
   return (
-    <Dialog
-      open={isOpen}
-      onClose={handleClose}
-      className="group relative z-[70]"
-    >
+    <Dialog open={isOpen} onClose={onClose} className="group relative z-[70]">
       <DialogBackdrop
         transition
         className="fixed inset-0 z-[70] bg-black/30 backdrop-blur-[2px] transition-opacity duration-200 ease-out data-closed:opacity-0 data-enter:opacity-100 dark:bg-black/30"
@@ -150,7 +66,7 @@ export default function PokemonPCSheet({
               </DialogTitle>
               <button
                 type="button"
-                onClick={handleClose}
+                onClick={onClose}
                 className={clsx(
                   "text-gray-400 hover:text-gray-600 dark:hover:text-gray-300",
                   "focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2",
@@ -163,161 +79,21 @@ export default function PokemonPCSheet({
             </div>
           </div>
 
-          {/* Content area: fills remaining height to allow true vertical centering */}
           <div className="flex min-h-0 flex-1 flex-col px-4 pt-2 pb-3">
-            <TabGroup selectedIndex={selectedIndex} onChange={handleChangeTab}>
-              <TabList className="mb-4 flex w-full flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain pb-1 [scrollbar-width:none] sm:pb-0 [&::-webkit-scrollbar]:hidden">
-                <Tab
-                  className={({ selected }) =>
-                    clsx(
-                      "inline-flex min-w-[7.25rem] shrink-0 items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none sm:flex-1",
-                      selected
-                        ? "border-gray-300 bg-white text-gray-900 shadow dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-                        : "border-gray-200 bg-gray-100 text-gray-700 hover:bg-gray-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700",
-                    )
-                  }
-                >
-                  <Users className="h-4 w-4" />
-                  <span className="font-medium flex-1">Team</span>
-                  <span className="ml-1 rounded bg-gray-200 px-1 text-[10px] text-gray-800 dark:bg-gray-600 dark:text-gray-100">
-                    {team.filter((entry) => entry.head || entry.body).length}/6
-                  </span>
-                </Tab>
-                <Tab
-                  className={({ selected }) =>
-                    clsx(
-                      "inline-flex min-w-[7.25rem] shrink-0 items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none sm:flex-1",
-                      selected
-                        ? "border-gray-300 bg-white text-gray-900 shadow dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-                        : "border-gray-200 bg-gray-100 text-gray-700 hover:bg-gray-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700",
-                    )
-                  }
-                >
-                  <Box className="h-4 w-4" />
-                  <span className="font-medium flex-1">Box</span>
-                  <span className="ml-1 rounded bg-gray-200 px-1 text-[10px] text-gray-800 dark:bg-gray-600 dark:text-gray-100">
-                    {stored.length}
-                  </span>
-                </Tab>
-                <Tab
-                  className={({ selected }) =>
-                    clsx(
-                      "inline-flex min-w-[7.25rem] shrink-0 items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none sm:flex-1",
-                      selected
-                        ? "border-gray-300 bg-white text-gray-900 shadow dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-                        : "border-gray-200 bg-gray-100 text-gray-700 hover:bg-gray-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700",
-                    )
-                  }
-                >
-                  <Skull className="h-4 w-4" />
-                  <span className="font-medium flex-1">Graveyard</span>
-                  <span className="ml-1 rounded bg-gray-200 px-1 text-[10px] text-gray-800 dark:bg-gray-600 dark:text-gray-100">
-                    {deceased.length}
-                  </span>
-                </Tab>
-              </TabList>
-
-              <TabPanels className="flex min-h-0 flex-1 flex-col">
-                <TabPanel className="flex min-h-0 flex-1">
-                  <div
-                    aria-label="Team members list"
-                    className="w-full space-y-3 py-2 max-h-[calc(100dvh-6.5rem)] overflow-y-auto"
-                  >
-                    {team.map((entry) => (
-                      <TeamEntryItem
-                        key={entry.locationId}
-                        entry={entry}
-                        idToName={idToName}
-                        onClose={handleClose}
-                        onTeamMemberClick={handleTeamMemberClick}
-                      />
-                    ))}
-                  </div>
-                </TabPanel>
-                <TabPanel className="flex min-h-0 flex-1">
-                  {stored.length === 0 ? (
-                    <div
-                      className="flex min-h-[60vh] w-full flex-1 flex-col items-center justify-center px-4 text-gray-600 dark:text-gray-300"
-                      role="status"
-                      aria-live="polite"
-                    >
-                      <Boxes
-                        className="mb-3 h-10 w-10 opacity-50"
-                        aria-hidden="true"
-                      />
-                      <p className="text-center">No Pokémon in your box.</p>
-                    </div>
-                  ) : (
-                    <div
-                      aria-label="Boxed Pokémon list"
-                      className="grid content-start w-full grid-cols-1 gap-2 py-2 sm:grid-cols-2 h-[calc(100dvh-6.5rem)] overflow-y-auto"
-                    >
-                      {stored.map((entry) => (
-                        <PCEntryItem
-                          key={entry.locationId}
-                          entry={entry}
-                          idToName={idToName}
-                          mode="stored"
-                          hoverRingClass="hover:ring-blue-400/30"
-                          fallbackLabel="Boxed Pokémon"
-                          className=""
-                          onClose={handleClose}
-                        />
-                      ))}
-                    </div>
-                  )}
-                </TabPanel>
-                <TabPanel className="flex min-h-0 flex-1">
-                  {deceased.length === 0 ? (
-                    <div
-                      className="flex min-h-[60vh] w-full flex-1 flex-col items-center justify-center px-4 text-gray-600 dark:text-gray-300"
-                      role="status"
-                      aria-live="polite"
-                    >
-                      <Skull
-                        className="mb-3 h-10 w-10 opacity-50"
-                        aria-hidden="true"
-                      />
-                      <p className="text-center">
-                        No fallen Pokémon. Keep it that way!
-                      </p>
-                    </div>
-                  ) : (
-                    <div className="w-full py-2 h-[calc(100dvh-6.5rem)] overflow-y-auto">
-                      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-                        {deceased.map((entry) => (
-                          <GraveyardGridItem
-                            key={entry.locationId}
-                            entry={entry}
-                            onLocationClick={(locationId) => {
-                              // Scroll to location in the encounter table
-                              const highlightUids: string[] = [];
-                              const pokemon = entry.head || entry.body;
-                              if (pokemon?.uid) {
-                                highlightUids.push(pokemon.uid);
-                              }
-
-                              scrollToLocationById(locationId, {
-                                behavior: "smooth",
-                                highlightUids,
-                                durationMs: 1200,
-                              });
-
-                              handleClose();
-                            }}
-                          />
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </TabPanel>
-              </TabPanels>
-            </TabGroup>
+            <PokemonPCSheetContent
+              activeTab={activeTab}
+              onChangeTab={onChangeTab}
+              team={team}
+              stored={stored}
+              deceased={deceased}
+              idToName={idToName}
+              onClose={onClose}
+              onOpenTeamMemberPicker={openPicker}
+            />
           </div>
         </DialogPanel>
       </div>
 
-      {/* Team Member Picker Modal */}
       <TeamMemberPickerModal
         isOpen={pickerModalOpen}
         onClose={closePicker}

--- a/src/components/pc/PokemonPCSheetContent.tsx
+++ b/src/components/pc/PokemonPCSheetContent.tsx
@@ -1,0 +1,162 @@
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
+import clsx from "clsx";
+import { Box, Boxes, type LucideIcon, Skull, Users } from "lucide-react";
+import { scrollToLocationById } from "@/utils/scrollToLocation";
+import { GraveyardGridItem } from "./GraveyardGridItem";
+import PCEntryItem from "./PCEntryItem";
+import { getPCTab, getPCTabIndex, type PCTab } from "./pcSheetDomain";
+import TeamEntryItem from "./TeamEntryItem";
+import type { PCEntry } from "./types";
+
+interface PokemonPCSheetContentProps {
+  activeTab: PCTab;
+  onChangeTab: (tab: PCTab) => void;
+  team: PCEntry[];
+  stored: PCEntry[];
+  deceased: PCEntry[];
+  idToName: Map<string, string>;
+  onClose: () => void;
+  onOpenTeamMemberPicker: (position: number) => void;
+}
+
+interface PCSheetTabProps {
+  icon: LucideIcon;
+  label: string;
+  count: string | number;
+}
+
+function PCSheetTab({ icon: Icon, label, count }: PCSheetTabProps) {
+  return (
+    <Tab
+      className={({ selected }) =>
+        clsx(
+          "inline-flex min-w-[7.25rem] shrink-0 items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none sm:flex-1",
+          selected
+            ? "border-gray-300 bg-white text-gray-900 shadow dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            : "border-gray-200 bg-gray-100 text-gray-700 hover:bg-gray-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700",
+        )
+      }
+    >
+      <Icon className="h-4 w-4" />
+      <span className="font-medium flex-1">{label}</span>
+      <span className="ml-1 rounded bg-gray-200 px-1 text-[10px] text-gray-800 dark:bg-gray-600 dark:text-gray-100">
+        {count}
+      </span>
+    </Tab>
+  );
+}
+
+function EmptyPCPanel({
+  icon: Icon,
+  message,
+}: {
+  icon: LucideIcon;
+  message: string;
+}) {
+  return (
+    <div
+      className="flex min-h-[60vh] w-full flex-1 flex-col items-center justify-center px-4 text-gray-600 dark:text-gray-300"
+      role="status"
+      aria-live="polite"
+    >
+      <Icon className="mb-3 h-10 w-10 opacity-50" aria-hidden="true" />
+      <p className="text-center">{message}</p>
+    </div>
+  );
+}
+
+export function PokemonPCSheetContent({
+  activeTab,
+  onChangeTab,
+  team,
+  stored,
+  deceased,
+  idToName,
+  onClose,
+  onOpenTeamMemberPicker,
+}: PokemonPCSheetContentProps) {
+  const teamCount = team.filter((entry) => entry.head || entry.body).length;
+
+  return (
+    <TabGroup
+      selectedIndex={getPCTabIndex(activeTab)}
+      onChange={(index) => onChangeTab(getPCTab(index))}
+    >
+      <TabList className="mb-4 flex w-full flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain pb-1 [scrollbar-width:none] sm:pb-0 [&::-webkit-scrollbar]:hidden">
+        <PCSheetTab icon={Users} label="Team" count={`${teamCount}/6`} />
+        <PCSheetTab icon={Box} label="Box" count={stored.length} />
+        <PCSheetTab icon={Skull} label="Graveyard" count={deceased.length} />
+      </TabList>
+
+      <TabPanels className="flex min-h-0 flex-1 flex-col">
+        <TabPanel className="flex min-h-0 flex-1">
+          <div
+            aria-label="Team members list"
+            className="w-full space-y-3 py-2 max-h-[calc(100dvh-6.5rem)] overflow-y-auto"
+          >
+            {team.map((entry) => (
+              <TeamEntryItem
+                key={entry.locationId}
+                entry={entry}
+                idToName={idToName}
+                onClose={onClose}
+                onTeamMemberClick={onOpenTeamMemberPicker}
+              />
+            ))}
+          </div>
+        </TabPanel>
+        <TabPanel className="flex min-h-0 flex-1">
+          {stored.length === 0 ? (
+            <EmptyPCPanel icon={Boxes} message="No Pokémon in your box." />
+          ) : (
+            <div
+              aria-label="Boxed Pokémon list"
+              className="grid content-start w-full grid-cols-1 gap-2 py-2 sm:grid-cols-2 h-[calc(100dvh-6.5rem)] overflow-y-auto"
+            >
+              {stored.map((entry) => (
+                <PCEntryItem
+                  key={entry.locationId}
+                  entry={entry}
+                  idToName={idToName}
+                  mode="stored"
+                  hoverRingClass="hover:ring-blue-400/30"
+                  fallbackLabel="Boxed Pokémon"
+                  className=""
+                  onClose={onClose}
+                />
+              ))}
+            </div>
+          )}
+        </TabPanel>
+        <TabPanel className="flex min-h-0 flex-1">
+          {deceased.length === 0 ? (
+            <EmptyPCPanel
+              icon={Skull}
+              message="No fallen Pokémon. Keep it that way!"
+            />
+          ) : (
+            <div className="w-full py-2 h-[calc(100dvh-6.5rem)] overflow-y-auto">
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                {deceased.map((entry) => (
+                  <GraveyardGridItem
+                    key={entry.locationId}
+                    entry={entry}
+                    onLocationClick={(locationId) => {
+                      const pokemon = entry.head || entry.body;
+                      scrollToLocationById(locationId, {
+                        behavior: "smooth",
+                        highlightUids: pokemon?.uid ? [pokemon.uid] : [],
+                        durationMs: 1200,
+                      });
+                      onClose();
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </TabPanel>
+      </TabPanels>
+    </TabGroup>
+  );
+}

--- a/src/components/pc/PokemonPCSheetContent.tsx
+++ b/src/components/pc/PokemonPCSheetContent.tsx
@@ -30,7 +30,7 @@ function PCSheetTab({ icon: Icon, label, count }: PCSheetTabProps) {
     <Tab
       className={({ selected }) =>
         clsx(
-          "inline-flex min-w-[7.25rem] shrink-0 items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none sm:flex-1",
+          "inline-flex min-w-[7.25rem] shrink-0 items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 sm:flex-1",
           selected
             ? "border-gray-300 bg-white text-gray-900 shadow dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
             : "border-gray-200 bg-gray-100 text-gray-700 hover:bg-gray-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700",

--- a/src/components/pc/usePokemonPCSheetData.ts
+++ b/src/components/pc/usePokemonPCSheetData.ts
@@ -1,0 +1,54 @@
+import { getLocationsSortedWithCustom } from "@/loaders/locations";
+import {
+  useActivePlaythrough,
+  useCustomLocations,
+  useEncounters,
+} from "@/stores/playthroughs/hooks";
+import { buildPokemonUidIndex } from "@/utils/encounter-utils";
+import { getTeamSlots } from "../team/teamSlots";
+import { getDeceasedEntries, getStoredEntries } from "./pcSheetDomain";
+import type { PCEntry } from "./types";
+
+function toTeamEntry({
+  position,
+  locationName,
+  headPokemon,
+  bodyPokemon,
+  isFusion,
+}: ReturnType<typeof getTeamSlots>[number]): PCEntry {
+  return {
+    locationId: `team-slot-${position}`,
+    locationName,
+    head: headPokemon,
+    body: bodyPokemon,
+    position,
+    isFusion,
+  };
+}
+
+export function usePokemonPCSheetData() {
+  const activePlaythrough = useActivePlaythrough();
+  const encounters = useEncounters();
+  const customLocations = useCustomLocations();
+  const idToName = new Map(
+    getLocationsSortedWithCustom(customLocations).map((location) => [
+      location.id,
+      location.name,
+    ]),
+  );
+  const pokemonByUid = buildPokemonUidIndex(encounters);
+  const team = activePlaythrough?.team
+    ? getTeamSlots(
+        activePlaythrough.team.members,
+        encounters,
+        pokemonByUid,
+      ).map(toTeamEntry)
+    : [];
+
+  return {
+    team,
+    stored: getStoredEntries(encounters, idToName),
+    deceased: getDeceasedEntries(encounters, idToName),
+    idToName,
+  };
+}

--- a/src/components/playthrough/CreatePlaythroughModal.tsx
+++ b/src/components/playthrough/CreatePlaythroughModal.tsx
@@ -8,7 +8,7 @@ import {
 } from "@headlessui/react";
 import clsx from "clsx";
 import { HelpCircle, X } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CursorTooltip } from "@/components/CursorTooltip";
 import {
   DEFAULT_NEW_PLAYTHROUGH_GAME_MODE,
@@ -41,14 +41,14 @@ export default function CreatePlaythroughModal({
     playthroughNameInputRef.current?.focus();
   }, [isOpen]);
 
-  const handleClose = useCallback(() => {
+  const handleClose = () => {
     setNewPlaythroughName("");
     setSelectedGameModeOverride(null);
     onClose();
-  }, [onClose]);
+  };
 
   // Create a new playthrough
-  const handleCreatePlaythrough = useCallback(async () => {
+  const handleCreatePlaythrough = async () => {
     const name = newPlaythroughName.trim();
     if (!name) return;
 
@@ -58,7 +58,7 @@ export default function CreatePlaythroughModal({
     } catch (error) {
       console.error("Failed to create playthrough:", error);
     }
-  }, [newPlaythroughName, selectedGameMode, onCreate, handleClose]);
+  };
 
   return (
     <Dialog

--- a/src/components/playthrough/GameModeToggle.tsx
+++ b/src/components/playthrough/GameModeToggle.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import clsx from "clsx";
-import React, { useOptimistic, useTransition } from "react";
+import { useOptimistic, useTransition } from "react";
 import { useActivePlaythrough, useGameMode } from "@/stores/playthroughs/hooks";
 import { playthroughActions } from "@/stores/playthroughs/index";
 import type { GameMode } from "@/stores/playthroughs/types";
@@ -17,24 +17,24 @@ const GameModeToggle = function GameModeToggle() {
     (_currentState, newMode: GameMode) => newMode,
   );
 
-  const handleModeSelect = React.useCallback(
-    (targetMode: GameMode, triggerMethod: "click" | "keyboard") => {
-      if (!activePlaythrough || isPending || optimisticMode === targetMode)
-        return;
+  const handleModeSelect = (
+    targetMode: GameMode,
+    triggerMethod: "click" | "keyboard",
+  ) => {
+    if (!activePlaythrough || isPending || optimisticMode === targetMode)
+      return;
 
-      startTransition(() => {
-        // Optimistic update - instant UI response
-        setOptimisticMode(targetMode);
+    startTransition(() => {
+      // Optimistic update - instant UI response
+      setOptimisticMode(targetMode);
 
-        // Actual state update
-        playthroughActions.setGameMode(targetMode, {
-          source_surface: "game_mode_toggle",
-          trigger_method: triggerMethod,
-        });
+      // Actual state update
+      playthroughActions.setGameMode(targetMode, {
+        source_surface: "game_mode_toggle",
+        trigger_method: triggerMethod,
       });
-    },
-    [activePlaythrough, optimisticMode, isPending, setOptimisticMode],
-  );
+    });
+  };
 
   const getBackgroundPosition = (mode: GameMode): string => {
     switch (mode) {

--- a/src/components/playthrough/PlaythroughSelector.tsx
+++ b/src/components/playthrough/PlaythroughSelector.tsx
@@ -370,7 +370,7 @@ export default function PlaythroughSelector({
                               </div>
                             </div>
                           </button>
-                          <div className="absolute right-4 top-1/2 flex -translate-y-1/2 items-center gap-1 opacity-0 transition-all duration-200 group-hover/menu-item:opacity-100 group-focus-within/menu-item:opacity-100">
+                          <div className="absolute right-4 top-1/2 flex -translate-y-1/2 items-center gap-1 opacity-0 transition-opacity duration-200 group-hover/menu-item:opacity-100 group-focus-within/menu-item:opacity-100">
                             <button
                               type="button"
                               onClick={(e) =>
@@ -383,7 +383,7 @@ export default function PlaythroughSelector({
                                 )
                               }
                               className={clsx(
-                                "p-2 rounded-lg transition-all duration-200",
+                                "p-2 rounded-lg transition-colors duration-200",
                                 "border border-transparent",
                                 "hover:bg-blue-100 hover:border-blue-300 dark:hover:bg-blue-900/20 dark:hover:border-blue-600",
                                 "focus:bg-blue-100 focus:border-blue-300 dark:focus:bg-blue-900/20 dark:focus:border-blue-600",

--- a/src/components/playthrough/PlaythroughSelector.tsx
+++ b/src/components/playthrough/PlaythroughSelector.tsx
@@ -12,7 +12,7 @@ import {
   Upload,
 } from "lucide-react";
 import type React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
 import { CursorTooltip } from "@/components/CursorTooltip";
 import { usePlaythroughImportExport } from "@/hooks/usePlaythroughImportExport";
@@ -90,31 +90,28 @@ export default function PlaythroughSelector({
   }, [allPlaythroughs.length]);
 
   // Switch to a different playthrough
-  const handlePlaythroughSelect = useCallback(
-    async (playthroughId: string, triggerMethod: "click" | "keyboard") => {
-      try {
-        await playthroughActions.setActivePlaythrough(playthroughId, {
-          source_surface: "playthrough_selector",
-          trigger_method: triggerMethod,
-        });
-      } catch (error) {
-        console.error("Failed to switch playthrough:", error);
-      }
-    },
-    [],
-  );
+  const handlePlaythroughSelect = async (
+    playthroughId: string,
+    triggerMethod: "click" | "keyboard",
+  ) => {
+    try {
+      await playthroughActions.setActivePlaythrough(playthroughId, {
+        source_surface: "playthrough_selector",
+        trigger_method: triggerMethod,
+      });
+    } catch (error) {
+      console.error("Failed to switch playthrough:", error);
+    }
+  };
 
   // Handle delete playthrough click
-  const handleDeleteClick = useCallback(
-    (playthrough: { id: string; name: string }) => {
-      setPlaythroughToDelete(playthrough as Playthrough);
-      setShowDeleteConfirm(true);
-    },
-    [],
-  );
+  const handleDeleteClick = (playthrough: { id: string; name: string }) => {
+    setPlaythroughToDelete(playthrough as Playthrough);
+    setShowDeleteConfirm(true);
+  };
 
   // Confirm delete playthrough
-  const handleConfirmDelete = useCallback(async () => {
+  const handleConfirmDelete = async () => {
     if (!playthroughToDelete) return;
 
     try {
@@ -124,7 +121,7 @@ export default function PlaythroughSelector({
     } catch (error) {
       console.error("Failed to delete playthrough:", error);
     }
-  }, [playthroughToDelete]);
+  };
 
   // Cancel delete
   const handleCancelDelete = () => {
@@ -132,7 +129,7 @@ export default function PlaythroughSelector({
     setPlaythroughToDelete(null);
   };
 
-  const trackSelectorOpened = useCallback(() => {
+  const trackSelectorOpened = () => {
     if (!activePlaythrough) {
       return;
     }
@@ -141,56 +138,50 @@ export default function PlaythroughSelector({
       ...getSharedEventProperties(activePlaythrough),
       source_surface: "header",
     });
-  }, [activePlaythrough]);
+  };
 
-  const handleCreateClick = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
-      event.preventDefault();
-      if (activePlaythrough) {
-        trackEvent("create_playthrough_modal_opened", {
-          ...getSharedEventProperties(activePlaythrough),
-          source_surface: "header",
-        });
-      }
-      setShowCreateInput(true);
-    },
-    [activePlaythrough],
-  );
+  const handleCreateClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    if (activePlaythrough) {
+      trackEvent("create_playthrough_modal_opened", {
+        ...getSharedEventProperties(activePlaythrough),
+        source_surface: "header",
+      });
+    }
+    setShowCreateInput(true);
+  };
 
   // Handle arrow key navigation using refs
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent, currentIndex: number) => {
-      e.preventDefault();
+  const handleKeyDown = (e: React.KeyboardEvent, currentIndex: number) => {
+    e.preventDefault();
 
-      switch (e.key) {
-        case "ArrowDown": {
-          const nextIndex =
-            currentIndex < sortedPlaythroughsForRender.length - 1
-              ? currentIndex + 1
-              : 0;
-          playthroughRefs.current[nextIndex]?.focus();
-          break;
-        }
-        case "ArrowUp": {
-          const prevIndex =
-            currentIndex > 0
-              ? currentIndex - 1
-              : sortedPlaythroughsForRender.length - 1;
-          playthroughRefs.current[prevIndex]?.focus();
-          break;
-        }
-        case "Home":
-          playthroughRefs.current[0]?.focus();
-          break;
-        case "End":
-          playthroughRefs.current[
-            sortedPlaythroughsForRender.length - 1
-          ]?.focus();
-          break;
+    switch (e.key) {
+      case "ArrowDown": {
+        const nextIndex =
+          currentIndex < sortedPlaythroughsForRender.length - 1
+            ? currentIndex + 1
+            : 0;
+        playthroughRefs.current[nextIndex]?.focus();
+        break;
       }
-    },
-    [sortedPlaythroughsForRender],
-  );
+      case "ArrowUp": {
+        const prevIndex =
+          currentIndex > 0
+            ? currentIndex - 1
+            : sortedPlaythroughsForRender.length - 1;
+        playthroughRefs.current[prevIndex]?.focus();
+        break;
+      }
+      case "Home":
+        playthroughRefs.current[0]?.focus();
+        break;
+      case "End":
+        playthroughRefs.current[
+          sortedPlaythroughsForRender.length - 1
+        ]?.focus();
+        break;
+    }
+  };
 
   return (
     <>

--- a/src/components/team/PokemonGridItem.tsx
+++ b/src/components/team/PokemonGridItem.tsx
@@ -32,16 +32,23 @@ export function PokemonGridItem({
 
   // Fetch full Pokemon data to get types
   useEffect(() => {
-    const fetchPokemonData = async () => {
-      try {
-        const data = await getPokemonById(pokemon.id);
-        setPokemonData(data);
-      } catch (error) {
-        console.error("Failed to fetch Pokemon data:", error);
-      }
-    };
+    let cancelled = false;
 
-    fetchPokemonData();
+    getPokemonById(pokemon.id)
+      .then((data) => {
+        if (!cancelled) {
+          setPokemonData(data);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error("Failed to fetch Pokemon data:", error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [pokemon.id]);
 
   const getButtonStyles = () => {

--- a/src/components/team/TeamMemberSelectionContext.tsx
+++ b/src/components/team/TeamMemberSelectionContext.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import type React from "react";
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useReducer,
-} from "react";
+import { createContext, useContext, useEffect, useReducer } from "react";
 import type { PokemonOptionType } from "@/loaders/pokemon";
 import {
   useActivePlaythrough,
@@ -374,7 +368,7 @@ export function TeamMemberSelectionProvider({
   useTeamSelectionEffects({ state, dispatch, existingTeamMember, encounters });
 
   // Get all available Pokémon from encounters, filtering out those already in use by other team members
-  const allAvailablePokemon = useMemo(() => {
+  const allAvailablePokemon = (() => {
     if (!encounters || !teamMembers) return [];
 
     return filterAvailableTeamPokemon(
@@ -383,18 +377,15 @@ export function TeamMemberSelectionProvider({
       position,
       existingTeamMember,
     );
-  }, [encounters, teamMembers, position, existingTeamMember]);
+  })();
 
   // Computed values
-  const stateValue = useMemo(
-    () => ({
-      ...state,
-      availablePokemon: allAvailablePokemon,
-      canUpdateTeam: true,
-      hasSelection: Boolean(state.selectedHead || state.selectedBody),
-    }),
-    [state, allAvailablePokemon],
-  );
+  const stateValue = {
+    ...state,
+    availablePokemon: allAvailablePokemon,
+    canUpdateTeam: true,
+    hasSelection: Boolean(state.selectedHead || state.selectedBody),
+  };
   const actionsValue = useTeamMemberSelectionActionValue({
     dispatch,
     selectedHead: state.selectedHead,

--- a/src/components/team/TeamMemberSelectionPanel.tsx
+++ b/src/components/team/TeamMemberSelectionPanel.tsx
@@ -80,7 +80,7 @@ export function TeamMemberSelectionPanel() {
             <button
               type="button"
               onClick={handleFlipFusion}
-              className="group size-6 flex items-center justify-center p-1 text-gray-600 dark:text-gray-300 rounded-md border border-gray-300 dark:border-gray-600 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 hover:bg-blue-500 hover:border-blue-600 bg-white dark:bg-gray-800"
+              className="group size-6 flex items-center justify-center p-1 text-gray-600 dark:text-gray-300 rounded-md border border-gray-300 dark:border-gray-600 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 hover:bg-blue-500 hover:border-blue-600 bg-white dark:bg-gray-800"
               aria-label="Flip head and body"
             >
               <ArrowLeftRight className="size-4 hover:text-white" />

--- a/src/components/team/TeamMemberSelectionPanel.tsx
+++ b/src/components/team/TeamMemberSelectionPanel.tsx
@@ -2,7 +2,6 @@
 
 import { ArrowLeftRight } from "lucide-react";
 import Image from "next/image";
-import React from "react";
 import { CursorTooltip } from "@/components/CursorTooltip";
 import { DNA_REVERSER_ICON } from "@/constants/items";
 import { PokemonGridItem } from "./PokemonGridItem";
@@ -36,7 +35,7 @@ export function TeamMemberSelectionPanel() {
   };
 
   // Filter Pokémon based on search query locally (no need to update state)
-  const filteredPokemon = React.useMemo(() => {
+  const filteredPokemon = (() => {
     if (!searchQuery.trim()) return availablePokemon;
 
     const query = searchQuery.toLowerCase();
@@ -45,7 +44,7 @@ export function TeamMemberSelectionPanel() {
         pokemon.name.toLowerCase().includes(query) ||
         pokemon.nickname?.toLowerCase().includes(query),
     );
-  }, [availablePokemon, searchQuery]);
+  })();
   return (
     <div className="flex-1 flex flex-col space-y-5">
       <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto_1fr] gap-4 items-center">

--- a/src/components/team/TeamSlots.tsx
+++ b/src/components/team/TeamSlots.tsx
@@ -108,7 +108,11 @@ export default function TeamSlots() {
     }
     // Use requestAnimationFrame to ensure proper timing
     const animationFrame = requestAnimationFrame(() => {
-      teamSlots.forEach((slot, index) => {
+      const animationSlots = activePlaythrough?.team
+        ? getTeamSlots(activePlaythrough.team.members, encounters, pokemonByUid)
+        : [];
+
+      animationSlots.forEach((slot, index) => {
         if (
           !slot.isEmpty &&
           slot.isFusion &&
@@ -139,7 +143,7 @@ export default function TeamSlots() {
     return () => {
       cancelAnimationFrame(animationFrame);
     };
-  }, [teamSlots]);
+  }, [activePlaythrough?.team, encounters, pokemonByUid]);
 
   // Show skeleton while loading
   if (!activePlaythrough || !encounters) {

--- a/src/components/team/TeamSlots.tsx
+++ b/src/components/team/TeamSlots.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { clsx } from "clsx";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import PokeballIcon from "@/assets/images/pokeball.svg";
 import { CursorTooltip } from "@/components/CursorTooltip";
 import { ArtworkVariantButton } from "@/components/PokemonSummaryCard/ArtworkVariantButton";
@@ -84,10 +84,7 @@ export default function TeamSlots() {
   const teamSpriteRefs = useRef<(FusionSpriteHandle | null)[]>([]);
   const previousFusionIds = useRef<(string | null)[]>([]);
 
-  const pokemonByUid = useMemo(
-    () => buildPokemonUidIndex(encounters),
-    [encounters],
-  );
+  const pokemonByUid = buildPokemonUidIndex(encounters);
 
   useEffect(() => {
     previousFusionIds.current = new Array(6).fill(null);

--- a/src/components/team/__tests__/PokemonGridItem.test.tsx
+++ b/src/components/team/__tests__/PokemonGridItem.test.tsx
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Pokemon, PokemonOptionType } from "@/loaders/pokemon";
+import { PokemonGridItem } from "../PokemonGridItem";
+
+const { getPokemonByIdMock } = vi.hoisted(() => ({
+  getPokemonByIdMock: vi.fn(),
+}));
+
+vi.mock("@/loaders/pokemon", () => ({
+  getPokemonById: getPokemonByIdMock,
+}));
+
+vi.mock("@/components/PokemonSprite", () => ({
+  PokemonSprite: () => null,
+}));
+
+vi.mock("@/components/TypePills", () => ({
+  TypePills: ({ primary }: { primary: string }) => (
+    <span data-testid="primary-type">{primary}</span>
+  ),
+}));
+
+const pokemonOption = (id: number, name: string): PokemonOptionType => ({
+  id,
+  name,
+  nationalDexId: id,
+});
+
+const pokemonData = (id: number, type: string) =>
+  ({
+    id,
+    types: [{ name: type }],
+  }) as Pokemon;
+
+const defaultProps = {
+  locationId: "route-1",
+  isSelectedHead: false,
+  isSelectedBody: false,
+  isActiveSlot: true,
+  onSelect: vi.fn(),
+};
+
+describe("PokemonGridItem", () => {
+  it("keeps the newest Pokémon types when lookups resolve out of order", async () => {
+    let resolveFirst: (pokemon: Pokemon | null) => void;
+    let resolveSecond: (pokemon: Pokemon | null) => void;
+    getPokemonByIdMock
+      .mockReturnValueOnce(
+        new Promise<Pokemon | null>((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise<Pokemon | null>((resolve) => {
+          resolveSecond = resolve;
+        }),
+      );
+    const { rerender } = render(
+      <PokemonGridItem
+        {...defaultProps}
+        pokemon={pokemonOption(1, "Bulbasaur")}
+      />,
+    );
+
+    rerender(
+      <PokemonGridItem
+        {...defaultProps}
+        pokemon={pokemonOption(4, "Charmander")}
+      />,
+    );
+
+    await act(async () => {
+      resolveSecond!(pokemonData(4, "fire"));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("primary-type").textContent).toBe("fire");
+    });
+
+    await act(async () => {
+      resolveFirst!(pokemonData(1, "grass"));
+    });
+
+    expect(screen.getByTestId("primary-type").textContent).toBe("fire");
+  });
+});

--- a/src/components/team/useTeamMemberPicker.ts
+++ b/src/components/team/useTeamMemberPicker.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import type { PokemonOptionType } from "@/loaders/pokemon";
 import { playthroughActions } from "@/stores/playthroughs";
 
@@ -6,42 +6,39 @@ export function useTeamMemberPicker() {
   const [pickerModalOpen, setPickerModalOpen] = useState(false);
   const [selectedPosition, setSelectedPosition] = useState<number | null>(null);
 
-  const closePicker = useCallback(() => {
+  const closePicker = () => {
     setPickerModalOpen(false);
     setSelectedPosition(null);
-  }, []);
+  };
 
-  const openPicker = useCallback((position: number) => {
+  const openPicker = (position: number) => {
     setSelectedPosition(position);
     setPickerModalOpen(true);
-  }, []);
+  };
 
-  const selectTeamMember = useCallback(
-    async (
-      headPokemon: PokemonOptionType | null,
-      bodyPokemon: PokemonOptionType | null,
-    ) => {
-      if (selectedPosition === null) return false;
+  const selectTeamMember = async (
+    headPokemon: PokemonOptionType | null,
+    bodyPokemon: PokemonOptionType | null,
+  ) => {
+    if (selectedPosition === null) return false;
 
-      const success = await playthroughActions.updateTeamMember(
+    const success = await playthroughActions.updateTeamMember(
+      selectedPosition,
+      headPokemon ? { uid: headPokemon.uid! } : null,
+      bodyPokemon ? { uid: bodyPokemon.uid! } : null,
+    );
+
+    if (!success) {
+      console.error(
+        "Failed to update team member at position:",
         selectedPosition,
-        headPokemon ? { uid: headPokemon.uid! } : null,
-        bodyPokemon ? { uid: bodyPokemon.uid! } : null,
       );
+    } else {
+      closePicker();
+    }
 
-      if (!success) {
-        console.error(
-          "Failed to update team member at position:",
-          selectedPosition,
-        );
-      } else {
-        closePicker();
-      }
-
-      return success;
-    },
-    [closePicker, selectedPosition],
-  );
+    return success;
+  };
 
   return {
     pickerModalOpen,

--- a/src/contexts/GlobalTooltipContext.tsx
+++ b/src/contexts/GlobalTooltipContext.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  type ReactNode,
-  useCallback,
-  useContext,
-  useState,
-} from "react";
+import { createContext, type ReactNode, useContext, useState } from "react";
 
 interface GlobalTooltipContextType {
   isAnyTooltipVisible: boolean;
@@ -26,7 +20,7 @@ export function GlobalTooltipProvider({
 }: GlobalTooltipProviderProps) {
   const [visibleTooltipCount, setVisibleTooltipCount] = useState(0);
 
-  const registerTooltip = useCallback((isVisible: boolean) => {
+  const registerTooltip = (isVisible: boolean) => {
     setVisibleTooltipCount((prev) => {
       if (isVisible) {
         return prev + 1;
@@ -34,7 +28,7 @@ export function GlobalTooltipProvider({
         return Math.max(0, prev - 1);
       }
     });
-  }, []);
+  };
 
   const isAnyTooltipVisible = visibleTooltipCount > 0;
 

--- a/src/hooks/__tests__/useKeyPressed.test.ts
+++ b/src/hooks/__tests__/useKeyPressed.test.ts
@@ -1,12 +1,32 @@
 /** @vitest-environment jsdom */
 
 import { act, renderHook } from "@testing-library/react";
+import { StrictMode } from "react";
 import { describe, expect, it } from "vitest";
 import { useKeyPressed } from "../useKeyPressed";
 
 describe("useKeyPressed", () => {
   it("keeps a key pressed across the external-store update", () => {
     const { result, unmount } = renderHook(() => useKeyPressed("Shift"));
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Shift" }));
+    });
+
+    expect(result.current).toBe(true);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keyup", { key: "Shift" }));
+    });
+
+    expect(result.current).toBe(false);
+    unmount();
+  });
+
+  it("keeps its subscription stable after Strict Mode resubscribes", () => {
+    const { result, unmount } = renderHook(() => useKeyPressed("Shift"), {
+      wrapper: StrictMode,
+    });
 
     act(() => {
       document.dispatchEvent(new KeyboardEvent("keydown", { key: "Shift" }));

--- a/src/hooks/__tests__/useKeyPressed.test.ts
+++ b/src/hooks/__tests__/useKeyPressed.test.ts
@@ -1,0 +1,24 @@
+/** @vitest-environment jsdom */
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useKeyPressed } from "../useKeyPressed";
+
+describe("useKeyPressed", () => {
+  it("keeps a key pressed across the external-store update", () => {
+    const { result, unmount } = renderHook(() => useKeyPressed("Shift"));
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Shift" }));
+    });
+
+    expect(result.current).toBe(true);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keyup", { key: "Shift" }));
+    });
+
+    expect(result.current).toBe(false);
+    unmount();
+  });
+});

--- a/src/hooks/__tests__/useMounted.test.tsx
+++ b/src/hooks/__tests__/useMounted.test.tsx
@@ -1,0 +1,13 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { useMounted } from "../useMounted";
+
+function MountedValue() {
+  return <span>{useMounted() ? "mounted" : "unmounted"}</span>;
+}
+
+describe("useMounted", () => {
+  it("renders as unmounted on the server", () => {
+    expect(renderToString(<MountedValue />)).toContain("unmounted");
+  });
+});

--- a/src/hooks/useFusionTypes.ts
+++ b/src/hooks/useFusionTypes.ts
@@ -1,6 +1,6 @@
 import type { TypeName } from "@/lib/typings";
 import { getFusionTyping, type TypeQuery } from "@/lib/typings";
-import type { PokemonOptionType } from "@/loaders/pokemon";
+import type { Pokemon, PokemonOptionType } from "@/loaders/pokemon";
 import { useAllPokemon } from "@/loaders/pokemon";
 import { usePokemonTypes } from "./usePokemonTypes";
 
@@ -10,41 +10,55 @@ export interface UseFusionTypesResult {
   isLoading: boolean;
 }
 
+function findPokemonByQuery(
+  pokemon: Pokemon[],
+  query: TypeQuery,
+): Pokemon | undefined {
+  if ("id" in query && query.id) {
+    return pokemon.find((entry) => entry.id === query.id);
+  }
+  if ("nationalDexId" in query && query.nationalDexId) {
+    return pokemon.find((entry) => entry.nationalDexId === query.nationalDexId);
+  }
+  if ("name" in query && query.name) {
+    return pokemon.find(
+      (entry) => entry.name.toLowerCase() === query.name?.toLowerCase(),
+    );
+  }
+}
+
+function getFusionTypesResult(
+  head: Pokemon,
+  body: Pokemon,
+): UseFusionTypesResult {
+  const { primary, secondary } = getFusionTyping(head, body);
+  return {
+    primary,
+    secondary: primary === secondary ? undefined : secondary,
+    isLoading: false,
+  };
+}
+
 function useFusionTypes(
   headQuery: TypeQuery | undefined,
   bodyQuery: TypeQuery | undefined,
 ): UseFusionTypesResult {
   const { data: allPokemon = [], isLoading } = useAllPokemon();
 
-  // Always compute individual typings so we can fall back when only one Pokémon is provided
   const headSingle = usePokemonTypes(headQuery);
   const bodySingle = usePokemonTypes(bodyQuery);
 
-  // Fallbacks: if only one query is provided, return that Pokémon's types
-  if (headQuery && !bodyQuery) return headSingle;
-  if (!headQuery && bodyQuery) return bodySingle;
-  if (!headQuery && !bodyQuery) return { isLoading };
+  if (!headQuery) {
+    return bodyQuery ? bodySingle : { isLoading };
+  }
+  if (!bodyQuery) return headSingle;
   if (!allPokemon || allPokemon.length === 0) return { isLoading: true };
 
-  const findPokemon = (q: TypeQuery) => {
-    if ("id" in q && q.id) return allPokemon.find((p) => p.id === q.id);
-    if ("nationalDexId" in q && q.nationalDexId)
-      return allPokemon.find((p) => p.nationalDexId === q.nationalDexId);
-    if ("name" in q && q.name)
-      return allPokemon.find(
-        (p) => p.name.toLowerCase() === q.name?.toLowerCase(),
-      );
-    return undefined;
-  };
-
-  const head = findPokemon(headQuery as TypeQuery);
-  const body = findPokemon(bodyQuery as TypeQuery);
+  const head = findPokemonByQuery(allPokemon, headQuery);
+  const body = findPokemonByQuery(allPokemon, bodyQuery);
   if (!head || !body) return { isLoading };
-  const { primary, secondary } = getFusionTyping(head, body);
-  if (primary === secondary)
-    return { primary, secondary: undefined, isLoading: false };
 
-  return { primary, secondary, isLoading: false };
+  return getFusionTypesResult(head, body);
 }
 
 /**

--- a/src/hooks/useFusionTypes.ts
+++ b/src/hooks/useFusionTypes.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import type { TypeName } from "@/lib/typings";
 import { getFusionTyping, type TypeQuery } from "@/lib/typings";
 import type { PokemonOptionType } from "@/loaders/pokemon";
@@ -21,34 +20,31 @@ function useFusionTypes(
   const headSingle = usePokemonTypes(headQuery);
   const bodySingle = usePokemonTypes(bodyQuery);
 
-  const result = useMemo<UseFusionTypesResult>(() => {
-    // Fallbacks: if only one query is provided, return that Pokémon's types
-    if (headQuery && !bodyQuery) return headSingle;
-    if (!headQuery && bodyQuery) return bodySingle;
-    if (!headQuery && !bodyQuery) return { isLoading };
-    if (!allPokemon || allPokemon.length === 0) return { isLoading: true };
+  // Fallbacks: if only one query is provided, return that Pokémon's types
+  if (headQuery && !bodyQuery) return headSingle;
+  if (!headQuery && bodyQuery) return bodySingle;
+  if (!headQuery && !bodyQuery) return { isLoading };
+  if (!allPokemon || allPokemon.length === 0) return { isLoading: true };
 
-    const findPokemon = (q: TypeQuery) => {
-      if ("id" in q && q.id) return allPokemon.find((p) => p.id === q.id);
-      if ("nationalDexId" in q && q.nationalDexId)
-        return allPokemon.find((p) => p.nationalDexId === q.nationalDexId);
-      if ("name" in q && q.name)
-        return allPokemon.find(
-          (p) => p.name.toLowerCase() === q.name?.toLowerCase(),
-        );
-      return undefined;
-    };
+  const findPokemon = (q: TypeQuery) => {
+    if ("id" in q && q.id) return allPokemon.find((p) => p.id === q.id);
+    if ("nationalDexId" in q && q.nationalDexId)
+      return allPokemon.find((p) => p.nationalDexId === q.nationalDexId);
+    if ("name" in q && q.name)
+      return allPokemon.find(
+        (p) => p.name.toLowerCase() === q.name?.toLowerCase(),
+      );
+    return undefined;
+  };
 
-    const head = findPokemon(headQuery as TypeQuery);
-    const body = findPokemon(bodyQuery as TypeQuery);
-    if (!head || !body) return { isLoading };
-    const { primary, secondary } = getFusionTyping(head, body);
-    if (primary === secondary)
-      return { primary, secondary: undefined, isLoading: false };
-    return { primary, secondary, isLoading: false };
-  }, [allPokemon, isLoading, headQuery, bodyQuery, headSingle, bodySingle]);
+  const head = findPokemon(headQuery as TypeQuery);
+  const body = findPokemon(bodyQuery as TypeQuery);
+  if (!head || !body) return { isLoading };
+  const { primary, secondary } = getFusionTyping(head, body);
+  if (primary === secondary)
+    return { primary, secondary: undefined, isLoading: false };
 
-  return result;
+  return { primary, secondary, isLoading: false };
 }
 
 /**

--- a/src/hooks/useKeyPressed.ts
+++ b/src/hooks/useKeyPressed.ts
@@ -1,4 +1,4 @@
-import { useMemo, useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 
 // Global state for all keys
 const keyStates = new Map<string, boolean>();
@@ -128,11 +128,8 @@ function notifyListeners(key: string) {
  * @returns {boolean} True if the specified key is currently pressed, false otherwise
  */
 export function useKeyPressed(key: string): boolean {
-  // Memoize the subscribe function to prevent re-subscriptions
-  const subscribe = useMemo(() => createSubscribe(key), [key]);
-
-  // Memoize the getSnapshot function to prevent unnecessary re-evaluations
-  const getSnapshot = useMemo(() => createGetSnapshot(key), [key]);
+  const subscribe = createSubscribe(key);
+  const getSnapshot = createGetSnapshot(key);
 
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/src/hooks/useKeyPressed.ts
+++ b/src/hooks/useKeyPressed.ts
@@ -3,6 +3,8 @@ import { useSyncExternalStore } from "react";
 // Global state for all keys
 const keyStates = new Map<string, boolean>();
 const keyListeners = new Map<string, Set<() => void>>();
+const keySubscriptions = new Map<string, ReturnType<typeof createSubscribe>>();
+const keySnapshots = new Map<string, ReturnType<typeof createGetSnapshot>>();
 
 // Track if global event listeners are attached
 let globalListenersAttached = false;
@@ -50,6 +52,8 @@ function createSubscribe(key: string) {
         if (listeners.size === 0) {
           keyListeners.delete(key);
           keyStates.delete(key);
+          keySubscriptions.delete(key);
+          keySnapshots.delete(key);
         }
       }
 
@@ -71,6 +75,26 @@ function createSubscribe(key: string) {
 // Get current state for a specific key
 function createGetSnapshot(key: string) {
   return () => keyStates.get(key) ?? false;
+}
+
+function getSubscribe(key: string) {
+  let subscribe = keySubscriptions.get(key);
+  if (!subscribe) {
+    subscribe = createSubscribe(key);
+    keySubscriptions.set(key, subscribe);
+  }
+
+  return subscribe;
+}
+
+function getSnapshot(key: string) {
+  let snapshot = keySnapshots.get(key);
+  if (!snapshot) {
+    snapshot = createGetSnapshot(key);
+    keySnapshots.set(key, snapshot);
+  }
+
+  return snapshot;
 }
 
 // Server-side snapshot (always false)
@@ -128,10 +152,11 @@ function notifyListeners(key: string) {
  * @returns {boolean} True if the specified key is currently pressed, false otherwise
  */
 export function useKeyPressed(key: string): boolean {
-  const subscribe = createSubscribe(key);
-  const getSnapshot = createGetSnapshot(key);
-
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  return useSyncExternalStore(
+    getSubscribe(key),
+    getSnapshot(key),
+    getServerSnapshot,
+  );
 }
 
 /**

--- a/src/hooks/useKeyPressed.ts
+++ b/src/hooks/useKeyPressed.ts
@@ -52,8 +52,6 @@ function createSubscribe(key: string) {
         if (listeners.size === 0) {
           keyListeners.delete(key);
           keyStates.delete(key);
-          keySubscriptions.delete(key);
-          keySnapshots.delete(key);
         }
       }
 

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import type { z } from "zod";
 
 const callbacks = new Set<(key: string) => void>();
@@ -56,32 +56,29 @@ export function useLocalStorage<T>(
     }
   };
 
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      // Return early no-op if not in browser environment
-      if (typeof window === "undefined") {
-        return () => {};
-      }
+  const subscribe = (onStoreChange: () => void) => {
+    // Return early no-op if not in browser environment
+    if (typeof window === "undefined") {
+      return () => {};
+    }
 
-      const onChange = (localKey: string | null) => {
-        if (localKey === key) {
-          onStoreChange();
-        }
-      };
-      const onStorageChange = (e: StorageEvent) => {
-        if (e.storageArea === localStorage) {
-          onChange(e.key);
-        }
-      };
-      callbacks.add(onChange);
-      window.addEventListener("storage", onStorageChange);
-      return () => {
-        callbacks.delete(onChange);
-        window.removeEventListener("storage", onStorageChange);
-      };
-    },
-    [key],
-  );
+    const onChange = (localKey: string | null) => {
+      if (localKey === key) {
+        onStoreChange();
+      }
+    };
+    const onStorageChange = (e: StorageEvent) => {
+      if (e.storageArea === localStorage) {
+        onChange(e.key);
+      }
+    };
+    callbacks.add(onChange);
+    window.addEventListener("storage", onStorageChange);
+    return () => {
+      callbacks.delete(onChange);
+      window.removeEventListener("storage", onStorageChange);
+    };
+  };
 
   const getServerSnapshot = (): string | null => {
     // On server, always return null since localStorage isn't available

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import type { z } from "zod";
 
 const callbacks = new Set<(key: string) => void>();
@@ -90,34 +90,28 @@ export function useLocalStorage<T>(
 
   const value = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
-  const setState = useCallback<React.Dispatch<React.SetStateAction<T>>>(
-    (newValue: React.SetStateAction<T>) => {
-      const snapshot = getSnapshot();
-      const value =
-        typeof newValue === "function"
-          ? (newValue as (prevState: T) => T)(parseSnapshot(snapshot))
-          : newValue;
+  const setState: React.Dispatch<React.SetStateAction<T>> = (newValue) => {
+    const snapshot = getSnapshot();
+    const value =
+      typeof newValue === "function"
+        ? (newValue as (prevState: T) => T)(parseSnapshot(snapshot))
+        : newValue;
 
-      try {
-        if (typeof window !== "undefined" && globalThis.localStorage) {
-          localStorage.setItem(key, serialize(value));
-          fallbackStorage.delete(key);
-        } else {
-          // Store value in fallback storage if not in browser environment
-          fallbackStorage.set(key, serialize(value));
-        }
-      } catch {
-        // Store value in fallback storage if there's an error with localStorage
+    try {
+      if (typeof window !== "undefined" && globalThis.localStorage) {
+        localStorage.setItem(key, serialize(value));
+        fallbackStorage.delete(key);
+      } else {
+        // Store value in fallback storage if not in browser environment
         fallbackStorage.set(key, serialize(value));
       }
+    } catch {
+      // Store value in fallback storage if there's an error with localStorage
+      fallbackStorage.set(key, serialize(value));
+    }
 
-      triggerCallbacks(key);
-    },
-    [initialValue, key, schema],
-  );
+    triggerCallbacks(key);
+  };
 
-  return useMemo(
-    () => [parseSnapshot(value ?? stringifiedInitialValue), setState],
-    [value, setState, stringifiedInitialValue],
-  );
+  return [parseSnapshot(value ?? stringifiedInitialValue), setState];
 }

--- a/src/hooks/useMounted.ts
+++ b/src/hooks/useMounted.ts
@@ -1,11 +1,13 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
+
+const subscribeToHydration = () => () => {};
+const getClientMountedSnapshot = () => true;
+const getServerMountedSnapshot = () => false;
 
 export function useMounted() {
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  return mounted;
+  return useSyncExternalStore(
+    subscribeToHydration,
+    getClientMountedSnapshot,
+    getServerMountedSnapshot,
+  );
 }

--- a/src/hooks/usePlaythroughImportExport.ts
+++ b/src/hooks/usePlaythroughImportExport.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import type { Playthrough } from "@/stores/playthroughs/types";
 import {
   exportPlaythrough,
@@ -37,27 +37,24 @@ export function usePlaythroughImportExport() {
   const [showImportError, setShowImportError] = useState(false);
   const [importErrorMessage, setImportErrorMessage] = useState("");
 
-  const handleExportClick = useCallback(
-    (playthrough: Playthrough, e: React.MouseEvent) => {
+  const handleExportClick = (playthrough: Playthrough, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    exportPlaythrough(playthrough);
+  };
+
+  const handleExportKeyDown = (
+    playthrough: Playthrough,
+    e: React.KeyboardEvent,
+  ) => {
+    if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       e.stopPropagation();
       exportPlaythrough(playthrough);
-    },
-    [],
-  );
+    }
+  };
 
-  const handleExportKeyDown = useCallback(
-    (playthrough: Playthrough, e: React.KeyboardEvent) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        e.stopPropagation();
-        exportPlaythrough(playthrough);
-      }
-    },
-    [],
-  );
-
-  const handleImportClick = useCallback(async () => {
+  const handleImportClick = async () => {
     try {
       // Create file input element
       const input = document.createElement("input");
@@ -83,7 +80,7 @@ export function usePlaythroughImportExport() {
       );
       setShowImportError(true);
     }
-  }, []);
+  };
 
   return {
     showImportError,

--- a/src/hooks/usePokemonTypes.ts
+++ b/src/hooks/usePokemonTypes.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import type { TypeName } from "@/lib/typings";
 import { getTypesForPokemon, type TypeQuery } from "@/lib/typings";
 import { useAllPokemon } from "@/loaders/pokemon";
@@ -14,34 +13,29 @@ export function usePokemonTypes(
 ): UsePokemonTypesResult {
   const { data: allPokemon = [], isLoading } = useAllPokemon();
 
-  const result = useMemo<UsePokemonTypesResult>(() => {
-    if (!query) return { isLoading };
-    if (!allPokemon || allPokemon.length === 0) return { isLoading: true };
+  if (!query) return { isLoading };
+  if (!allPokemon || allPokemon.length === 0) return { isLoading: true };
 
-    const resolveBy = (q: TypeQuery) => {
-      if ("name" in q) {
-        const p = allPokemon.find(
-          (x) => x.name.toLowerCase() === q.name?.toLowerCase(),
-        );
-        return p ? getTypesForPokemon(p) : undefined;
-      }
-      if ("id" in q) {
-        const p = allPokemon.find((x) => x.id === q.id);
-        return p ? getTypesForPokemon(p) : undefined;
-      }
-      if ("nationalDexId" in q) {
-        const p = allPokemon.find((x) => x.nationalDexId === q.nationalDexId);
-        return p ? getTypesForPokemon(p) : undefined;
-      }
-      return undefined;
-    };
+  const resolveBy = (q: TypeQuery) => {
+    if ("name" in q) {
+      const p = allPokemon.find(
+        (x) => x.name.toLowerCase() === q.name?.toLowerCase(),
+      );
+      return p ? getTypesForPokemon(p) : undefined;
+    }
+    if ("id" in q) {
+      const p = allPokemon.find((x) => x.id === q.id);
+      return p ? getTypesForPokemon(p) : undefined;
+    }
+    if ("nationalDexId" in q) {
+      const p = allPokemon.find((x) => x.nationalDexId === q.nationalDexId);
+      return p ? getTypesForPokemon(p) : undefined;
+    }
+    return undefined;
+  };
 
-    const types = resolveBy(query);
-    if (!types) return { isLoading };
-    return { ...types, isLoading: false };
-  }, [allPokemon, isLoading, query]);
-
-  return result;
+  const types = resolveBy(query);
+  return types ? { ...types, isLoading: false } : { isLoading };
 }
 
 export default usePokemonTypes;

--- a/src/lib/searchCore.ts
+++ b/src/lib/searchCore.ts
@@ -84,9 +84,13 @@ export class SearchCore {
     // Numeric search (by ID) - exact match for better performance
     if (/^\d+$/.test(trimmedQuery)) {
       const queryNum = parseInt(trimmedQuery, 10);
-      return this.pokemonData
-        .filter((p) => p.id === queryNum || p.nationalDexId === queryNum)
-        .map((p) => ({ ...p, score: 0 }));
+      const matches: SearchResult[] = [];
+      for (const pokemon of this.pokemonData) {
+        if (pokemon.id === queryNum || pokemon.nationalDexId === queryNum) {
+          matches.push({ ...pokemon, score: 0 });
+        }
+      }
+      return matches;
     }
 
     // Fuzzy search for names - let Fuse.js handle the ranking

--- a/src/loaders/encounters.ts
+++ b/src/loaders/encounters.ts
@@ -1,4 +1,3 @@
-import { useCallback, useMemo } from "react";
 import { encountersData } from "@/lib/queryClient";
 import {
   EncounterSource,
@@ -125,12 +124,10 @@ export function useEncountersForLocation({
   const { data: allPokemon = [] } = useAllPokemon();
   const nameMap = usePokemonNameMap();
 
-  // Process encounter data using useMemo, merging duplicates with multiple sources
-  const routeEncounterData = useMemo((): RouteEncounterPokemon[] => {
-    if (!enabled || !pokemonEncounters.length || !allPokemon.length) {
-      return [];
-    }
+  // Process encounter data, merging duplicates with multiple sources
+  let routeEncounterData: RouteEncounterPokemon[] = [];
 
+  if (enabled && pokemonEncounters.length && allPokemon.length) {
     // Group encounters by Pokemon ID to merge duplicates
     const encounterMap = new Map<number, EncounterSource[]>();
 
@@ -145,30 +142,27 @@ export function useEncountersForLocation({
     });
 
     // Convert back to array with merged sources
-    return Array.from(encounterMap.entries()).map(([id, sources]) => {
-      const pokemon = allPokemon.find((p: Pokemon) => p.id === id);
-      return {
-        id,
-        name: nameMap.get(id) || `Unknown Pokemon (${id})`,
-        nationalDexId: pokemon?.nationalDexId || 0,
-        originalLocation: locationId,
-        sources,
-      };
-    });
-  }, [pokemonEncounters, allPokemon, nameMap, enabled, locationId]);
+    routeEncounterData = Array.from(encounterMap.entries()).map(
+      ([id, sources]) => {
+        const pokemon = allPokemon.find((p: Pokemon) => p.id === id);
+        return {
+          id,
+          name: nameMap.get(id) || `Unknown Pokemon (${id})`,
+          nationalDexId: pokemon?.nationalDexId || 0,
+          originalLocation: locationId,
+          sources,
+        };
+      },
+    );
+  }
 
-  const routePokemonIds = useMemo(
-    () => new Set(routeEncounterData.map((pokemon) => pokemon.id)),
-    [routeEncounterData],
+  const routePokemonIds = new Set(
+    routeEncounterData.map((pokemon) => pokemon.id),
   );
 
   // Predicate function to check if a Pokemon is in the current route
-  const isRoutePokemon = useCallback(
-    (pokemonId: number): boolean => {
-      return routePokemonIds.has(pokemonId);
-    },
-    [routePokemonIds],
-  );
+  const isRoutePokemon = (pokemonId: number): boolean =>
+    routePokemonIds.has(pokemonId);
 
   return {
     routeEncounterData,

--- a/src/loaders/locations.ts
+++ b/src/loaders/locations.ts
@@ -360,8 +360,9 @@ export function mergeLocationsWithCustom(
     }
 
     // Remove placed locations from unplaced list
+    const placedCustoms = new Set(placedInThisPass);
     unplacedCustoms = unplacedCustoms.filter(
-      (custom) => !placedInThisPass.includes(custom),
+      (custom) => !placedCustoms.has(custom),
     );
 
     // If no progress was made, we have circular dependencies or missing references
@@ -462,18 +463,23 @@ export function updateCustomLocationDependencies(
   const parentLocationId = removedLocation.insertAfterLocationId;
 
   // Update all locations that depended on the removed location
-  return customLocations
-    .filter((loc) => loc.id !== removedLocationId) // Remove the target location
-    .map((loc) => {
-      if (loc.insertAfterLocationId === removedLocationId) {
-        // This location depended on the removed one, update it to depend on the parent
-        return {
-          ...loc,
-          insertAfterLocationId: parentLocationId,
-        };
-      }
-      return loc;
-    });
+  const updatedLocations: CustomLocation[] = [];
+  for (const location of customLocations) {
+    if (location.id === removedLocationId) {
+      continue;
+    }
+    if (location.insertAfterLocationId === removedLocationId) {
+      // This location depended on the removed one, update it to depend on the parent.
+      updatedLocations.push({
+        ...location,
+        insertAfterLocationId: parentLocationId,
+      });
+    } else {
+      updatedLocations.push(location);
+    }
+  }
+
+  return updatedLocations;
 }
 
 // Get all custom locations that depend on a given location (directly or indirectly)

--- a/src/loaders/pokemon.ts
+++ b/src/loaders/pokemon.ts
@@ -386,11 +386,12 @@ export function usePokemonEvolutionData(
         isLoading,
       };
 
-    const evolutionIds =
-      currentPokemon.evolution?.evolves_to.map((e) => e.id) || [];
+    const evolutionIds = new Set(
+      currentPokemon.evolution?.evolves_to.map((e) => e.id) || [],
+    );
     const preEvolutionId = currentPokemon.evolution?.evolves_from?.id || null;
     const evolutions = allPokemon.filter((p) =>
-      evolutionIds.includes(p.nationalDexId),
+      evolutionIds.has(p.nationalDexId),
     );
     const preEvolution = preEvolutionId
       ? allPokemon.find((p) => p.nationalDexId === preEvolutionId) || null
@@ -442,15 +443,18 @@ export function usePokemonSearch({
           "searchService failed, using client-side filtering fallback",
           err,
         );
-        return allPokemon
-          .filter((pokemon) =>
-            pokemon.name.toLowerCase().includes(debouncedQuery.toLowerCase()),
-          )
-          .map((p) => ({
-            id: p.id,
-            name: p.name,
-            nationalDexId: p.nationalDexId,
-          }));
+        const normalizedQuery = debouncedQuery.toLowerCase();
+        const matches: PokemonOptionType[] = [];
+        for (const pokemon of allPokemon) {
+          if (pokemon.name.toLowerCase().includes(normalizedQuery)) {
+            matches.push({
+              id: pokemon.id,
+              name: pokemon.name,
+              nationalDexId: pokemon.nationalDexId,
+            });
+          }
+        }
+        return matches;
       }
     },
     select: (data) => {

--- a/src/loaders/pokemon.ts
+++ b/src/loaders/pokemon.ts
@@ -3,7 +3,6 @@ import {
   type QueryOptions,
   useQuery,
 } from "@tanstack/react-query";
-import { useMemo } from "react";
 import { useDebounce } from "use-debounce";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
@@ -358,9 +357,7 @@ function usePokemonByType(type: string) {
 export function usePokemonNameMap() {
   const { data: allPokemon = [] } = useAllPokemon();
 
-  const nameMap = useMemo(() => {
-    return new Map(allPokemon.map((p) => [p.id, p.name]));
-  }, [allPokemon]);
+  const nameMap = new Map(allPokemon.map((p) => [p.id, p.name]));
 
   return nameMap;
 }
@@ -374,34 +371,32 @@ export function usePokemonEvolutionData(
     enabled,
   });
 
-  return useMemo(() => {
-    if (!pokemonId || !allPokemon || !enabled)
-      return { evolutions: [], preEvolution: null, isLoading };
+  if (!pokemonId || !allPokemon || !enabled)
+    return { evolutions: [], preEvolution: null, isLoading };
 
-    const currentPokemon = allPokemon.find((p) => p.id === pokemonId);
-    if (!currentPokemon)
-      return {
-        evolutions: [],
-        preEvolution: null,
-        isLoading,
-      };
-
-    const evolutionIds = new Set(
-      currentPokemon.evolution?.evolves_to.map((e) => e.id) || [],
-    );
-    const preEvolutionId = currentPokemon.evolution?.evolves_from?.id || null;
-    const evolutions = allPokemon.filter((p) =>
-      evolutionIds.has(p.nationalDexId),
-    );
-    const preEvolution = preEvolutionId
-      ? allPokemon.find((p) => p.nationalDexId === preEvolutionId) || null
-      : null;
+  const currentPokemon = allPokemon.find((p) => p.id === pokemonId);
+  if (!currentPokemon)
     return {
-      evolutions,
-      preEvolution,
+      evolutions: [],
+      preEvolution: null,
       isLoading,
     };
-  }, [allPokemon, pokemonId, isLoading, enabled]);
+
+  const evolutionIds = new Set(
+    currentPokemon.evolution?.evolves_to.map((e) => e.id) || [],
+  );
+  const preEvolutionId = currentPokemon.evolution?.evolves_from?.id || null;
+  const evolutions = allPokemon.filter((p) =>
+    evolutionIds.has(p.nationalDexId),
+  );
+  const preEvolution = preEvolutionId
+    ? allPokemon.find((p) => p.nationalDexId === preEvolutionId) || null
+    : null;
+  return {
+    evolutions,
+    preEvolution,
+    isLoading,
+  };
 }
 
 // Hook for searching Pokemon with debounced query

--- a/src/stores/__tests__/settings.browser.test.ts
+++ b/src/stores/__tests__/settings.browser.test.ts
@@ -18,6 +18,9 @@ const clearLocalStorage = () => {
   localStorage.clear();
 };
 
+const importFreshSettings = () =>
+  import(/* @vite-ignore */ `../settings.ts?t=${Date.now()}`);
+
 describe("Settings Store", () => {
   beforeEach(() => {
     // Clear all mocks and localStorage
@@ -89,7 +92,7 @@ describe("Settings Store", () => {
         .mockReturnValue(oldPlaythrough);
 
       const { settingsStore: freshStore, settingsActions: freshActions } =
-        await import("../settings.ts?t=" + Date.now());
+        await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
 
@@ -117,7 +120,7 @@ describe("Settings Store", () => {
         .mockReturnValue(oldPlaythrough);
 
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -146,7 +149,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -169,7 +172,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -180,7 +183,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -196,7 +199,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -220,7 +223,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -240,7 +243,7 @@ describe("Settings Store", () => {
       } as any);
 
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -259,7 +262,7 @@ describe("Settings Store", () => {
       localStorage.setItem("settings", JSON.stringify(storedSettings));
 
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -279,7 +282,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -300,7 +303,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -322,7 +325,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       // Should preserve user's explicit choice
@@ -336,7 +339,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -360,7 +363,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings.ts?t=${Date.now()}`
+        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);

--- a/src/stores/__tests__/settings.browser.test.ts
+++ b/src/stores/__tests__/settings.browser.test.ts
@@ -18,8 +18,10 @@ const clearLocalStorage = () => {
   localStorage.clear();
 };
 
+let settingsImportVersion = 0;
+
 const importFreshSettings = () =>
-  import(/* @vite-ignore */ `../settings.ts?t=${Date.now()}`);
+  import(/* @vite-ignore */ `../settings.ts?t=${++settingsImportVersion}`);
 
 describe("Settings Store", () => {
   beforeEach(() => {
@@ -119,9 +121,7 @@ describe("Settings Store", () => {
         .mockReturnValueOnce(null)
         .mockReturnValue(oldPlaythrough);
 
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
 
@@ -148,9 +148,7 @@ describe("Settings Store", () => {
       } as any);
 
       // Import fresh instance to trigger initialization
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
     });
@@ -171,9 +169,7 @@ describe("Settings Store", () => {
       } as any);
 
       // Import fresh instance to trigger initialization
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
     });
@@ -182,9 +178,7 @@ describe("Settings Store", () => {
       mockGetActivePlaythrough.mockReturnValue(null);
 
       // Import fresh instance to trigger initialization
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
     });
@@ -198,9 +192,7 @@ describe("Settings Store", () => {
       const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
       // Import fresh instance to trigger initialization
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
       expect(consoleSpy).toHaveBeenCalledWith(
@@ -222,9 +214,7 @@ describe("Settings Store", () => {
       localStorage.setItem("settings", JSON.stringify(storedSettings));
 
       // Import fresh instance to trigger initialization
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
       expect(freshStore.version).toBe("1.0.0");
@@ -242,9 +232,7 @@ describe("Settings Store", () => {
         name: "Old Run",
       } as any);
 
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
       expect(localStorage.getItem("settings:v1")).toBe(
@@ -261,9 +249,7 @@ describe("Settings Store", () => {
       localStorage.setItem("settings:v1", "");
       localStorage.setItem("settings", JSON.stringify(storedSettings));
 
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
       expect(localStorage.getItem("settings:v1")).toBe(
@@ -281,9 +267,7 @@ describe("Settings Store", () => {
       } as any);
 
       // Import fresh instance to trigger initialization
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
     });
@@ -302,9 +286,7 @@ describe("Settings Store", () => {
       } as any);
 
       // Import fresh instance to trigger initialization
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
     });
@@ -324,9 +306,7 @@ describe("Settings Store", () => {
       } as any);
 
       // Import fresh instance to trigger initialization
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       // Should preserve user's explicit choice
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -338,9 +318,7 @@ describe("Settings Store", () => {
       const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
       // Import fresh instance to trigger initialization
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
       expect(consoleSpy).toHaveBeenCalledWith(
@@ -362,9 +340,7 @@ describe("Settings Store", () => {
       const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
       // Import fresh instance to trigger initialization
-      const { settingsStore: freshStore } = await import(
-        /* @vite-ignore */ `../settings.ts?t=${Date.now()}`
-      );
+      const { settingsStore: freshStore } = await importFreshSettings();
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
       expect(consoleSpy).toHaveBeenCalledWith(

--- a/src/stores/__tests__/settings.browser.test.ts
+++ b/src/stores/__tests__/settings.browser.test.ts
@@ -89,7 +89,7 @@ describe("Settings Store", () => {
         .mockReturnValue(oldPlaythrough);
 
       const { settingsStore: freshStore, settingsActions: freshActions } =
-        await import("../settings?t=" + Date.now());
+        await import("../settings.ts?t=" + Date.now());
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
 
@@ -117,7 +117,7 @@ describe("Settings Store", () => {
         .mockReturnValue(oldPlaythrough);
 
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -146,7 +146,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -169,7 +169,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -180,7 +180,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -196,7 +196,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -220,7 +220,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -240,7 +240,7 @@ describe("Settings Store", () => {
       } as any);
 
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -259,7 +259,7 @@ describe("Settings Store", () => {
       localStorage.setItem("settings", JSON.stringify(storedSettings));
 
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -279,7 +279,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -300,7 +300,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(true);
@@ -322,7 +322,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       // Should preserve user's explicit choice
@@ -336,7 +336,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);
@@ -360,7 +360,7 @@ describe("Settings Store", () => {
 
       // Import fresh instance to trigger initialization
       const { settingsStore: freshStore } = await import(
-        `../settings?t=${Date.now()}`
+        `../settings.ts?t=${Date.now()}`
       );
 
       expect(freshStore.moveEncountersBetweenLocations).toBe(false);

--- a/src/stores/playthroughs/__tests__/hooks.test.tsx
+++ b/src/stores/playthroughs/__tests__/hooks.test.tsx
@@ -1,0 +1,44 @@
+/** @vitest-environment jsdom */
+
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useAllPlaythroughs } from "../hooks";
+import { playthroughsStore } from "../store";
+
+const { getAllPlaythroughsMock } = vi.hoisted(() => ({
+  getAllPlaythroughsMock: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../store", async () => {
+  const { proxy } = await import("valtio");
+  return {
+    getAllPlaythroughs: getAllPlaythroughsMock,
+    playthroughsStore: proxy({
+      activePlaythroughId: "run-1",
+      isLoading: false,
+      isSaving: false,
+      playthroughs: [{ id: "run-1" }],
+    }),
+  };
+});
+
+describe("useAllPlaythroughs", () => {
+  it("does not load when the store starts loading before its effect runs", () => {
+    function LoadingBeforePassiveEffects({
+      children,
+    }: React.PropsWithChildren) {
+      React.useLayoutEffect(() => {
+        playthroughsStore.isLoading = true;
+      }, []);
+
+      return children;
+    }
+
+    renderHook(() => useAllPlaythroughs(), {
+      wrapper: LoadingBeforePassiveEffects,
+    });
+
+    expect(getAllPlaythroughsMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/stores/playthroughs/encounters/team.ts
+++ b/src/stores/playthroughs/encounters/team.ts
@@ -254,11 +254,13 @@ export const findCanonicalLocationForUids = (uids: string[]) => {
 
   const matches = Object.entries(activePlaythrough.encounters).filter(
     ([, encounter]) => {
-      const encounterUids = [encounter.head?.uid, encounter.body?.uid].filter(
-        (uid) => uid != null,
+      const encounterUids = new Set(
+        [encounter.head?.uid, encounter.body?.uid].filter(
+          (uid): uid is string => uid != null,
+        ),
       );
 
-      return uids.every((uid) => encounterUids.includes(uid));
+      return uids.every((uid) => encounterUids.has(uid));
     },
   );
 
@@ -275,6 +277,7 @@ export const removeTeamMembersWithPokemon = (pokemonUIDs: string[]) => {
     return;
   }
 
+  const removedPokemonUids = new Set(pokemonUIDs);
   let hasChanges = false;
 
   for (let i = 0; i < activePlaythrough.team.members.length; i++) {
@@ -284,8 +287,9 @@ export const removeTeamMembersWithPokemon = (pokemonUIDs: string[]) => {
     }
 
     const hasRemovedPokemon =
-      (member.headPokemonUid && pokemonUIDs.includes(member.headPokemonUid)) ||
-      (member.bodyPokemonUid && pokemonUIDs.includes(member.bodyPokemonUid));
+      (member.headPokemonUid &&
+        removedPokemonUids.has(member.headPokemonUid)) ||
+      (member.bodyPokemonUid && removedPokemonUids.has(member.bodyPokemonUid));
 
     if (hasRemovedPokemon) {
       activePlaythrough.team.members[i] = null;

--- a/src/stores/playthroughs/encounters/variants.ts
+++ b/src/stores/playthroughs/encounters/variants.ts
@@ -218,14 +218,15 @@ export const preloadArtworkVariants = async () => {
 
       const batchPromises = batch.map(([, encounter]) => {
         if (encounter.isFusion && encounter.head && encounter.body) {
-          return getArtworkVariants(encounter.head.id, encounter.body.id).catch(
-            (error: unknown) => {
-              console.warn(
-                `Failed to preload fusion variants ${encounter.head?.id}.${encounter.body?.id}:`,
-                error,
-              );
-            },
-          );
+          const { id: headId } = encounter.head;
+          const { id: bodyId } = encounter.body;
+
+          return getArtworkVariants(headId, bodyId).catch((error: unknown) => {
+            console.warn(
+              `Failed to preload fusion variants ${headId}.${bodyId}:`,
+              error,
+            );
+          });
         }
 
         if (encounter.head) {

--- a/src/stores/playthroughs/hooks.ts
+++ b/src/stores/playthroughs/hooks.ts
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { useSnapshot } from "valtio";
 import type { z } from "zod";
 import type { CustomLocationSchema } from "@/loaders/locations";
@@ -31,25 +31,19 @@ export const useAllPlaythroughs = () => {
     }
   }, [snapshot.isLoading, snapshot.playthroughs.length]);
 
-  return useMemo(() => {
-    return snapshot.playthroughs;
-  }, [snapshot.playthroughs]);
+  return snapshot.playthroughs;
 };
 
 export const useActivePlaythrough = (): Playthrough | null => {
   const snapshot = useSnapshot(playthroughsStore);
 
-  return useMemo(() => {
-    if (!snapshot.activePlaythroughId) return null;
+  if (!snapshot.activePlaythroughId) return null;
 
-    const activePlaythroughData = snapshot.playthroughs.find(
-      (p) => p.id === snapshot.activePlaythroughId,
-    );
+  const activePlaythroughData = snapshot.playthroughs.find(
+    (p) => p.id === snapshot.activePlaythroughId,
+  );
 
-    return activePlaythroughData
-      ? (activePlaythroughData as Playthrough)
-      : null;
-  }, [snapshot.activePlaythroughId, snapshot.playthroughs]);
+  return activePlaythroughData ? (activePlaythroughData as Playthrough) : null;
 };
 
 export const useActivePlaythroughId = (): string | null => {
@@ -91,10 +85,8 @@ export const usePlaythroughById = (
     (p) => p.id === playthroughId,
   );
 
-  return useMemo(() => {
-    if (!playthroughId || !playthroughData) return null;
-    return playthroughData as Playthrough;
-  }, [playthroughId, playthroughData]);
+  if (!playthroughId || !playthroughData) return null;
+  return playthroughData as Playthrough;
 };
 
 export const useIsLoading = (): boolean => {
@@ -134,9 +126,7 @@ export const useCustomLocations = (): z.infer<
 >[] => {
   const activePlaythrough = useActivePlaythrough();
 
-  return useMemo(() => {
-    return activePlaythrough?.customLocations || [];
-  }, [activePlaythrough?.customLocations]);
+  return activePlaythrough?.customLocations || [];
 };
 
 const useMergedLocations = () => {

--- a/src/stores/playthroughs/hooks.ts
+++ b/src/stores/playthroughs/hooks.ts
@@ -21,7 +21,10 @@ export const useAllPlaythroughs = () => {
   // Automatically load all playthroughs if we only have one loaded (likely just the active one)
   // and we're not currently loading
   React.useEffect(() => {
-    if (!snapshot.isLoading && snapshot.playthroughs.length <= 1) {
+    if (
+      !playthroughsStore.isLoading &&
+      playthroughsStore.playthroughs.length <= 1
+    ) {
       getAllPlaythroughs().catch((error) => {
         console.error("Failed to load all playthroughs:", error);
       });

--- a/src/utils/encounter-utils.ts
+++ b/src/utils/encounter-utils.ts
@@ -6,6 +6,8 @@ export type PokemonUidIndex = Map<string, PokemonOptionType>;
 export function buildPokemonUidIndex(
   encounters: Record<string, EncounterData> | null | undefined,
 ): PokemonUidIndex {
+  "use memo";
+
   const pokemonByUid: PokemonUidIndex = new Map();
 
   if (!encounters) return pokemonByUid;

--- a/src/utils/formatCredits.ts
+++ b/src/utils/formatCredits.ts
@@ -14,9 +14,13 @@ export function formatArtistCredits(artists?: string[] | null): string {
   }
 
   // Filter out empty strings and trim whitespace
-  const cleanedArtists = artists
-    .map((artist) => artist.trim())
-    .filter((artist) => artist.length > 0);
+  const cleanedArtists: string[] = [];
+  for (const artist of artists) {
+    const trimmedArtist = artist.trim();
+    if (trimmedArtist.length > 0) {
+      cleanedArtists.push(trimmedArtist);
+    }
+  }
 
   if (cleanedArtists.length === 0) {
     return "Unknown artist";

--- a/tests/scrape-wild-encounters-wikitext.test.ts
+++ b/tests/scrape-wild-encounters-wikitext.test.ts
@@ -167,14 +167,12 @@ describe("Wild encounter wikitext parser", () => {
   });
 
   it("fails validation when wild encounter output contains special encounters", () => {
-    const payload = JSON.parse(
-      JSON.stringify([
-        {
-          routeName: "Route 1",
-          encounters: [{ pokemonId: 16, encounterType: "special" }],
-        },
-      ]),
-    );
+    const payload = structuredClone([
+      {
+        routeName: "Route 1",
+        encounters: [{ pokemonId: 16, encounterType: "special" }],
+      },
+    ]) as never;
 
     expect(() =>
       assertEncounterPayload(payload, pokemonNameMap, "unit test encounters"),
@@ -182,14 +180,12 @@ describe("Wild encounter wikitext parser", () => {
   });
 
   it("returns the normalized payload after validation", () => {
-    const payload = JSON.parse(
-      JSON.stringify([
-        {
-          routeName: " Route 1 ",
-          encounters: [{ pokemonId: 16, encounterType: "grass" }],
-        },
-      ]),
-    );
+    const payload = structuredClone([
+      {
+        routeName: " Route 1 ",
+        encounters: [{ pokemonId: 16, encounterType: "grass" }],
+      },
+    ]) as never;
 
     expect(
       assertEncounterPayload(payload, pokemonNameMap, "unit test encounters"),
@@ -202,15 +198,13 @@ describe("Wild encounter wikitext parser", () => {
   });
 
   it("fails validation when scraped payloads contain unexpected keys", () => {
-    const payload = JSON.parse(
-      JSON.stringify([
-        {
-          routeName: "Route 1",
-          source: "wiki",
-          encounters: [{ pokemonId: 16, encounterType: "grass" }],
-        },
-      ]),
-    );
+    const payload = structuredClone([
+      {
+        routeName: "Route 1",
+        source: "wiki",
+        encounters: [{ pokemonId: 16, encounterType: "grass" }],
+      },
+    ]) as never;
 
     expect(() =>
       assertEncounterPayload(payload, pokemonNameMap, "unit test encounters"),


### PR DESCRIPTION
## Summary
Resolve React Doctor runtime findings while keeping React Compiler compatibility and Fallow’s new-only gate clean.

## Changes
- Fix stale drag state, effect synchronization, accessibility, and Vercel credential scoping.
- Replace redundant manual memoization and low-risk collection hot paths.
- Extract PC sheet and combobox menu decisions to reduce component complexity.

## Risk
Interactive drag, context-menu, and PC-sheet behavior were refactored across shared UI components. Browser tests remain unavailable locally because Playwright Chromium lacks `libglib-2.0.so.0`.

## Testing
- `pnpm type-check`
- `pnpm test:run` (1105 passed, 2 skipped)
- `pnpm validate`
- `pnpm quality:react`
- `pnpm exec fallow audit --format json --quiet --explain`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a tabbed Pokémon PC sheet for Team, Box, and Graveyard management.
  - Expanded Pokémon context menus with move, evolve/devolve, fusion, status, and external dex actions.
  - Improved analytics debug-panel activation via URL flag or local setting.
- **Bug Fixes**
  - Improved drag-and-drop reliability, including async fusion flows and preview correctness.
  - Prevented stale Pokémon details from overwriting newer selections.
  - Refined encounter, location, search, type, and artwork-variant processing.
- **Documentation**
  - Updated React Doctor badge and remediation plan.
- **Tests**
  - Added/expanded coverage for drag-and-drop, fusion behavior, async lookups, server rendering, and key/mount handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->