### PR TITLE
fix(persistence): recover missing IndexedDB store

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.18.4"
+        "@opencode-ai/plugin": "1.18.10"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -99,13 +99,13 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.4.tgz",
-      "integrity": "sha512-Mkq128aLJo4E8Sb2bX8zrRlQ+I2WPaJ/n1kzaor8nTi/K/zNP4t8LGKwyMbuRoD/lhw4veSbzDOASSSypv3mcQ==",
+      "version": "1.18.10",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.10.tgz",
+      "integrity": "sha512-l4R1ulu5wtA0+cCinzdSPkEO8ZCdIgb/ZjltzstIWQqRqeH3H880OabNaeje/ZCkSoAT8c/o9oT3tdjyFP7o7g==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.4",
+        "@opencode-ai/sdk": "1.18.10",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.4.tgz",
-      "integrity": "sha512-p/3P0KtWknoLvpsk8QrUzCKd4Q1A5Z3RmACEvwuQBGxnUy4AGo379lUYMgt7fczFn53079oroLuo6BosQri+HA==",
+      "version": "1.18.10",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.10.tgz",
+      "integrity": "sha512-K+glWbBp5pfGepZ/6EHvuXY3IpVG2qgsEqF4z9mOiUQUrs6KWN72Vdp15Qsl2TCDbemgHWXKQKgbX3b8PSK2hg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/src/components/PokemonCombobox/__tests__/fusionCombination.test.ts
+++ b/src/components/PokemonCombobox/__tests__/fusionCombination.test.ts
@@ -41,4 +41,16 @@ describe("resolveFusionCombination", () => {
       resolveFusionCombination("11.200", [null] as unknown as typeof pokemon),
     ).toBeNull();
   });
+
+  it.each([Number.NaN, Infinity, 11.5])(
+    "rejects a cached Pokémon with invalid ID %s",
+    (id) => {
+      expect(
+        resolveFusionCombination("11.200", [
+          { id, name: "Metapod", nationalDexId: 11 },
+          pokemon[1],
+        ]),
+      ).toBeNull();
+    },
+  );
 });

--- a/src/components/PokemonCombobox/__tests__/fusionCombination.test.ts
+++ b/src/components/PokemonCombobox/__tests__/fusionCombination.test.ts
@@ -31,4 +31,14 @@ describe("resolveFusionCombination", () => {
   it("rejects shorthand with an unknown Pokémon ID", () => {
     expect(resolveFusionCombination("11.999", pokemon)).toBeNull();
   });
+
+  it("rejects a malformed cached Pokémon collection", () => {
+    expect(resolveFusionCombination("11.200", {} as typeof pokemon)).toBeNull();
+  });
+
+  it("ignores malformed cached Pokémon entries", () => {
+    expect(
+      resolveFusionCombination("11.200", [null] as unknown as typeof pokemon),
+    ).toBeNull();
+  });
 });

