### PR TITLE
fix(persistence): recover malformed encounter cache

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,25 +1,26 @@
 // Simplified Service Worker with Image Caching
 // API cache gets cleared on each deployment, images remain persistent
 const BUILD_ID =
-  new URL(self.location).searchParams.get('buildId') || 'default';
+  new URL(self.location).searchParams.get("buildId") || "default";
 const API_CACHE_NAME = `infinite-fusion-api-${BUILD_ID}`;
 // Image caches remain static - no versioning needed since images don't change
 const IMAGE_CACHE_NAME = `infinite-fusion-images-v1`;
-
-// Essential URLs to cache immediately
-const urlsToCache = ['/', SPRITESHEET_URL];
-
-// Image domains that we want to cache
-const imageDomains = [
-  'raw.githubusercontent.com',
-  'ifd-spaces.sfo2.cdn.digitaloceanspaces.com',
-];
+const POKEMON_IMAGE_CACHE_NAME = `infinite-fusion-pokemon-images-v1`;
 
 // Essential spritesheet to cache immediately (with version for cache busting)
 const SPRITESHEET_URL = `/images/pokemon-spritesheet.png?v=${BUILD_ID}`;
 
+// Essential URLs to cache immediately
+const urlsToCache = ["/", SPRITESHEET_URL];
+
+// Image domains that we want to cache
+const imageDomains = [
+  "raw.githubusercontent.com",
+  "ifd-spaces.sfo2.cdn.digitaloceanspaces.com",
+];
+
 // Queue for sprite variant prefetch requests
-let spriteVariantQueue = [];
+const spriteVariantQueue = [];
 let isProcessingSpriteVariants = false;
 
 // Add sprite variants to background queue
