### PR TITLE
fix: top-bar layout shift from GitHub buttons

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.18.10"
+        "@opencode-ai/plugin": "1.18.11"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -99,13 +99,13 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.10",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.10.tgz",
-      "integrity": "sha512-l4R1ulu5wtA0+cCinzdSPkEO8ZCdIgb/ZjltzstIWQqRqeH3H880OabNaeje/ZCkSoAT8c/o9oT3tdjyFP7o7g==",
+      "version": "1.18.11",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.11.tgz",
+      "integrity": "sha512-mgn7+YO2J5tM2sWtV8pPBz6Lz6vWZswBOjUWssLvGaxKPuHR60sZ3Py4/tjI9RNl74aB4lhI0NUlanuWZS8NfA==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.10",
+        "@opencode-ai/sdk": "1.18.11",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.10",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.10.tgz",
-      "integrity": "sha512-K+glWbBp5pfGepZ/6EHvuXY3IpVG2qgsEqF4z9mOiUQUrs6KWN72Vdp15Qsl2TCDbemgHWXKQKgbX3b8PSK2hg==",
+      "version": "1.18.11",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.11.tgz",
+      "integrity": "sha512-yDImmNv4PhxdMgtiHVNWQWEVwQlAm7Dr0y4XU7CT4dOIbzgO+VP+9I02lAP7Zva1FhGeyI7oKMI2tzB9RUsWaQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/src/components/GitHubEngagementCta.tsx
+++ b/src/components/GitHubEngagementCta.tsx
@@ -41,7 +41,7 @@ export function GitHubEngagementCta({ route }: GitHubEngagementCtaProps) {
       aria-label="Support the tracker"
       className="flex items-center gap-2"
     >
-      <span className="github-button-control">
+      <span className="github-button-control h-7 w-20">
         <GitHubButton
           href="https://github.com/fbosch/infinite-fusion-nuzlocke"
           data-color-scheme={colorScheme}
@@ -52,7 +52,7 @@ export function GitHubEngagementCta({ route }: GitHubEngagementCtaProps) {
           aria-label="Star fbosch/infinite-fusion-nuzlocke on GitHub"
         />
       </span>
-      <span className="github-button-control">
+      <span className="github-button-control h-7 w-20">
         <GitHubButton
           href="https://github.com/fbosch/infinite-fusion-nuzlocke/issues"
           data-color-scheme={colorScheme}

--- a/src/components/__tests__/GitHubEngagementCta.test.tsx
+++ b/src/components/__tests__/GitHubEngagementCta.test.tsx
@@ -67,11 +67,16 @@ describe("GitHubEngagementCta", () => {
     expect(starLink.getAttribute("data-show-count")).toBe("true");
     expect(starLink.getAttribute("data-color-scheme")).toBe("light");
     expect(starLink.getAttribute("data-text")).toBe("");
-    expect(starLink.parentElement?.className).toBe("github-button-control");
+    expect(starLink.parentElement?.className).toBe(
+      "github-button-control h-7 w-20",
+    );
     expect(issueLink.getAttribute("href")).toBe(
       "https://github.com/fbosch/infinite-fusion-nuzlocke/issues",
     );
     expect(issueLink.getAttribute("data-show-count")).toBe("true");
+    expect(issueLink.parentElement?.className).toBe(
+      "github-button-control h-7 w-20",
+    );
   });
 
   it("emits one impression per route when half of the CTA becomes visible", () => {


### PR DESCRIPTION
## Summary
Reserve the GitHub engagement controls' iframe footprint so hydration and count loading cannot move the top-bar controls.

## Changes
- Reserve 80 x 28 pixels for each GitHub control before it renders.
- Cover the reserved dimensions in the component test.

## Testing
- `pnpm type-check`
- `pnpm test:run` (120 files passed; 1120 tests passed, 2 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the size of GitHub star and issue buttons for a more consistent layout.

* **Tests**
  * Updated coverage to verify the controls retain their expected dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->