### PR TITLE
fix: prevent location table scroll shifts

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.18.11"
+        "@opencode-ai/plugin": "1.18.13"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -99,13 +99,13 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.11.tgz",
-      "integrity": "sha512-mgn7+YO2J5tM2sWtV8pPBz6Lz6vWZswBOjUWssLvGaxKPuHR60sZ3Py4/tjI9RNl74aB4lhI0NUlanuWZS8NfA==",
+      "version": "1.18.13",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.13.tgz",
+      "integrity": "sha512-2H9YT80M1PYElpG+lmd/9kGqsNouiJIBCUhLblmgFwoSrB4wyahgkCS6NcFQR/AYXNH4I1Yd3lmQcVaEPu1qNg==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.11",
+        "@opencode-ai/sdk": "1.18.13",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.11.tgz",
-      "integrity": "sha512-yDImmNv4PhxdMgtiHVNWQWEVwQlAm7Dr0y4XU7CT4dOIbzgO+VP+9I02lAP7Zva1FhGeyI7oKMI2tzB9RUsWaQ==",
+      "version": "1.18.13",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.13.tgz",
+      "integrity": "sha512-JY9etiVcu1G/pZjaH2vjK/b8z54ujxaWCD1GziO4ADUhRM6m6zm2332bPGcxEfA6TwweiJfNlK6wVZQ0f/X4KQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/src/components/LocationTable/__tests__/LocationTableScrollButton.test.tsx
+++ b/src/components/LocationTable/__tests__/LocationTableScrollButton.test.tsx
@@ -121,7 +121,7 @@ describe("LocationTable scroll-to-recent button", () => {
     });
   });
 
-  it("renders only virtual rows with four-row overscan", async () => {
+  it("renders only virtual rows with twelve-row overscan", async () => {
     useVirtualizerMock.mockReturnValue({
       getTotalSize: () => 450,
       getVirtualItems: () => [{ end: 300, index: 1, start: 150 }],
@@ -135,7 +135,7 @@ describe("LocationTable scroll-to-recent button", () => {
     expect(options.count).toBe(3);
     expect(options.estimateSize()).toBe(150);
     expect(options.getScrollElement()).toBeInstanceOf(HTMLDivElement);
-    expect(options.overscan).toBe(4);
+    expect(options.overscan).toBe(12);
     expect(locationRowProps).toHaveBeenLastCalledWith("route-2");
   });
 

--- a/src/components/LocationTable/useLocationTableVirtualization.ts
+++ b/src/components/LocationTable/useLocationTableVirtualization.ts
@@ -9,7 +9,7 @@ import {
 } from "@/utils/scrollToLocation";
 
 const LOCATION_ROW_HEIGHT_PX = 150;
-const LOCATION_ROW_OVERSCAN_COUNT = 4;
+const LOCATION_ROW_OVERSCAN_COUNT = 12;
 
 export function useLocationTableVirtualization({
   table,


### PR DESCRIPTION
## Summary
Increase location-table virtualization overscan so spacer-row changes stay outside the viewport during scrolling, removing the reproduced layout shifts.

## Changes
- Increase row overscan from 4 to 12.
- Update the virtualization contract test.
- Update the OpenCode plugin lockfile.

## Risk
The table now mounts 16-30 rows during the measured scroll sequence instead of the smaller prior window. This trades additional render work for scroll stability.

## Testing
- `pnpm type-check`
- `pnpm test:run`
- Production-build Chrome scroll sequence at desktop and mobile viewports: no layout-shift entries at overscan 12; overscan 8 still reproduced two shifts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling performance and continuity in the location table by rendering more nearby rows in advance.
  * Reduced the likelihood of blank content appearing during rapid scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->