--- a/src/components/PokemonCombobox/fusionCombination.ts
+++ b/src/components/PokemonCombobox/fusionCombination.ts
@@ -1,4 +1,4 @@
-import type { PokemonOptionType } from "@/loaders/pokemon";
+import { PokemonOptionSchema, type PokemonOptionType } from "@/loaders/pokemon";
 
 export interface FusionCombination {
   head: PokemonOptionType;
@@ -12,20 +12,16 @@ type PokemonSearchResult = Pick<
 
 const FUSION_COMBINATION_PATTERN = /^(\d+)\.(\d+)$/;
 
+const PokemonSearchResultSchema = PokemonOptionSchema.pick({
+  id: true,
+  name: true,
+  nationalDexId: true,
+});
+
 const isPokemonSearchResult = (
   pokemon: unknown,
-): pokemon is PokemonSearchResult => {
-  if (!pokemon || typeof pokemon !== "object") {
-    return false;
-  }
-
-  const candidate = pokemon as Record<string, unknown>;
-  return (
-    typeof candidate.id === "number" &&
-    typeof candidate.name === "string" &&
-    typeof candidate.nationalDexId === "number"
-  );
-};
+): pokemon is PokemonSearchResult =>
+  PokemonSearchResultSchema.safeParse(pokemon).success;
 
 export function resolveFusionCombination(
   query: string,

--- a/src/components/PokemonCombobox/fusionCombination.ts
+++ b/src/components/PokemonCombobox/fusionCombination.ts
@@ -12,10 +12,29 @@ type PokemonSearchResult = Pick<
 
 const FUSION_COMBINATION_PATTERN = /^(\d+)\.(\d+)$/;
 
+const isPokemonSearchResult = (
+  pokemon: unknown,
+): pokemon is PokemonSearchResult => {
+  if (!pokemon || typeof pokemon !== "object") {
+    return false;
+  }
+
+  const candidate = pokemon as Record<string, unknown>;
+  return (
+    typeof candidate.id === "number" &&
+    typeof candidate.name === "string" &&
+    typeof candidate.nationalDexId === "number"
+  );
+};
+
 export function resolveFusionCombination(
   query: string,
   pokemon: PokemonSearchResult[],
 ): FusionCombination | null {
+  if (Array.isArray(pokemon) === false) {
+    return null;
+  }
+
   const match = FUSION_COMBINATION_PATTERN.exec(query.trim());
   if (!match) {
     return null;
@@ -23,8 +42,12 @@ export function resolveFusionCombination(
 
   const headId = Number(match[1]);
   const bodyId = Number(match[2]);
-  const head = pokemon.find(({ id }) => id === headId);
-  const body = pokemon.find(({ id }) => id === bodyId);
+  const head = pokemon.find(
+    (candidate) => isPokemonSearchResult(candidate) && candidate.id === headId,
+  );
+  const body = pokemon.find(
+    (candidate) => isPokemonSearchResult(candidate) && candidate.id === bodyId,
+  );
 
   if (!head || !body) {
     return null;

--- a/src/stores/playthroughs/persistence.ts
+++ b/src/stores/playthroughs/persistence.ts
@@ -9,7 +9,76 @@ import { createDefaultPlaythrough } from "./defaultPlaythrough";
 import { normalizePersistedPlaythrough } from "./migrations";
 
 // Create a custom store for playthroughs data
-export const playthroughsStore_idb = createStore("playthroughs", "data");
+const PLAYTHROUGHS_DATABASE = "playthroughs";
+const PLAYTHROUGHS_STORE = "data";
+
+export const playthroughsStore_idb = createStore(
+  PLAYTHROUGHS_DATABASE,
+  PLAYTHROUGHS_STORE,
+);
+
+let playthroughsStoreInitialization: Promise<void> | undefined;
+
+const openPlaythroughsDatabase = (version?: number): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    let isBlocked = false;
+    const request =
+      version === undefined
+        ? indexedDB.open(PLAYTHROUGHS_DATABASE)
+        : indexedDB.open(PLAYTHROUGHS_DATABASE, version);
+
+    request.onupgradeneeded = () => {
+      if (
+        request.result.objectStoreNames.contains(PLAYTHROUGHS_STORE) === false
+      ) {
+        request.result.createObjectStore(PLAYTHROUGHS_STORE);
+      }
+    };
+    request.onblocked = () => {
+      isBlocked = true;
+      reject(
+        new Error("Playthrough storage upgrade is blocked by another tab"),
+      );
+    };
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      if (isBlocked) {
+        request.result.close();
+        return;
+      }
+
+      resolve(request.result);
+    };
+  });
+
+const ensurePlaythroughsStore = (): Promise<void> => {
+  if (typeof indexedDB === "undefined") {
+    return Promise.resolve();
+  }
+
+  if (playthroughsStoreInitialization) {
+    return playthroughsStoreInitialization;
+  }
+
+  playthroughsStoreInitialization = (async () => {
+    const database = await openPlaythroughsDatabase();
+    if (database.objectStoreNames.contains(PLAYTHROUGHS_STORE)) {
+      database.close();
+      return;
+    }
+
+    const nextVersion = database.version + 1;
+    database.close();
+
+    const upgradedDatabase = await openPlaythroughsDatabase(nextVersion);
+    upgradedDatabase.close();
+  })().catch((error) => {
+    playthroughsStoreInitialization = undefined;
+    throw error;
+  });
+
+  return playthroughsStoreInitialization;
+};
 
 // Storage keys
 export const ACTIVE_PLAYTHROUGH_KEY = "activePlaythroughId";
@@ -57,6 +126,7 @@ const migrateActivePlaythroughId = async (): Promise<string | null> => {
   }
 
   try {
+    await ensurePlaythroughsStore();
     // Try to get the value from IndexedDB
     const indexedDBValue = await get(
       ACTIVE_PLAYTHROUGH_KEY,
@@ -103,6 +173,7 @@ export const loadPlaythroughById = async (
   if (typeof window === "undefined") return null;
 
   try {
+    await ensurePlaythroughsStore();
     const playthroughData = await get(playthroughId, playthroughsStore_idb);
     if (playthroughData) {
       return normalizePersistedPlaythrough(playthroughData);
@@ -118,6 +189,7 @@ export const loadAllPlaythroughs = async (): Promise<Playthrough[]> => {
   if (typeof window === "undefined") return [];
 
   try {
+    await ensurePlaythroughsStore();
     // Get all keys from IndexedDB and filter out non-playthrough keys
     const allKeys = await keys(playthroughsStore_idb);
     const playthroughIds = allKeys.filter(
@@ -159,6 +231,7 @@ export const deletePlaythroughFromIndexedDB = async (
   if (typeof window === "undefined") return;
 
   try {
+    await ensurePlaythroughsStore();
     // Simply delete the playthrough - no need to maintain ID list
     await del(playthroughId, playthroughsStore_idb);
   } catch (error) {
@@ -197,6 +270,7 @@ export const createDebouncedSaveAll = (
       if (typeof window === "undefined") return;
 
       try {
+        await ensurePlaythroughsStore();
         playthroughsStore.isSaving = true;
 
         const activePlaythrough = getActivePlaythrough();
@@ -239,6 +313,7 @@ export const loadFromIndexedDB = async (
   if (typeof window === "undefined") return;
 
   try {
+    await ensurePlaythroughsStore();
     playthroughsStore.isLoading = true;
 
     // Load all playthroughs

--- a/tests/persistence.browser.test.ts
+++ b/tests/persistence.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { loadFromIndexedDB } from "@/stores/playthroughs/persistence";
 import type { PlaythroughsState } from "@/stores/playthroughs/types";
 
@@ -15,7 +15,22 @@ const openDatabase = (onUpgradeNeeded?: (database: IDBDatabase) => void) =>
     request.onsuccess = () => resolve(request.result);
   });
 
+const deleteDatabase = () =>
+  new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(PLAYTHROUGHS_DATABASE);
+
+    request.onblocked = () => {
+      reject(new Error("Unable to clear the playthroughs IndexedDB fixture"));
+    };
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve();
+  });
+
 describe("playthrough persistence browser regressions", () => {
+  beforeEach(async () => {
+    await deleteDatabase();
+  });
+
   it("adds the data store when an existing database does not have it", async () => {
     const legacyDatabase = await openDatabase((database) => {
       database.createObjectStore("legacy");

--- a/tests/persistence.browser.test.ts
+++ b/tests/persistence.browser.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { loadFromIndexedDB } from "@/stores/playthroughs/persistence";
+import type { PlaythroughsState } from "@/stores/playthroughs/types";
+
+const PLAYTHROUGHS_DATABASE = "playthroughs";
+
+const openDatabase = (onUpgradeNeeded?: (database: IDBDatabase) => void) =>
+  new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(PLAYTHROUGHS_DATABASE);
+
+    request.onupgradeneeded = () => {
+      onUpgradeNeeded?.(request.result);
+    };
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+  });
+
+describe("playthrough persistence browser regressions", () => {
+  it("adds the data store when an existing database does not have it", async () => {
+    const legacyDatabase = await openDatabase((database) => {
+      database.createObjectStore("legacy");
+    });
+    legacyDatabase.close();
+
+    const state: PlaythroughsState = {
+      playthroughs: [],
+      activePlaythroughId: undefined,
+      isLoading: false,
+      isSaving: false,
+    };
+
+    await loadFromIndexedDB(state);
+
+    const database = await openDatabase();
+    expect(Array.from(database.objectStoreNames)).toContain("data");
+    database.close();
+  });
+});


### PR DESCRIPTION
## Summary
Recover Firefox clients whose playthrough IndexedDB database lacks the `data` store, and prevent malformed cached Pokemon data from crashing fusion shorthand lookup.

## Changes
- Upgrade the playthrough database to add its required object store before reads and writes.
- Return no fusion result when cached Pokemon collections or entries are malformed.
- Add regressions for malformed Pokemon data and legacy IndexedDB schemas.

## Risk
A database upgrade blocked by another open tab falls back to the existing error path and retries on a later storage access.

## Testing
- `pnpm type-check`
- `pnpm test:run`
- `pnpm validate`
- Browser IndexedDB regression added; local execution is blocked because Playwright Chromium is missing `libglib-2.0.so.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fusion resolution by safely handling malformed Pokémon collections and entries.
  * Improved playthrough persistence reliability by ensuring storage is initialized and upgraded before use.
  * Added graceful handling when browser storage is unavailable or initialization fails.

* **Tests**
  * Added coverage for malformed fusion data.
  * Added a browser regression test for upgrading legacy persistence storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->