@@ -30,21 +31,21 @@ function queueSpriteVariants(spriteVariantsResponse) {
 
   // Check if already queued
   const isAlreadyQueued = spriteVariantQueue.some(
-    item => item.cacheKey === spriteVariantsResponse.cacheKey
+    (item) => item.cacheKey === spriteVariantsResponse.cacheKey,
   );
 
   if (!isAlreadyQueued) {
     spriteVariantQueue.push(spriteVariantsResponse);
     console.debug(
-      `Service Worker: Queued sprite variants for ${spriteVariantsResponse.cacheKey} (queue length: ${spriteVariantQueue.length})`
+      `Service Worker: Queued sprite variants for ${spriteVariantsResponse.cacheKey} (queue length: ${spriteVariantQueue.length})`,
     );
 
     // Start processing if not already running
     if (!isProcessingSpriteVariants) {
-      processSpriteVariantQueue().catch(error => {
+      processSpriteVariantQueue().catch((error) => {
         console.warn(
-          'Service Worker: Sprite variant queue processing failed:',
-          error
+          "Service Worker: Sprite variant queue processing failed:",
+          error,
         );
       });
     }
@@ -59,7 +60,7 @@ async function processSpriteVariantQueue() {
 
   isProcessingSpriteVariants = true;
   console.debug(
-    `Service Worker: Starting sprite variant queue processing (${spriteVariantQueue.length} items)`
+    `Service Worker: Starting sprite variant queue processing (${spriteVariantQueue.length} items)`,
   );
 
   // Wait for initial page load and network to be idle
@@ -74,7 +75,7 @@ async function processSpriteVariantQueue() {
     // Check network conditions before each batch
     if (!shouldContinuePrefetch()) {
       console.debug(
-        'Service Worker: Pausing sprite variant processing due to network conditions'
+        "Service Worker: Pausing sprite variant processing due to network conditions",
       );
       break;
     }
@@ -85,13 +86,13 @@ async function processSpriteVariantQueue() {
     // Take items from queue for this batch
     const batchItems = spriteVariantQueue.splice(
       0,
-      Math.min(batchSize, spriteVariantQueue.length)
+      Math.min(batchSize, spriteVariantQueue.length),
     );
 
     await Promise.allSettled(
-      batchItems.map(async item => {
+      batchItems.map(async (item) => {
         await processSingleSpriteVariantItem(item, cache);
-      })
+      }),
     );
 
     // Add delay between batches
@@ -101,7 +102,7 @@ async function processSpriteVariantQueue() {
   }
 
   isProcessingSpriteVariants = false;
-  console.debug('Service Worker: Sprite variant queue processing complete');
+  console.debug("Service Worker: Sprite variant queue processing complete");
 }
 
 // Process a single sprite variant item
@@ -114,14 +115,14 @@ async function processSingleSpriteVariantItem(item, cache) {
 
   // Generate sprite URLs for all variants
   const spriteUrls = variants.map(
-    variant =>
-      `https://ifd-spaces.sfo2.cdn.digitaloceanspaces.com/custom/${cacheKey}${variant}.png`
+    (variant) =>
+      `https://ifd-spaces.sfo2.cdn.digitaloceanspaces.com/custom/${cacheKey}${variant}.png`,
   );
 
   let successCount = 0;
 
   await Promise.allSettled(
-    spriteUrls.map(async url => {
+    spriteUrls.map(async (url) => {
       try {
         // Skip if already cached
         if (await cache.match(url)) {
@@ -130,8 +131,8 @@ async function processSingleSpriteVariantItem(item, cache) {
         }
 
         const response = await fetch(url, {
-          mode: 'no-cors', // Required for DigitalOcean Spaces CORS policy
-          priority: 'low', // Use low priority for background requests
+          mode: "no-cors", // Required for DigitalOcean Spaces CORS policy
+          priority: "low", // Use low priority for background requests
         });
 
         if (response.ok) {
@@ -141,22 +142,22 @@ async function processSingleSpriteVariantItem(item, cache) {
       } catch (error) {
         // Silently continue on individual failures
         console.debug(
-          'Service Worker: Failed to prefetch sprite variant:',
+          "Service Worker: Failed to prefetch sprite variant:",
           url,
-          error
+          error,
         );
       }
-    })
+    }),
   );
 
   console.debug(
-    `Service Worker: Cached ${successCount}/${spriteUrls.length} sprite variants for ${cacheKey}`
+    `Service Worker: Cached ${successCount}/${spriteUrls.length} sprite variants for ${cacheKey}`,
   );
 }
 
 // Wait for initial page load to complete
 function waitForPageLoad() {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     // Wait at least 2 seconds for initial critical resources
     setTimeout(resolve, 2000);
   });
@@ -164,9 +165,9 @@ function waitForPageLoad() {
 
 // Wait for network to be idle
 function waitForNetworkIdle() {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     // Use requestIdleCallback if available, otherwise setTimeout
-    if (typeof requestIdleCallback !== 'undefined') {
+    if (typeof requestIdleCallback !== "undefined") {
       requestIdleCallback(resolve, { timeout: 1000 });
     } else {
       setTimeout(resolve, 100);
@@ -177,10 +178,10 @@ function waitForNetworkIdle() {
 // Get network information for adaptive behavior
 function getNetworkInfo() {
   // Use Network Information API if available
-  if ('connection' in navigator) {
+  if ("connection" in navigator) {
     const connection = navigator.connection;
     return {
-      effectiveType: connection.effectiveType || '4g',
+      effectiveType: connection.effectiveType || "4g",
       downlink: connection.downlink || 10,
       saveData: connection.saveData || false,
     };
@@ -188,7 +189,7 @@ function getNetworkInfo() {
 
   // Fallback for browsers without Network Information API
   return {
-    effectiveType: '4g',
+    effectiveType: "4g",
     downlink: 10,
     saveData: false,
   };
@@ -199,12 +200,12 @@ function getBatchSize(networkInfo) {
   if (networkInfo.saveData) return 3; // Very conservative for data saver
 
   switch (networkInfo.effectiveType) {
-    case 'slow-2g':
-    case '2g':
+    case "slow-2g":
+    case "2g":
       return 3;
-    case '3g':
+    case "3g":
       return 8;
-    case '4g':
+    case "4g":
     default:
       return 15;
   }
@@ -215,12 +216,12 @@ function getDelayBetweenBatches(networkInfo) {
   if (networkInfo.saveData) return 2000; // 2 second delay for data saver
 
   switch (networkInfo.effectiveType) {
-    case 'slow-2g':
-    case '2g':
+    case "slow-2g":
+    case "2g":
       return 1500; // 1.5 second delay for slow connections
-    case '3g':
+    case "3g":
       return 800; // 0.8 second delay for 3G
-    case '4g':
+    case "4g":
     default:
       return 300; // 0.3 second delay for fast connections
   }
@@ -236,7 +237,7 @@ function shouldContinuePrefetch() {
   }
 
   // Stop if connection became very slow
-  if (networkInfo.effectiveType === 'slow-2g') {
+  if (networkInfo.effectiveType === "slow-2g") {
     return false;
   }
 
@@ -245,73 +246,73 @@ function shouldContinuePrefetch() {
 
 // Simple sleep utility
 function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // Install event - cache essential resources and start background prefetching
-self.addEventListener('install', event => {
-  console.debug('Service Worker: Installing...');
+self.addEventListener("install", (event) => {
+  console.debug("Service Worker: Installing...");
   event.waitUntil(
     // Cache essential files first
     caches
       .open(API_CACHE_NAME)
-      .then(cache => {
-        console.debug('Service Worker: Caching essential files');
+      .then((cache) => {
+        console.debug("Service Worker: Caching essential files");
         return cache.addAll(urlsToCache);
       })
       .then(() => {
-        console.debug('Service Worker: Essential files and spritesheet cached');
+        console.debug("Service Worker: Essential files and spritesheet cached");
         return self.skipWaiting();
       })
-      .catch(error => {
-        console.error('Service Worker: Failed to cache essential files', error);
+      .catch((error) => {
+        console.error("Service Worker: Failed to cache essential files", error);
         return self.skipWaiting(); // Continue even if caching fails
-      })
+      }),
   );
 });
 
 // Activate event - clean up old caches
-self.addEventListener('activate', event => {
-  console.debug('Service Worker: Activating...');
+self.addEventListener("activate", (event) => {
+  console.debug("Service Worker: Activating...");
   event.waitUntil(
     Promise.all([
       // Clean up old API caches only (keep image caches)
-      caches.keys().then(cacheNames => {
+      caches.keys().then((cacheNames) => {
         return Promise.all(
-          cacheNames.map(cacheName => {
+          cacheNames.map((cacheName) => {
             // Only delete old API caches, preserve image caches
             if (
-              cacheName.startsWith('infinite-fusion-api-') &&
+              cacheName.startsWith("infinite-fusion-api-") &&
               cacheName !== API_CACHE_NAME
             ) {
               console.debug(
-                'Service Worker: Deleting old API cache',
-                cacheName
+                "Service Worker: Deleting old API cache",
+                cacheName,
               );
               return caches.delete(cacheName);
             }
             // Keep all image caches and current API cache
-          })
+          }),
         );
       }),
       // Take control of all clients
       self.clients.claim(),
-    ])
+    ]),
   );
 });
 
 // Message event - handle communication from client
-self.addEventListener('message', event => {
+self.addEventListener("message", (event) => {
   const { type, data } = event.data;
 
   switch (type) {
-    case 'PREFETCH_SPRITE_VARIANTS':
+    case "PREFETCH_SPRITE_VARIANTS":
       // Queue sprite variants for background processing
       queueSpriteVariants(data);
       break;
 
     default:
-      console.debug('Service Worker: Unknown message type:', type);
+      console.debug("Service Worker: Unknown message type:", type);
   }
 });
 
@@ -324,7 +325,7 @@ async function handleSpriteVariantsRequest(request) {
     // Check if the response is successful and contains JSON
     if (
       response.ok &&
-      response.headers.get('content-type')?.includes('application/json')
+      response.headers.get("content-type")?.includes("application/json")
     ) {
       // Clone the response so we can read it for prefetching
       const responseClone = response.clone();
@@ -338,7 +339,7 @@ async function handleSpriteVariantsRequest(request) {
           // Check if this is a successful sprite variants response
           if (data.variants && Array.isArray(data.variants) && data.cacheKey) {
             console.debug(
-              `Service Worker: Queueing sprite variants for ${data.cacheKey} after API response`
+              `Service Worker: Queueing sprite variants for ${data.cacheKey} after API response`,
             );
 
             // Queue sprite variants for background processing
@@ -347,8 +348,8 @@ async function handleSpriteVariantsRequest(request) {
         } catch (jsonError) {
           // If JSON parsing fails, just continue without prefetching
           console.debug(
-            'Service Worker: Failed to parse sprite variants response:',
-            jsonError
+            "Service Worker: Failed to parse sprite variants response:",
+            jsonError,
           );
         }
       }, 0); // Execute on next tick after response is returned
@@ -357,41 +358,41 @@ async function handleSpriteVariantsRequest(request) {
     return response;
   } catch (error) {
     console.error(
-      'Service Worker: Error handling sprite variants request:',
-      error
+      "Service Worker: Error handling sprite variants request:",
+      error,
     );
     // Return a network error response
-    return new Response('Network error', { status: 503 });
+    return new Response("Network error", { status: 503 });
   }
 }
 
 // Fetch event - handle requests with simplified logic
-self.addEventListener('fetch', event => {
+self.addEventListener("fetch", (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
   // Intercept sprite variants API requests to trigger prefetching
-  if (url.pathname === '/api/sprite/variants') {
+  if (url.pathname === "/api/sprite/variants") {
     event.respondWith(handleSpriteVariantsRequest(request));
     return;
   }
 
   // Skip other API requests - let React Query handle them
-  if (url.pathname.startsWith('/api/')) {
+  if (url.pathname.startsWith("/api/")) {
     return;
   }
 
   // Handle image requests with cache-first strategy
   if (
-    request.destination === 'image' ||
-    imageDomains.some(domain => url.hostname === domain)
+    request.destination === "image" ||
+    imageDomains.some((domain) => url.hostname === domain)
   ) {
     event.respondWith(handleImageRequest(request));
     return;
   }
 
   // Handle navigation requests (pages)
-  if (request.mode === 'navigate') {
+  if (request.mode === "navigate") {
     event.respondWith(handleNavigationRequest(request));
     return;
   }
@@ -399,11 +400,11 @@ self.addEventListener('fetch', event => {
   // For other requests, try network first with cache fallback
   event.respondWith(
     fetch(request)
-      .then(response => {
+      .then((response) => {
         // Cache successful responses for static assets
         if (response.status === 200 && shouldCacheStaticAsset(request)) {
           const responseClone = response.clone();
-          caches.open(API_CACHE_NAME).then(cache => {
+          caches.open(API_CACHE_NAME).then((cache) => {
             cache.put(request, responseClone);
           });
         }
@@ -412,7 +413,7 @@ self.addEventListener('fetch', event => {
       .catch(() => {
         // Fallback to cache if network fails
         return caches.match(request);
-      })
+      }),
   );
 });
 
@@ -422,8 +423,8 @@ async function handleImageRequest(request) {
 
   // Use Pokemon cache for Pokemon sprites, general cache for others
   const isPokemonSprite =
-    url.hostname === 'raw.githubusercontent.com' &&
-    url.pathname.includes('/sprites/pokemon/');
+    url.hostname === "raw.githubusercontent.com" &&
+    url.pathname.includes("/sprites/pokemon/");
 
   const cacheName = isPokemonSprite
     ? POKEMON_IMAGE_CACHE_NAME
@@ -448,12 +449,12 @@ async function handleImageRequest(request) {
 
     return response;
   } catch (error) {
-    console.warn('Service Worker: Failed to fetch image', request.url, error);
+    console.warn("Service Worker: Failed to fetch image", request.url, error);
 
     // Return a minimal fallback response
-    return new Response('', {
+    return new Response("", {
       status: 404,
-      statusText: 'Not Found',
+      statusText: "Not Found",
     });
   }
 }
@@ -467,18 +468,18 @@ async function handleNavigationRequest(request) {
   } catch (error) {
     // Fallback to cached index.html for offline support
     const cache = await caches.open(API_CACHE_NAME);
-    const cachedResponse = await cache.match('/');
+    const cachedResponse = await cache.match("/");
 
     if (cachedResponse) {
       return cachedResponse;
     }
 
     // Ultimate fallback
-    return new Response('Offline - Please check your connection', {
+    return new Response("Offline - Please check your connection", {
       status: 503,
-      statusText: 'Service Unavailable',
+      statusText: "Service Unavailable",
       headers: {
-        'Content-Type': 'text/plain',
+        "Content-Type": "text/plain",
       },
     });
   }
@@ -490,14 +491,14 @@ function shouldCacheStaticAsset(request) {
 
   // Cache static assets like CSS, JS, fonts
   return (
-    url.pathname.includes('/_next/static/') ||
-    url.pathname.includes('/fonts/') ||
-    url.pathname.includes('/images/') ||
-    url.pathname.endsWith('.ico') ||
-    url.pathname.endsWith('.png') ||
-    url.pathname.endsWith('.jpg') ||
-    url.pathname.endsWith('.webp')
+    url.pathname.includes("/_next/static/") ||
+    url.pathname.includes("/fonts/") ||
+    url.pathname.includes("/images/") ||
+    url.pathname.endsWith(".ico") ||
+    url.pathname.endsWith(".png") ||
+    url.pathname.endsWith(".jpg") ||
+    url.pathname.endsWith(".webp")
   );
 }
 
-console.debug('Service Worker: Script loaded');
+console.debug("Service Worker: Script loaded");

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -4,6 +4,7 @@ import {
 } from "@tanstack/query-persist-client-core";
 import { createStore, del, get, set } from "idb-keyval";
 import { z } from "zod";
+import { RouteEncountersArraySchema } from "@/types/encounters";
 
 const readEnvVar = (key: "NODE_ENV" | "NEXT_PUBLIC_BUILD_ID") => {
   if (typeof process === "undefined") {
@@ -57,7 +58,17 @@ const PersistedQuerySchema = z.custom<PersistedQuery>((value) => {
 const deserializePersistedQuery = (data: unknown): PersistedQuery => {
   try {
     const parsed = typeof data === "string" ? JSON.parse(data) : data;
-    return PersistedQuerySchema.parse(parsed);
+    const persistedQuery = PersistedQuerySchema.parse(parsed);
+
+    if (
+      persistedQuery.queryKey[0] === "encounters" &&
+      RouteEncountersArraySchema.safeParse(persistedQuery.state.data)
+        .success === false
+    ) {
+      throw new Error("Invalid persisted encounters query payload");
+    }
+
+    return persistedQuery;
   } catch {
     throw new Error("Invalid persisted query payload");
   }

--- a/src/loaders/__tests__/locations-query-cache.test.tsx
+++ b/src/loaders/__tests__/locations-query-cache.test.tsx
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { describe, expect, it } from "vitest";
+import { getLocations, useLocationEncountersById } from "../locations";
+
+describe("useLocationEncountersById", () => {
+  it("ignores a malformed persisted encounters query", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const location = getLocations().find((item) => item.name === "Route 1");
+
+    queryClient.setQueryData(["encounters", "all", "classic"], {
+      staleCacheEntry: true,
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(
+      () => useLocationEncountersById(location?.id, "classic"),
+      { wrapper },
+    );
+
+    expect(result.current.pokemonEncounters).toEqual([]);
+  });
+});

--- a/src/loaders/locations.ts
+++ b/src/loaders/locations.ts
@@ -225,7 +225,10 @@ export function useLocationEncountersById(
     };
   }
 
-  const encounter = encounters.find((e) => e.routeName === location?.name);
+  const validEncounters = Array.isArray(encounters) ? encounters : [];
+  const encounter = validEncounters.find(
+    (entry) => entry.routeName === location?.name,
+  );
 
   return {
     pokemonEncounters: encounter?.pokemon || [],


### PR DESCRIPTION
## Summary
Prevents malformed persisted encounter data from crashing the location table in Zen/Firefox.

## Changes
- Reject invalid persisted encounter-query payloads so the query persister removes them and fetches validated API data.
- Guard the location encounter loader against non-array query values.
- Fix service-worker cache constant initialization and define the Pokémon image cache.
- Add regression coverage for malformed encounter cache data.

## Testing
- `pnpm vitest run src/loaders/__tests__/locations-query-cache.test.tsx`
- `pnpm type-check`
- `pnpm test:run`
- `pnpm validate`
- `pnpm exec fallow audit --format json --quiet --explain`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or corrupted saved encounter data.
  * Prevented location encounter views from failing when stored data is malformed.
  * Added safer offline behavior for cached Pokémon images and static assets.

* **Tests**
  * Added coverage verifying malformed saved encounter data returns an empty encounter list without retrying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->